### PR TITLE
feat: Show LoRA ID in edit modal

### DIFF
--- a/src/pages/LoraLibrary.tsx
+++ b/src/pages/LoraLibrary.tsx
@@ -635,6 +635,13 @@ function EditLoraDialog({
           margin="normal"
           value={name}
           onChange={(e) => setName(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <Typography variant="caption" sx={{ color: "text.disabled", mr: 1 }}>
+                ID: {lora.id}
+              </Typography>
+            ),
+          }}
         />
         <TextField
           label="CivitAI Page URL"


### PR DESCRIPTION
## Summary
Display the unique database identifier at the top of the edit dialog above the name field for easy reference.