### PR TITLE
Replace faceswap source type dropdown with toggle buttons

### DIFF
--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -24,6 +24,8 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
   useMediaQuery,
   useTheme,
@@ -1123,23 +1125,22 @@ function SegmentModal({
                   sx={{ flex: 1, minWidth: 120 }}
                 />
               </Box>
-              <TextField
-                label="Source Type"
-                select
-                size="small"
-                fullWidth
+              <ToggleButtonGroup
                 value={faceswapSourceType}
-                onChange={(e) => {
-                  const v = e.target.value as "upload" | "preset";
+                exclusive
+                onChange={(_e, v) => {
+                  if (v === null) return;
                   setFaceswapSourceType(v);
                   if (v === "upload") setFaceswapPresetUri(null);
                   if (v === "preset") setFaceswapFile(null);
                 }}
+                size="small"
+                fullWidth
                 sx={{ mb: 1 }}
               >
-                <MenuItem value="upload">Upload Image</MenuItem>
-                <MenuItem value="preset">Preset</MenuItem>
-              </TextField>
+                <ToggleButton value="upload">Upload</ToggleButton>
+                <ToggleButton value="preset">Preset</ToggleButton>
+              </ToggleButtonGroup>
               {faceswapSourceType === "upload" && (
                 <>
                   <Button variant="outlined" size="small" component="label">

--- a/src/pages/JobQueue.tsx
+++ b/src/pages/JobQueue.tsx
@@ -30,6 +30,8 @@ import {
   TableSortLabel,
   TablePagination,
   IconButton,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
   useMediaQuery,
   useTheme,
@@ -912,23 +914,22 @@ function CreateJobDialog({
                   sx={{ flex: 1, minWidth: 120 }}
                 />
               </Box>
-              <TextField
-                label="Source Type"
-                select
-                size="small"
-                fullWidth
+              <ToggleButtonGroup
                 value={faceswapSourceType}
-                onChange={(e) => {
-                  const v = e.target.value as "upload" | "preset";
+                exclusive
+                onChange={(_e, v) => {
+                  if (v === null) return;
                   setFaceswapSourceType(v);
                   if (v === "upload") setFaceswapPresetUri(null);
                   if (v === "preset") setFaceswapImage(null);
                 }}
+                size="small"
+                fullWidth
                 sx={{ mb: 1 }}
               >
-                <MenuItem value="upload">Upload Image</MenuItem>
-                <MenuItem value="preset">Preset</MenuItem>
-              </TextField>
+                <ToggleButton value="upload">Upload</ToggleButton>
+                <ToggleButton value="preset">Preset</ToggleButton>
+              </ToggleButtonGroup>
               {faceswapSourceType === "upload" && (
                 <Button variant="outlined" size="small" component="label">
                   {faceswapImage ? faceswapImage.name : "Choose Faceswap Image"}


### PR DESCRIPTION
Switch from TextField select to MUI ToggleButtonGroup for the faceswap
source type selector in both CreateJobDialog and SegmentModal. This
prepares the UI for adding a third "start frame" option.

https://claude.ai/code/session_01GeVEgMU7ijM1kFkzNukAzT