### PR TITLE
Reduce docker prune retention to 48h

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
               "docker rm '"${{ env.CONTAINER_NAME }}"' || true",
               "docker run -d --name '"${{ env.CONTAINER_NAME }}"' --restart unless-stopped --network host -v /etc/letsencrypt:/etc/letsencrypt:ro '"${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}"':latest",
               "for i in 1 2 3 4 5; do curl -sf -k https://localhost/ && break || sleep 5; done",
-              "docker image prune -af --filter until=168h"
+              "docker image prune -af --filter until=48h"
             ]' \
             --query "Command.CommandId" \
             --output text)


### PR DESCRIPTION
## Summary
- Changes `docker image prune` filter from `until=168h` (7 days) to `until=48h` (2 days) to free disk space more aggressively

🤖 Generated with [Claude Code](https://claude.com/claude-code)