### PR TITLE
Add drain button to Workers page

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -263,6 +263,10 @@ export async function deleteWorker(id: string): Promise<void> {
   await registry.delete(`/workers/${id}`);
 }
 
+export async function drainWorker(id: string): Promise<void> {
+  await registry.post(`/workers/${id}/drain`);
+}
+
 export async function uploadFile(
   file: File,
   jobId?: string,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -212,7 +212,7 @@ export interface WorkerResponse {
   updated_at: string;
 }
 
-export type WorkerStatus = "online-idle" | "online-busy" | "offline";
+export type WorkerStatus = "online-idle" | "online-busy" | "offline" | "draining";
 
 export interface WorkerStatsItem {
   worker_name: string;

--- a/src/components/StatusChip.tsx
+++ b/src/components/StatusChip.tsx
@@ -11,6 +11,7 @@ const STATUS_COLORS: Record<string, { bg: string; fg: string }> = {
   paused: { bg: "#f3e5f5", fg: "#6a1b9a" },
   finalizing: { bg: "#e0f2f1", fg: "#00695c" },
   finalized: { bg: "#e0f2f1", fg: "#00695c" },
+  draining: { bg: "#fff8e1", fg: "#f57f17" },
 };
 
 interface Props {


### PR DESCRIPTION
## Summary
- Drain button (power icon, amber) on idle/busy worker cards
- Confirmation dialog before draining
- "Draining" status shown as amber chip
- Sort order: busy > draining > idle > offline
- `drainWorker()` API client function calls `POST /workers/{id}/drain`

## Test plan
- [ ] Drain button visible on idle and busy workers
- [ ] Drain button hidden on offline and draining workers
- [ ] Click drain → confirmation dialog → status changes to "draining" (amber)
- [ ] Draining workers sort between busy and idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)