### PR TITLE
Fix missing useTheme/useMediaQuery imports in JobQueue

### DIFF
--- a/src/pages/JobQueue.tsx
+++ b/src/pages/JobQueue.tsx
@@ -19,8 +19,9 @@ import {
   TableRow,
   TableSortLabel,
   TablePagination,
-  IconButton,
   MenuItem,
+  useMediaQuery,
+  useTheme,
 } from "@mui/material";
 import { Add, DragIndicator } from "@mui/icons-material";
 import { useNavigate } from "react-router";


### PR DESCRIPTION
## Summary
- Restore `useTheme` and `useMediaQuery` imports accidentally removed during CreateJobDialog extraction in #66
- Remove unused `IconButton` import

## Test plan
- [ ] CI build passes (`tsc -b && vite build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)