### PR TITLE
Pre-fill LightX2V fields with defaults and show range hints

### DIFF
--- a/src/pages/JobQueue.tsx
+++ b/src/pages/JobQueue.tsx
@@ -643,8 +643,8 @@ function CreateJobDialog({
   const [duration, setDuration] = useState(5.0);
   const [speed, setSpeed] = useState(1.0);
   const [seed, setSeed] = useState("");
-  const [lightx2vHigh, setLightx2vHigh] = useState("");
-  const [lightx2vLow, setLightx2vLow] = useState("");
+  const [lightx2vHigh, setLightx2vHigh] = useState("2.0");
+  const [lightx2vLow, setLightx2vLow] = useState("1.0");
   const [startingImage, setStartingImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [faceswapEnabled, setFaceswapEnabled] = useState(false);
@@ -726,8 +726,8 @@ function CreateJobDialog({
     setDuration(5.0);
     setSpeed(1.0);
     setSeed("");
-    setLightx2vHigh("");
-    setLightx2vLow("");
+    setLightx2vHigh("2.0");
+    setLightx2vLow("1.0");
     setStartingImage(null);
     if (imagePreview) URL.revokeObjectURL(imagePreview);
     setImagePreview(null);
@@ -764,8 +764,8 @@ function CreateJobDialog({
         height,
         fps,
         seed: seed ? parseInt(seed) : null,
-        lightx2v_strength_high: lightx2vHigh ? parseFloat(lightx2vHigh) : null,
-        lightx2v_strength_low: lightx2vLow ? parseFloat(lightx2vLow) : null,
+        lightx2v_strength_high: lightx2vHigh && parseFloat(lightx2vHigh) !== 2.0 ? parseFloat(lightx2vHigh) : null,
+        lightx2v_strength_low: lightx2vLow && parseFloat(lightx2vLow) !== 1.0 ? parseFloat(lightx2vLow) : null,
         first_segment: {
           prompt: prompt.trim(),
           duration_seconds: duration,
@@ -961,20 +961,18 @@ function CreateJobDialog({
             type="number"
             value={lightx2vHigh}
             onChange={(e) => setLightx2vHigh(e.target.value)}
-            placeholder="2.0"
             sx={{ flex: 1, minWidth: 120 }}
             slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
-            helperText="Default: 2.0"
+            helperText="Range: 1.0–5.6"
           />
           <TextField
             label="LightX2V Low"
             type="number"
             value={lightx2vLow}
             onChange={(e) => setLightx2vLow(e.target.value)}
-            placeholder="1.0"
             sx={{ flex: 1, minWidth: 120 }}
             slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
-            helperText="Default: 1.0"
+            helperText="Range: 1.0–2.0"
           />
         </Box>
 


### PR DESCRIPTION
## Summary
- Pre-fill LightX2V High/Low with default values (2.0/1.0) instead of empty placeholders
- Helper text shows expected ranges (High: 1.0–5.6, Low: 1.0–2.0)
- Send null when value matches default so daemon uses its own config

## Test plan
- [ ] Open CreateJobDialog — fields show 2.0 and 1.0 pre-filled
- [ ] Submit without changing — null sent to API
- [ ] Change value and submit — custom value sent to API

🤖 Generated with [Claude Code](https://claude.com/claude-code)