### PR TITLE
Fix preset dropdown not showing default selection

### DIFF
--- a/src/pages/JobQueue.tsx
+++ b/src/pages/JobQueue.tsx
@@ -686,7 +686,13 @@ function CreateJobDialog({
     if (open) {
       fetchLoras();
       fetchTags();
-      getFaceswapPresets().then(setFaceswapPresets).catch(() => {});
+      getFaceswapPresets().then((presets) => {
+        setFaceswapPresets(presets);
+        if (faceswapPresetUri && !presets.some((p) => p.url === faceswapPresetUri)) {
+          const match = presets.find((p) => p.key === "kelly_young.safetensors");
+          if (match) setFaceswapPresetUri(match.url);
+        }
+      }).catch(() => {});
     }
   }, [open, fetchLoras, fetchTags]);
 


### PR DESCRIPTION
## Summary
- After presets load from API, sync the default URI to match the actual preset URL format
- Matches by key name (kelly_young.safetensors) so it works regardless of S3 URI format

## Test plan
- [ ] Open New Job dialog — preset dropdown shows kelly_young selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)