### PR TITLE
Auto-disable LoRA weight inputs when model file is missing

### DIFF
--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -1146,8 +1146,8 @@ function lorasToSlots(
       return {
         lora_id: l.lora_id!,
         name: lib?.name ?? l.lora_id!.slice(0, 8),
-        high_weight: l.high_weight,
-        low_weight: l.low_weight,
+        high_weight: lib?.high_file ? l.high_weight : 0,
+        low_weight: lib?.low_file ? l.low_weight : 0,
         preview_image: lib?.preview_image ?? null,
       };
     });
@@ -1237,8 +1237,8 @@ function SegmentModal({
       {
         lora_id: item.id,
         name: item.name,
-        high_weight: item.default_high_weight,
-        low_weight: item.default_low_weight,
+        high_weight: item.high_file ? item.default_high_weight : 0,
+        low_weight: item.low_file ? item.default_low_weight : 0,
         preview_image: item.preview_image,
       },
     ]);
@@ -1717,6 +1717,7 @@ function SegmentModal({
                     parseFloat(e.target.value),
                   )
                 }
+                disabled={!loraLibrary.find((l) => l.id === lora.lora_id)?.high_file}
                 sx={{ width: 80 }}
                 slotProps={{ htmlInput: { step: 0.1, min: 0, max: 2 } }}
               />
@@ -1732,6 +1733,7 @@ function SegmentModal({
                     parseFloat(e.target.value),
                   )
                 }
+                disabled={!loraLibrary.find((l) => l.id === lora.lora_id)?.low_file}
                 sx={{ width: 80 }}
                 slotProps={{ htmlInput: { step: 0.1, min: 0, max: 2 } }}
               />

--- a/src/pages/JobQueue.tsx
+++ b/src/pages/JobQueue.tsx
@@ -674,8 +674,8 @@ function CreateJobDialog({
       {
         lora_id: item.id,
         name: item.name,
-        high_weight: item.default_high_weight,
-        low_weight: item.default_low_weight,
+        high_weight: item.high_file ? item.default_high_weight : 0,
+        low_weight: item.low_file ? item.default_low_weight : 0,
         preview_image: item.preview_image,
       },
     ]);
@@ -1085,6 +1085,7 @@ function CreateJobDialog({
                       parseFloat(e.target.value),
                     )
                   }
+                  disabled={!loraLibrary.find((l) => l.id === lora.lora_id)?.high_file}
                   sx={{ flex: 1, minWidth: 100 }}
                   slotProps={{ htmlInput: { step: 0.1, min: 0, max: 2 } }}
                 />
@@ -1100,6 +1101,7 @@ function CreateJobDialog({
                       parseFloat(e.target.value),
                     )
                   }
+                  disabled={!loraLibrary.find((l) => l.id === lora.lora_id)?.low_file}
                   sx={{ flex: 1, minWidth: 100 }}
                   slotProps={{ htmlInput: { step: 0.1, min: 0, max: 2 } }}
                 />


### PR DESCRIPTION
When a LoRA only has a high-noise or low-noise model, force the missing model's weight to 0 and disable the input field to prevent users from accidentally setting weights for non-existent models.

Closes #40