### PR TITLE
Add LightX2V default settings to Settings page

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -22,6 +22,7 @@ import {
 } from "@mui/material";
 import { ClearOutlined } from "@mui/icons-material";
 import { useLoraStore } from "../stores/loraStore";
+import { useSettingsStore } from "../stores/settingsStore";
 import { useTagStore } from "../stores/tagStore";
 import { createJob, getFileUrl, getFaceswapPresets } from "../api/client";
 import type { JobCreate, LoraListItem, FaceswapPreset } from "../api/types";
@@ -41,6 +42,7 @@ export default function CreateJobDialog({
 }: CreateJobDialogProps) {
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const { defaultLightx2vHigh, defaultLightx2vLow } = useSettingsStore();
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
   const [width, setWidth] = useState(640);
@@ -49,8 +51,8 @@ export default function CreateJobDialog({
   const [duration, setDuration] = useState(5.0);
   const [speed, setSpeed] = useState(1.0);
   const [seed, setSeed] = useState("");
-  const [lightx2vHigh, setLightx2vHigh] = useState("2.0");
-  const [lightx2vLow, setLightx2vLow] = useState("1.0");
+  const [lightx2vHigh, setLightx2vHigh] = useState(defaultLightx2vHigh);
+  const [lightx2vLow, setLightx2vLow] = useState(defaultLightx2vLow);
   const [startingImage, setStartingImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [faceswapEnabled, setFaceswapEnabled] = useState(true);
@@ -151,8 +153,8 @@ export default function CreateJobDialog({
     setDuration(5.0);
     setSpeed(1.0);
     setSeed("");
-    setLightx2vHigh("2.0");
-    setLightx2vLow("1.0");
+    setLightx2vHigh(defaultLightx2vHigh);
+    setLightx2vLow(defaultLightx2vLow);
     setStartingImage(null);
     if (imagePreview) URL.revokeObjectURL(imagePreview);
     setImagePreview(null);
@@ -168,7 +170,7 @@ export default function CreateJobDialog({
     setSelectedTag2("");
     setNameManuallyEdited(false);
     setError("");
-  }, [imagePreview]);
+  }, [imagePreview, defaultLightx2vHigh, defaultLightx2vLow]);
 
   const handleSubmit = async () => {
     if (!name.trim() || !prompt.trim()) {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -12,6 +12,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { useTagStore } from "../stores/tagStore";
+import { useSettingsStore } from "../stores/settingsStore";
 
 export default function SettingsPage() {
   const theme = useTheme();
@@ -20,6 +21,12 @@ export default function SettingsPage() {
     useTagStore();
   const [input1, setInput1] = useState("");
   const [input2, setInput2] = useState("");
+  const {
+    defaultLightx2vHigh,
+    defaultLightx2vLow,
+    setDefaultLightx2vHigh,
+    setDefaultLightx2vLow,
+  } = useSettingsStore();
 
   useEffect(() => {
     fetchTags();
@@ -136,6 +143,36 @@ export default function SettingsPage() {
                 ))}
               </Box>
             </Box>
+          </Box>
+        </CardContent>
+      </Card>
+
+      <Card sx={{ mt: 3 }}>
+        <CardContent>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            Job Defaults
+          </Typography>
+          <Box sx={{ display: "flex", gap: 2, maxWidth: 400 }}>
+            <TextField
+              label="LightX2V High"
+              type="number"
+              size="small"
+              value={defaultLightx2vHigh}
+              onChange={(e) => setDefaultLightx2vHigh(e.target.value)}
+              slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
+              helperText="Range: 1.0–5.6"
+              sx={{ flex: 1 }}
+            />
+            <TextField
+              label="LightX2V Low"
+              type="number"
+              size="small"
+              value={defaultLightx2vLow}
+              onChange={(e) => setDefaultLightx2vLow(e.target.value)}
+              slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
+              helperText="Range: 1.0–2.0"
+              sx={{ flex: 1 }}
+            />
           </Box>
         </CardContent>
       </Card>

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface SettingsState {
+  defaultLightx2vHigh: string;
+  defaultLightx2vLow: string;
+  setDefaultLightx2vHigh: (value: string) => void;
+  setDefaultLightx2vLow: (value: string) => void;
+}
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set) => ({
+      defaultLightx2vHigh: "2.0",
+      defaultLightx2vLow: "1.0",
+      setDefaultLightx2vHigh: (value) => set({ defaultLightx2vHigh: value }),
+      setDefaultLightx2vLow: (value) => set({ defaultLightx2vLow: value }),
+    }),
+    { name: "wanly-settings" },
+  ),
+);


### PR DESCRIPTION
## Summary
- Add localStorage-backed Zustand settings store for default LightX2V High/Low values
- Add "Job Defaults" card to Settings page with number inputs
- CreateJobDialog reads defaults from store instead of hardcoded `"2.0"` / `"1.0"`

## Test plan
- [ ] Go to Settings page, change LightX2V defaults
- [ ] Open Create Job dialog, verify new defaults are pre-filled
- [ ] Refresh page, verify settings persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)