### PR TITLE
Add archived job status

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -191,7 +191,8 @@ export type JobStatus =
   | "failed"
   | "paused"
   | "finalizing"
-  | "finalized";
+  | "finalized"
+  | "archived";
 
 export type SegmentStatus =
   | "pending"

--- a/src/components/StatusChip.tsx
+++ b/src/components/StatusChip.tsx
@@ -12,6 +12,7 @@ const STATUS_COLORS: Record<string, { bg: string; fg: string }> = {
   finalizing: { bg: "#e0f2f1", fg: "#00695c" },
   finalized: { bg: "#e0f2f1", fg: "#00695c" },
   draining: { bg: "#fff8e1", fg: "#f57f17" },
+  archived: { bg: "#eeeeee", fg: "#424242" },
 };
 
 interface Props {

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -125,6 +125,7 @@ export default function JobDetail() {
   const [detailSeg, setDetailSeg] = useState<SegmentResponse | null>(null);
   const [reopening, setReopening] = useState(false);
   const [reopenConfirm, setReopenConfirm] = useState(false);
+  const [archiving, setArchiving] = useState(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
@@ -172,6 +173,32 @@ export default function JobDetail() {
       setError("Failed to re-open job");
     } finally {
       setReopening(false);
+    }
+  };
+
+  const handleArchive = async () => {
+    if (!id) return;
+    setArchiving(true);
+    try {
+      await updateJob(id, { status: "archived" });
+      fetchJob();
+    } catch {
+      setError("Failed to archive job");
+    } finally {
+      setArchiving(false);
+    }
+  };
+
+  const handleUnarchive = async () => {
+    if (!id) return;
+    setArchiving(true);
+    try {
+      await updateJob(id, { status: "awaiting" });
+      fetchJob();
+    } catch {
+      setError("Failed to unarchive job");
+    } finally {
+      setArchiving(false);
     }
   };
 
@@ -389,6 +416,28 @@ export default function JobDetail() {
                 }
               >
                 {reopening ? "Re-opening..." : "Re-open Job"}
+              </Button>
+            )}
+            {["awaiting", "failed", "paused"].includes(job.status) && (
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={handleArchive}
+                disabled={archiving}
+                sx={{ color: "#616161", borderColor: "#bdbdbd" }}
+              >
+                {archiving ? "Archiving..." : "Archive"}
+              </Button>
+            )}
+            {job.status === "archived" && (
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={handleUnarchive}
+                disabled={archiving}
+                sx={{ color: "#616161", borderColor: "#bdbdbd" }}
+              >
+                {archiving ? "Unarchiving..." : "Unarchive"}
               </Button>
             )}
           </Box>

--- a/src/pages/JobQueue.tsx
+++ b/src/pages/JobQueue.tsx
@@ -51,6 +51,7 @@ const ALL_STATUSES: JobStatus[] = [
   "processing",
   "pending",
   "paused",
+  "archived",
 ];
 
 const STATUS_PRIORITY: Record<string, number> = {
@@ -59,6 +60,7 @@ const STATUS_PRIORITY: Record<string, number> = {
   processing: 2,
   pending: 3,
   paused: 4,
+  archived: 5,
 };
 
 type SortKey = "name" | "status" | "fps" | "created_at" | "updated_at";
@@ -73,7 +75,7 @@ function formatDate(iso: string) {
   });
 }
 
-const DRAG_LOCKED_STATUSES = new Set(["failed", "awaiting", "processing", "finalizing", "completed"]);
+const DRAG_LOCKED_STATUSES = new Set(["failed", "awaiting", "processing", "finalizing", "completed", "archived"]);
 
 function arrayMove<T>(arr: T[], from: number, to: number): T[] {
   const result = [...arr];


### PR DESCRIPTION
## Summary
- Add `archived` to `JobStatus` type and dark grey StatusChip color
- Archive button on Job Detail (for awaiting/failed/paused jobs)
- Unarchive button returns archived jobs to awaiting
- Archived jobs hidden from default queue view, available via filter dropdown

Closes #51

## Test plan
- [ ] Archive an awaiting job → disappears from queue
- [ ] Filter by "archived" → job appears with grey chip
- [ ] Click into archived job → Unarchive button visible
- [ ] Unarchive → job returns to awaiting in queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)