### PR TITLE
Add prompt presets UI with load preset

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -14,6 +14,9 @@ import type {
   LoraUpdate,
   StatsResponse,
   WorkerSegmentResponse,
+  PromptPreset,
+  PromptPresetCreate,
+  PromptPresetUpdate,
   WildcardResponse,
   WildcardCreate,
   WildcardUpdate,
@@ -194,6 +197,30 @@ export async function updateLora(
 
 export async function deleteLora(id: string): Promise<void> {
   await api.delete(`/loras/${id}`);
+}
+
+// --- Prompt Presets ---
+
+export async function getPromptPresets(): Promise<PromptPreset[]> {
+  const { data } = await api.get<PromptPreset[]>("/prompt-presets");
+  return data;
+}
+
+export async function createPromptPreset(body: PromptPresetCreate): Promise<PromptPreset> {
+  const { data } = await api.post<PromptPreset>("/prompt-presets", body);
+  return data;
+}
+
+export async function updatePromptPreset(
+  id: string,
+  body: PromptPresetUpdate,
+): Promise<PromptPreset> {
+  const { data } = await api.patch<PromptPreset>(`/prompt-presets/${id}`, body);
+  return data;
+}
+
+export async function deletePromptPreset(id: string): Promise<void> {
+  await api.delete(`/prompt-presets/${id}`);
 }
 
 // --- Wildcards ---

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -235,6 +235,33 @@ export interface WorkerStatsItem {
   last_seen: string | null;
 }
 
+export interface PromptPresetLoraSlot {
+  lora_id: string;
+  high_weight: number;
+  low_weight: number;
+}
+
+export interface PromptPreset {
+  id: string;
+  name: string;
+  prompt: string;
+  loras: PromptPresetLoraSlot[] | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PromptPresetCreate {
+  name: string;
+  prompt: string;
+  loras?: PromptPresetLoraSlot[] | null;
+}
+
+export interface PromptPresetUpdate {
+  name?: string;
+  prompt?: string;
+  loras?: PromptPresetLoraSlot[] | null;
+}
+
 export interface WildcardResponse {
   id: string;
   name: string;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -28,7 +28,7 @@ const NAV_ITEMS = [
   { label: "Workers", icon: <Dns />, path: "/workers" },
   { label: "Videos", icon: <VideoLibrary />, path: "/videos" },
   { label: "LoRA Library", icon: <AutoFixHigh />, path: "/loras" },
-  { label: "Wildcards", icon: <TextSnippet />, path: "/prompts" },
+  { label: "Prompts", icon: <TextSnippet />, path: "/prompts" },
   { label: "Image Repo", icon: <Image />, path: "/images" },
   { label: "Settings", icon: <Settings />, path: "/settings" },
 ];

--- a/src/stores/promptPresetStore.ts
+++ b/src/stores/promptPresetStore.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import { getPromptPresets } from "../api/client";
+import type { PromptPreset } from "../api/types";
+
+interface PromptPresetState {
+  presets: PromptPreset[];
+  loading: boolean;
+  error: string | null;
+  fetchPresets: () => Promise<void>;
+}
+
+export const usePromptPresetStore = create<PromptPresetState>((set) => ({
+  presets: [],
+  loading: false,
+  error: null,
+
+  fetchPresets: async () => {
+    set({ loading: true, error: null });
+    try {
+      const presets = await getPromptPresets();
+      presets.sort((a, b) => a.name.localeCompare(b.name));
+      set({ presets, loading: false });
+    } catch (e) {
+      set({
+        loading: false,
+        error: e instanceof Error ? e.message : "Failed to fetch presets",
+      });
+    }
+  },
+}));


### PR DESCRIPTION
## Summary
- Prompts page now shows Prompt Presets card grid above Wildcards section, with create/edit/delete
- "Load Preset" autocomplete added to CreateJobDialog and Next Segment modal — auto-fills prompt + LoRAs
- Sidebar nav label renamed from "Wildcards" to "Prompts"

## Test plan
- [ ] Create/edit/delete presets on the Prompts page
- [ ] Verify LoRA chips display on preset cards (resolved from LoRA library)
- [ ] Open Create Job dialog → select a preset → verify prompt + LoRAs auto-fill
- [ ] Open Next Segment modal → select a preset → verify prompt + LoRAs auto-fill
- [ ] Wildcards section still works as before

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)