### PR TITLE
Add faceswap preset support with upload/preset source type toggle

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -17,6 +17,7 @@ import type {
   WildcardResponse,
   WildcardCreate,
   WildcardUpdate,
+  FaceswapPreset,
 } from "./types";
 
 const API_URL = import.meta.env.VITE_API_URL || "/api";
@@ -189,6 +190,13 @@ export async function updateWildcard(
 
 export async function deleteWildcard(id: string): Promise<void> {
   await api.delete(`/wildcards/${id}`);
+}
+
+// --- Faceswap Presets ---
+
+export async function getFaceswapPresets(): Promise<FaceswapPreset[]> {
+  const { data } = await api.get<FaceswapPreset[]>("/faceswap/presets");
+  return data;
 }
 
 // --- Registry (workers) ---

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -242,3 +242,9 @@ export interface StatsResponse {
   total_video_time: number;
   worker_stats: WorkerStatsItem[];
 }
+
+export interface FaceswapPreset {
+  key: string;
+  name: string;
+  url: string;
+}


### PR DESCRIPTION
Adds the ability to select preset face images from the wanly-faces S3
bucket as an alternative to uploading a faceswap source image. Both
CreateJobDialog and SegmentModal now show a source type selector
(Upload / Preset) when faceswap is enabled, with a thumbnail dropdown
for preset selection. The faceswap_source_type field (already in types
but previously unused) is now wired through the UI and submission logic.

https://claude.ai/code/session_01WdR8SxShF5awhdmjp3veso