### PR TITLE
Add Re-open Job button for finalized jobs

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -100,6 +100,11 @@ export async function deleteJob(id: string): Promise<void> {
   await api.delete(`/jobs/${id}`);
 }
 
+export async function reopenJob(id: string): Promise<JobDetailResponse> {
+  const { data } = await api.post<JobDetailResponse>(`/jobs/${id}/reopen`);
+  return data;
+}
+
 export async function addSegment(
   jobId: string,
   body: SegmentCreate,


### PR DESCRIPTION
Adds reopenJob API client function and Re-open button with confirmation dialog to JobDetail page. Calls POST /jobs/{id}/reopen.