### PR TITLE
Add responsive mobile sidebar and TopBar layout

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -33,7 +33,12 @@ const NAV_ITEMS = [
   { label: "Settings", icon: <Settings />, path: "/settings" },
 ];
 
-export default function Sidebar() {
+interface SidebarProps {
+  mobileOpen: boolean;
+  onClose: () => void;
+}
+
+export default function Sidebar({ mobileOpen, onClose }: SidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -42,21 +47,13 @@ export default function Sidebar() {
     return location.pathname.startsWith(path);
   };
 
-  return (
-    <Drawer
-      variant="permanent"
-      sx={{
-        width: DRAWER_WIDTH,
-        flexShrink: 0,
-        "& .MuiDrawer-paper": {
-          width: DRAWER_WIDTH,
-          boxSizing: "border-box",
-          bgcolor: "#1a223f",
-          color: "#fff",
-          border: "none",
-        },
-      }}
-    >
+  const handleNavClick = (path: string) => {
+    navigate(path);
+    onClose();
+  };
+
+  const drawerContent = (
+    <>
       <Toolbar sx={{ px: 2, py: 1 }}>
         <Typography variant="h6" noWrap sx={{ fontWeight: 700 }}>
           Wanly Console
@@ -67,7 +64,7 @@ export default function Sidebar() {
           {NAV_ITEMS.map((item) => (
             <ListItemButton
               key={item.path}
-              onClick={() => navigate(item.path)}
+              onClick={() => handleNavClick(item.path)}
               selected={isActive(item.path)}
               sx={{
                 mx: 1,
@@ -93,6 +90,45 @@ export default function Sidebar() {
           ))}
         </List>
       </Box>
-    </Drawer>
+    </>
+  );
+
+  const paperStyles = {
+    width: DRAWER_WIDTH,
+    boxSizing: "border-box" as const,
+    bgcolor: "#1a223f",
+    color: "#fff",
+    border: "none",
+  };
+
+  return (
+    <>
+      {/* Mobile drawer */}
+      <Drawer
+        variant="temporary"
+        open={mobileOpen}
+        onClose={onClose}
+        ModalProps={{ keepMounted: true }}
+        sx={{
+          display: { xs: "block", md: "none" },
+          "& .MuiDrawer-paper": paperStyles,
+        }}
+      >
+        {drawerContent}
+      </Drawer>
+
+      {/* Desktop drawer */}
+      <Drawer
+        variant="permanent"
+        sx={{
+          display: { xs: "none", md: "block" },
+          width: DRAWER_WIDTH,
+          flexShrink: 0,
+          "& .MuiDrawer-paper": paperStyles,
+        }}
+      >
+        {drawerContent}
+      </Drawer>
+    </>
   );
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,16 +1,21 @@
 import {
   AppBar,
+  IconButton,
   Toolbar,
   Typography,
   Button,
   Box,
 } from "@mui/material";
-import { Logout } from "@mui/icons-material";
+import { Logout, Menu as MenuIcon } from "@mui/icons-material";
 import { useAuthStore } from "../stores/authStore";
 import { useNavigate } from "react-router";
 import { DRAWER_WIDTH } from "./Sidebar";
 
-export default function TopBar() {
+interface TopBarProps {
+  onMenuClick: () => void;
+}
+
+export default function TopBar({ onMenuClick }: TopBarProps) {
   const logout = useAuthStore((s) => s.logout);
   const navigate = useNavigate();
 
@@ -24,8 +29,8 @@ export default function TopBar() {
       position="fixed"
       elevation={0}
       sx={{
-        width: `calc(100% - ${DRAWER_WIDTH}px)`,
-        ml: `${DRAWER_WIDTH}px`,
+        width: { xs: "100%", md: `calc(100% - ${DRAWER_WIDTH}px)` },
+        ml: { xs: 0, md: `${DRAWER_WIDTH}px` },
         bgcolor: "background.paper",
         color: "text.primary",
         borderBottom: "1px solid",
@@ -33,6 +38,14 @@ export default function TopBar() {
       }}
     >
       <Toolbar>
+        <IconButton
+          color="inherit"
+          edge="start"
+          onClick={onMenuClick}
+          sx={{ mr: 2, display: { md: "none" } }}
+        >
+          <MenuIcon />
+        </IconButton>
         <Typography variant="h6" sx={{ flexGrow: 1, fontWeight: 600 }}>
           {/* Page title can be set via context if needed */}
         </Typography>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,26 +1,33 @@
+import { useState } from "react";
 import { Box, Toolbar } from "@mui/material";
 import { Outlet, Navigate } from "react-router";
-import Sidebar from "../components/Sidebar";
+import Sidebar, { DRAWER_WIDTH } from "../components/Sidebar";
 import TopBar from "../components/TopBar";
 import { useAuthStore } from "../stores/authStore";
 
 export default function MainLayout() {
   const token = useAuthStore((s) => s.token);
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   if (!token) {
     return <Navigate to="/login" replace />;
   }
 
+  const handleDrawerToggle = () => {
+    setMobileOpen((prev) => !prev);
+  };
+
   return (
     <Box sx={{ display: "flex", minHeight: "100vh" }}>
-      <Sidebar />
-      <TopBar />
+      <Sidebar mobileOpen={mobileOpen} onClose={handleDrawerToggle} />
+      <TopBar onMenuClick={handleDrawerToggle} />
       <Box
         component="main"
         sx={{
           flexGrow: 1,
           bgcolor: "background.default",
-          p: 3,
+          p: { xs: 1.5, sm: 2, md: 3 },
+          width: { md: `calc(100% - ${DRAWER_WIDTH}px)` },
         }}
       >
         <Toolbar />


### PR DESCRIPTION
- Convert Sidebar from permanent to responsive drawer (temporary on mobile, permanent on desktop)
- Add hamburger menu button to TopBar, visible only on mobile (below md breakpoint)
- Make TopBar width/margin responsive instead of hardcoded to sidebar width
- Add responsive main content padding (smaller on mobile)
- Auto-close mobile drawer on navigation

https://claude.ai/code/session_01UYXcfZPAddAPN2nRdKp1Mx