### PR TITLE
Add inline worker rename on worker card

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -285,6 +285,13 @@ export async function drainWorker(id: string): Promise<void> {
   await registry.post(`/workers/${id}/drain`);
 }
 
+export async function renameWorker(id: string, friendlyName: string): Promise<WorkerResponse> {
+  const { data } = await registry.patch<WorkerResponse>(`/workers/${id}/friendly_name`, {
+    friendly_name: friendlyName,
+  });
+  return data;
+}
+
 export async function uploadFile(
   file: File,
   jobId?: string,


### PR DESCRIPTION
## Summary
- Add pencil icon next to worker name on worker cards
- Click turns name into an editable text field
- Saves on blur or Enter, cancels on Escape
- Calls `PATCH /workers/{id}/friendly_name` on the registry API

Closes #69

## Test plan
- [ ] Click pencil icon on worker card → name becomes editable
- [ ] Type new name, press Enter → name saved, card updates
- [ ] Press Escape → edit cancelled, original name restored
- [ ] Click away (blur) → name saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)