### PR TITLE
Persist title tags via API instead of localStorage

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -18,6 +18,8 @@ import type {
   WildcardCreate,
   WildcardUpdate,
   FaceswapPreset,
+  TitleTagResponse,
+  TitleTagCreate,
 } from "./types";
 
 const API_URL = import.meta.env.VITE_API_URL || "/api";
@@ -200,6 +202,24 @@ export async function updateWildcard(
 
 export async function deleteWildcard(id: string): Promise<void> {
   await api.delete(`/wildcards/${id}`);
+}
+
+// --- Title Tags ---
+
+export async function getTags(group?: number): Promise<TitleTagResponse[]> {
+  const { data } = await api.get<TitleTagResponse[]>("/tags", {
+    params: group !== undefined ? { group } : undefined,
+  });
+  return data;
+}
+
+export async function createTag(body: TitleTagCreate): Promise<TitleTagResponse> {
+  const { data } = await api.post<TitleTagResponse>("/tags", body);
+  return data;
+}
+
+export async function deleteTag(id: string): Promise<void> {
+  await api.delete(`/tags/${id}`);
 }
 
 // --- Faceswap Presets ---

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -249,3 +249,16 @@ export interface FaceswapPreset {
   name: string;
   url: string;
 }
+
+export interface TitleTagResponse {
+  id: string;
+  name: string;
+  group: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TitleTagCreate {
+  name: string;
+  group: number;
+}

--- a/src/pages/JobQueue.tsx
+++ b/src/pages/JobQueue.tsx
@@ -705,7 +705,7 @@ function CreateJobDialog({
   const [submitting, setSubmitting] = useState(false);
 
   // Tag state
-  const { titleTags1, titleTags2 } = useTagStore();
+  const { titleTags1, titleTags2, fetchTags } = useTagStore();
   const [selectedTag1, setSelectedTag1] = useState("");
   const [selectedTag2, setSelectedTag2] = useState("");
   const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
@@ -728,9 +728,10 @@ function CreateJobDialog({
   useEffect(() => {
     if (open) {
       fetchLoras();
+      fetchTags();
       getFaceswapPresets().then(setFaceswapPresets).catch(() => {});
     }
-  }, [open, fetchLoras]);
+  }, [open, fetchLoras, fetchTags]);
 
   const addLoraFromLibrary = (item: LoraListItem | null) => {
     if (!item || loras.length >= 3) return;
@@ -875,8 +876,8 @@ function CreateJobDialog({
                   <em>None</em>
                 </MenuItem>
                 {titleTags1.map((tag) => (
-                  <MenuItem key={tag} value={tag}>
-                    {tag}
+                  <MenuItem key={tag.id} value={tag.name}>
+                    {tag.name}
                   </MenuItem>
                 ))}
               </TextField>
@@ -897,8 +898,8 @@ function CreateJobDialog({
                   <em>None</em>
                 </MenuItem>
                 {titleTags2.map((tag) => (
-                  <MenuItem key={tag} value={tag}>
-                    {tag}
+                  <MenuItem key={tag.id} value={tag.name}>
+                    {tag.name}
                   </MenuItem>
                 ))}
               </TextField>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Box,
   Button,
   Card,
   CardContent,
   Chip,
+  CircularProgress,
   TextField,
   Typography,
   useMediaQuery,
@@ -15,18 +16,22 @@ import { useTagStore } from "../stores/tagStore";
 export default function SettingsPage() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
-  const { titleTags1, titleTags2, addTag1, removeTag1, addTag2, removeTag2 } =
+  const { titleTags1, titleTags2, loading, fetchTags, addTag, removeTag } =
     useTagStore();
   const [input1, setInput1] = useState("");
   const [input2, setInput2] = useState("");
 
+  useEffect(() => {
+    fetchTags();
+  }, [fetchTags]);
+
   const handleAdd1 = () => {
-    addTag1(input1);
+    addTag(input1, 1);
     setInput1("");
   };
 
   const handleAdd2 = () => {
-    addTag2(input2);
+    addTag(input2, 2);
     setInput2("");
   };
 
@@ -40,6 +45,11 @@ export default function SettingsPage() {
           <Typography variant="h6" sx={{ mb: 2 }}>
             Tags
           </Typography>
+          {loading && titleTags1.length === 0 && titleTags2.length === 0 && (
+            <Box sx={{ textAlign: "center", py: 2 }}>
+              <CircularProgress size={24} />
+            </Box>
+          )}
           <Box
             sx={{
               display: "flex",
@@ -78,9 +88,9 @@ export default function SettingsPage() {
               <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
                 {titleTags1.map((tag) => (
                   <Chip
-                    key={tag}
-                    label={tag}
-                    onDelete={() => removeTag1(tag)}
+                    key={tag.id}
+                    label={tag.name}
+                    onDelete={() => removeTag(tag.id)}
                     size="small"
                   />
                 ))}
@@ -118,9 +128,9 @@ export default function SettingsPage() {
               <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
                 {titleTags2.map((tag) => (
                   <Chip
-                    key={tag}
-                    label={tag}
-                    onDelete={() => removeTag2(tag)}
+                    key={tag.id}
+                    label={tag.name}
+                    onDelete={() => removeTag(tag.id)}
                     size="small"
                   />
                 ))}

--- a/src/stores/tagStore.ts
+++ b/src/stores/tagStore.ts
@@ -1,56 +1,65 @@
 import { create } from "zustand";
+import { getTags, createTag, deleteTag } from "../api/client";
+import type { TitleTagResponse } from "../api/types";
 
 interface TagState {
-  titleTags1: string[];
-  titleTags2: string[];
-  addTag1: (tag: string) => void;
-  removeTag1: (tag: string) => void;
-  addTag2: (tag: string) => void;
-  removeTag2: (tag: string) => void;
-}
-
-function loadTags(key: string): string[] {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? JSON.parse(raw) : [];
-  } catch {
-    return [];
-  }
+  titleTags1: TitleTagResponse[];
+  titleTags2: TitleTagResponse[];
+  loading: boolean;
+  error: string | null;
+  fetchTags: () => Promise<void>;
+  addTag: (name: string, group: number) => Promise<void>;
+  removeTag: (id: string) => Promise<void>;
 }
 
 export const useTagStore = create<TagState>((set, get) => ({
-  titleTags1: loadTags("titleTags1"),
-  titleTags2: loadTags("titleTags2"),
+  titleTags1: [],
+  titleTags2: [],
+  loading: false,
+  error: null,
 
-  addTag1: (tag: string) => {
-    const trimmed = tag.trim();
+  fetchTags: async () => {
+    set({ loading: true, error: null });
+    try {
+      const all = await getTags();
+      const g1 = all.filter((t) => t.group === 1).sort((a, b) => a.name.localeCompare(b.name));
+      const g2 = all.filter((t) => t.group === 2).sort((a, b) => a.name.localeCompare(b.name));
+      set({ titleTags1: g1, titleTags2: g2, loading: false });
+    } catch (e) {
+      set({
+        loading: false,
+        error: e instanceof Error ? e.message : "Failed to fetch tags",
+      });
+    }
+  },
+
+  addTag: async (name: string, group: number) => {
+    const trimmed = name.trim();
     if (!trimmed) return;
-    const current = get().titleTags1;
-    if (current.some((t) => t.toLowerCase() === trimmed.toLowerCase())) return;
-    const updated = [...current, trimmed];
-    localStorage.setItem("titleTags1", JSON.stringify(updated));
-    set({ titleTags1: updated });
+    try {
+      const tag = await createTag({ name: trimmed, group });
+      const key = group === 1 ? "titleTags1" : "titleTags2";
+      const current = get()[key];
+      const updated = [...current, tag].sort((a, b) => a.name.localeCompare(b.name));
+      set({ [key]: updated } as Pick<TagState, typeof key>);
+    } catch {
+      // duplicate or network error — re-fetch to stay in sync
+      await get().fetchTags();
+    }
   },
 
-  removeTag1: (tag: string) => {
-    const updated = get().titleTags1.filter((t) => t !== tag);
-    localStorage.setItem("titleTags1", JSON.stringify(updated));
-    set({ titleTags1: updated });
-  },
-
-  addTag2: (tag: string) => {
-    const trimmed = tag.trim();
-    if (!trimmed) return;
-    const current = get().titleTags2;
-    if (current.some((t) => t.toLowerCase() === trimmed.toLowerCase())) return;
-    const updated = [...current, trimmed];
-    localStorage.setItem("titleTags2", JSON.stringify(updated));
-    set({ titleTags2: updated });
-  },
-
-  removeTag2: (tag: string) => {
-    const updated = get().titleTags2.filter((t) => t !== tag);
-    localStorage.setItem("titleTags2", JSON.stringify(updated));
-    set({ titleTags2: updated });
+  removeTag: async (id: string) => {
+    // Optimistically remove from whichever group contains it
+    const { titleTags1, titleTags2 } = get();
+    set({
+      titleTags1: titleTags1.filter((t) => t.id !== id),
+      titleTags2: titleTags2.filter((t) => t.id !== id),
+    });
+    try {
+      await deleteTag(id);
+    } catch {
+      // Revert on failure
+      await get().fetchTags();
+    }
   },
 }));


### PR DESCRIPTION
Rewrite tagStore to fetch/create/delete tags through wanly-api, update SettingsPage and CreateJobDialog to use the new store shape.