### PR TITLE
Show effective LightX2V values on Job Detail

### DIFF
--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -325,11 +325,11 @@ export default function JobDetail() {
             <MetaItem label="Seed" value={`${job.seed}`} />
             <MetaItem
               label="LightX2V High"
-              value={job.lightx2v_strength_high != null ? `${job.lightx2v_strength_high}` : "Default"}
+              value={`${job.lightx2v_strength_high ?? 2.0}`}
             />
             <MetaItem
               label="LightX2V Low"
-              value={job.lightx2v_strength_low != null ? `${job.lightx2v_strength_low}` : "Default"}
+              value={`${job.lightx2v_strength_low ?? 1.0}`}
             />
             <MetaItem
               label="Segments"


### PR DESCRIPTION
## Summary
- Show effective value (stored or daemon default 2.0/1.0) instead of "Default" text

## Test plan
- [ ] View job with null lightx2v values — shows 2.0 and 1.0
- [ ] View job with custom values — shows those values

🤖 Generated with [Claude Code](https://claude.com/claude-code)