### PR TITLE
Fix: add draining status to WorkerDetail

### DIFF
--- a/src/pages/WorkerDetail.tsx
+++ b/src/pages/WorkerDetail.tsx
@@ -24,6 +24,7 @@ const STATUS_CONFIG: Record<WorkerStatus, { color: string; label: string }> = {
   "online-idle": { color: "#4caf50", label: "Idle" },
   "online-busy": { color: "#ff9800", label: "Busy" },
   offline: { color: "#9e9e9e", label: "Offline" },
+  draining: { color: "#f57f17", label: "Draining" },
 };
 
 function formatDate(iso: string) {


### PR DESCRIPTION
## Summary
- Add missing `draining` entry to `STATUS_CONFIG` in `WorkerDetail.tsx`
- Fixes TS build error after `WorkerStatus` type was extended

🤖 Generated with [Claude Code](https://claude.com/claude-code)