### PR TITLE
Add drag-and-drop job queue reordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "wanly-console",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/react": "^0.3.2",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^7.3.7",
@@ -319,6 +320,77 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/abstract": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/abstract/-/abstract-0.3.2.tgz",
+      "integrity": "sha512-uvPVK+SZYD6Viddn9M0K0JQdXknuVSxA/EbMlFRanve3P/XTc18oLa5zGftKSGjfQGmuzkZ34E26DSbly1zi3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/geometry": "^0.3.2",
+        "@dnd-kit/state": "^0.3.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/collision": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/collision/-/collision-0.3.2.tgz",
+      "integrity": "sha512-pNmNSLCI8S9fNQ7QJ3fBCDjiT0sqBhUFcKgmyYaGvGCAU+kq0AP8OWlh0JSisc9k5mFyxmRpmFQcnJpILz/RPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.3.2",
+        "@dnd-kit/geometry": "^0.3.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/dom": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/dom/-/dom-0.3.2.tgz",
+      "integrity": "sha512-cIUAVgt2szQyz6JRy7I+0r+xeyOAGH21Y15hb5bIyHoDEaZBvIDH+OOlD9eoLjCbsxDLN9WloU2CBi3OE6LYDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.3.2",
+        "@dnd-kit/collision": "^0.3.2",
+        "@dnd-kit/geometry": "^0.3.2",
+        "@dnd-kit/state": "^0.3.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/geometry": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/geometry/-/geometry-0.3.2.tgz",
+      "integrity": "sha512-3UBPuIS7E3oGiHxOE8h810QA+0pnrnCtGxl4Os1z3yy5YkC/BEYGY+TxWPTQaY1/OMV7GCX7ZNMlama2QN3n3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/state": "^0.3.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/react": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/react/-/react-0.3.2.tgz",
+      "integrity": "sha512-1Opg1xw6I75Z95c+rF2NJa0pdGb8rLAENtuopKtJ1J0PudWlz+P6yL137xy/6DV43uaRmNGtsdbMbR0yRYJ72g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.3.2",
+        "@dnd-kit/dom": "^0.3.2",
+        "@dnd-kit/state": "^0.3.2",
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/state": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/state/-/state-0.3.2.tgz",
+      "integrity": "sha512-dLUIkoYrIJhGXfF2wGLTfb46vUokEsO/OoE21TSfmahYrx7ysTmnwbePsznFaHlwgZhQEh6AlLvthLCeY21b1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.10.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -1405,6 +1477,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.13.0.tgz",
+      "integrity": "sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3997,6 +4079,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/react": "^0.3.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.3.7",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -61,8 +61,16 @@ export async function getJobs(params?: {
   limit?: number;
   offset?: number;
   status?: string;
+  sort?: string;
 }): Promise<JobListResponse> {
   const { data } = await api.get<JobListResponse>("/jobs", { params });
+  return data;
+}
+
+export async function reorderJobs(jobIds: string[]): Promise<JobResponse[]> {
+  const { data } = await api.put<JobResponse[]>("/jobs/reorder", {
+    job_ids: jobIds,
+  });
   return data;
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -101,6 +101,7 @@ export interface JobResponse {
   fps: number;
   seed: number;
   starting_image: string | null;
+  priority: number;
   status: JobStatus;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary
- Installs `@dnd-kit/react` for sortable drag-and-drop
- Default view: priority order with drag handles (grip icon) on each row/card
- Optimistic reorder on drop → `PUT /jobs/reorder`, reverts on failure
- Column sort headers exit priority mode and hide drag handles
- "Reset to priority order" button restores drag-and-drop view
- Floating DragOverlay card during drag, polling pauses while dragging
- Mobile cards support drag handles

**Requires:** wanly-api PR #13 deployed first (migration + endpoints)

## Test plan
- [ ] Drag a job from bottom to top — verify API call fires and list persists after refresh
- [ ] Click a column header — drag handles disappear, sort applies
- [ ] Click "Reset to priority order" — handles return
- [ ] Verify mobile drag works with touch (DevTools responsive mode)
- [ ] Verify polling resumes after drag ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)