### PR TITLE
Display GPU stats on worker cards

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -205,6 +205,14 @@ export type SegmentStatus =
   | "completed"
   | "failed";
 
+export interface GpuStats {
+  vram_used_mb: number;
+  vram_total_mb: number;
+  gpu_name: string;
+  torch_vram_used_mb: number;
+  torch_vram_free_mb: number;
+}
+
 export interface WorkerResponse {
   id: string;
   friendly_name: string;
@@ -212,6 +220,7 @@ export interface WorkerResponse {
   ip_address: string;
   status: WorkerStatus;
   comfyui_running: boolean;
+  gpu_stats: GpuStats | null;
   last_heartbeat: string;
   registered_at: string;
   updated_at: string;

--- a/src/pages/Workers.tsx
+++ b/src/pages/Workers.tsx
@@ -23,6 +23,7 @@ import {
   DeleteOutline,
   PowerSettingsNew,
   Edit,
+  Memory,
 } from "@mui/icons-material";
 import { getWorkers, deleteWorker, drainWorker, renameWorker } from "../api/client";
 import type { WorkerResponse, WorkerStatus } from "../api/types";
@@ -358,6 +359,32 @@ function WorkerCard({
               ComfyUI {worker.comfyui_running ? "running" : "stopped"}
             </Typography>
           </Box>
+          {worker.gpu_stats && (
+            <>
+              <InfoRow
+                icon={<Memory sx={{ fontSize: 16 }} />}
+                label={worker.gpu_stats.gpu_name}
+              />
+              <Box sx={{ ml: 3.25 }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.25 }}>
+                  <Box sx={{
+                    flex: 1, height: 6, borderRadius: 3, bgcolor: "action.hover",
+                    overflow: "hidden",
+                  }}>
+                    <Box sx={{
+                      height: "100%", borderRadius: 3,
+                      width: `${Math.round(worker.gpu_stats.vram_used_mb / worker.gpu_stats.vram_total_mb * 100)}%`,
+                      bgcolor: worker.gpu_stats.vram_used_mb / worker.gpu_stats.vram_total_mb > 0.9
+                        ? "error.main" : "primary.main",
+                    }} />
+                  </Box>
+                  <Typography variant="caption" color="text.secondary" sx={{ whiteSpace: "nowrap" }}>
+                    {worker.gpu_stats.vram_used_mb.toLocaleString()} / {worker.gpu_stats.vram_total_mb.toLocaleString()} MiB
+                  </Typography>
+                </Box>
+              </Box>
+            </>
+          )}
         </Box>
 
         <Typography


### PR DESCRIPTION
## Summary
- Add `GpuStats` type and `gpu_stats` field to `WorkerResponse`
- Show GPU name and VRAM usage progress bar on worker cards
- VRAM bar turns red when usage exceeds 90%

## Test plan
- [ ] Verify worker cards show GPU name and VRAM bar when stats are available
- [ ] Verify cards still render correctly when gpu_stats is null (offline workers)
- [ ] Verify VRAM bar color changes at >90% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)