### PR TITLE
Fix preset default selection key/case mismatch

### DIFF
--- a/src/pages/JobQueue.tsx
+++ b/src/pages/JobQueue.tsx
@@ -688,7 +688,7 @@ function CreateJobDialog({
       fetchTags();
       getFaceswapPresets().then((presets) => {
         setFaceswapPresets(presets);
-        const kelly = presets.find((p) => p.key === "kelly_young.safetensors");
+        const kelly = presets.find((p) => p.name.toLowerCase() === "kelly_young.safetensors" || p.key.toLowerCase() === "kelly_young.safetensors.png");
         if (kelly && !faceswapPresetUri) setFaceswapPresetUri(kelly.url);
       }).catch(() => {});
     }


### PR DESCRIPTION
## Summary
- S3 key is `Kelly_young.safetensors.png` but code matched on `kelly_young.safetensors`
- Now matches case-insensitively on both `p.name` and `p.key`

## Test plan
- [ ] Open New Job dialog — preset dropdown shows Kelly_young.safetensors selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)