### PR TITLE
refactor: Extract hardcoded defaults into shared constants

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -29,6 +29,7 @@ import type {
   AppSettingsResponse,
   AppSettingsUpdate,
 } from "./types";
+import { LOCAL_STORAGE_TOKEN_KEY } from "../constants";
 
 const API_URL = import.meta.env.VITE_API_URL || "/api";
 const REGISTRY_URL = import.meta.env.VITE_REGISTRY_URL || "/registry";
@@ -38,7 +39,7 @@ const api = axios.create({
 });
 
 api.interceptors.request.use((config) => {
-  const token = localStorage.getItem("token");
+  const token = localStorage.getItem(LOCAL_STORAGE_TOKEN_KEY);
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
@@ -49,7 +50,7 @@ api.interceptors.response.use(
   (res) => res,
   (err) => {
     if (err.response?.status === 401) {
-      localStorage.removeItem("token");
+      localStorage.removeItem(LOCAL_STORAGE_TOKEN_KEY);
       window.location.href = "/login";
     }
     return Promise.reject(err);
@@ -190,7 +191,7 @@ export async function getWorkerSegments(workerId: string): Promise<WorkerSegment
 }
 
 export function getFileUrl(s3Path: string, version?: string): string {
-  const token = localStorage.getItem("token");
+  const token = localStorage.getItem(LOCAL_STORAGE_TOKEN_KEY);
   let url = `${API_URL}/files?path=${encodeURIComponent(s3Path)}`;
   if (token) url += `&token=${encodeURIComponent(token)}`;
   if (version) url += `&v=${encodeURIComponent(version)}`;

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -30,6 +30,19 @@ import { useTagStore } from "../stores/tagStore";
 import { usePromptPresetStore } from "../stores/promptPresetStore";
 import { createJob, getFileUrl, getFaceswapPresets } from "../api/client";
 import type { JobCreate, LoraListItem, FaceswapPreset, PromptPreset } from "../api/types";
+import {
+  DEFAULT_WIDTH,
+  DEFAULT_HEIGHT,
+  DEFAULT_FPS,
+  DEFAULT_DURATION,
+  DEFAULT_SPEED,
+  DEFAULT_FACESWAP_ENABLED,
+  DEFAULT_FACESWAP_SOURCE_TYPE,
+  DEFAULT_FACESWAP_METHOD,
+  DEFAULT_FACESWAP_FACES_INDEX,
+  DEFAULT_FACESWAP_FACES_ORDER,
+  MAX_LORAS,
+} from "../constants";
 
 interface CreateJobDialogProps {
   open: boolean;
@@ -51,11 +64,11 @@ export default function CreateJobDialog({
   const { defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, fetchSettings } = useSettingsStore();
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
-  const [width, setWidth] = useState(640);
-  const [height, setHeight] = useState(640);
-  const [fps, setFps] = useState(60);
-  const [duration, setDuration] = useState(5.0);
-  const [speed, setSpeed] = useState(1.0);
+  const [width, setWidth] = useState(DEFAULT_WIDTH);
+  const [height, setHeight] = useState(DEFAULT_HEIGHT);
+  const [fps, setFps] = useState(DEFAULT_FPS);
+  const [duration, setDuration] = useState(DEFAULT_DURATION);
+  const [speed, setSpeed] = useState(DEFAULT_SPEED);
   const [seed, setSeed] = useState("");
   const [lightx2vHigh, setLightx2vHigh] = useState(defaultLightx2vHigh);
   const [lightx2vLow, setLightx2vLow] = useState(defaultLightx2vLow);
@@ -64,14 +77,14 @@ export default function CreateJobDialog({
   const [startingImage, setStartingImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [startingImageUri, setStartingImageUri] = useState<string | null>(null);
-  const [faceswapEnabled, setFaceswapEnabled] = useState(false);
-  const [faceswapSourceType, setFaceswapSourceType] = useState<"upload" | "preset" | "start_frame">("preset");
+  const [faceswapEnabled, setFaceswapEnabled] = useState(DEFAULT_FACESWAP_ENABLED);
+  const [faceswapSourceType, setFaceswapSourceType] = useState<"upload" | "preset" | "start_frame">(DEFAULT_FACESWAP_SOURCE_TYPE);
   const [faceswapImage, setFaceswapImage] = useState<File | null>(null);
   const [faceswapPresetUri, setFaceswapPresetUri] = useState<string | null>(null);
   const [faceswapPresets, setFaceswapPresets] = useState<FaceswapPreset[]>([]);
-  const [faceswapMethod, setFaceswapMethod] = useState("reactor");
-  const [faceswapFacesIndex, setFaceswapFacesIndex] = useState("0");
-  const [faceswapFacesOrder, setFaceswapFacesOrder] = useState("left-right");
+  const [faceswapMethod, setFaceswapMethod] = useState(DEFAULT_FACESWAP_METHOD);
+  const [faceswapFacesIndex, setFaceswapFacesIndex] = useState(DEFAULT_FACESWAP_FACES_INDEX);
+  const [faceswapFacesOrder, setFaceswapFacesOrder] = useState(DEFAULT_FACESWAP_FACES_ORDER);
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
@@ -165,7 +178,7 @@ export default function CreateJobDialog({
   };
 
   const addLoraFromLibrary = (item: LoraListItem | null) => {
-    if (!item || loras.length >= 3) return;
+    if (!item || loras.length >= MAX_LORAS) return;
     if (loras.some((l) => l.lora_id === item.id)) return;
     setLoras([
       ...loras,
@@ -197,11 +210,11 @@ export default function CreateJobDialog({
   const resetForm = useCallback(() => {
     setName("");
     setPrompt("");
-    setWidth(640);
-    setHeight(640);
-    setFps(30);
-    setDuration(5.0);
-    setSpeed(1.0);
+    setWidth(DEFAULT_WIDTH);
+    setHeight(DEFAULT_HEIGHT);
+    setFps(DEFAULT_FPS);
+    setDuration(DEFAULT_DURATION);
+    setSpeed(DEFAULT_SPEED);
     setSeed("");
     setLightx2vHigh(defaultLightx2vHigh);
     setLightx2vLow(defaultLightx2vLow);
@@ -211,13 +224,13 @@ export default function CreateJobDialog({
     if (imagePreview) URL.revokeObjectURL(imagePreview);
     setImagePreview(null);
     setStartingImageUri(null);
-    setFaceswapEnabled(true);
-    setFaceswapSourceType("preset");
+    setFaceswapEnabled(DEFAULT_FACESWAP_ENABLED);
+    setFaceswapSourceType(DEFAULT_FACESWAP_SOURCE_TYPE);
     setFaceswapImage(null);
     setFaceswapPresetUri(null);
-    setFaceswapMethod("reactor");
-    setFaceswapFacesIndex("0");
-    setFaceswapFacesOrder("left-right");
+    setFaceswapMethod(DEFAULT_FACESWAP_METHOD);
+    setFaceswapFacesIndex(DEFAULT_FACESWAP_FACES_INDEX);
+    setFaceswapFacesOrder(DEFAULT_FACESWAP_FACES_ORDER);
     setLoras([]);
     setSelectedTag1("");
     setSelectedTag2("");
@@ -571,7 +584,7 @@ export default function CreateJobDialog({
             </Typography>
           </AccordionSummary>
           <AccordionDetails sx={{ pt: 0 }}>
-            {loras.length < 3 && (
+            {loras.length < MAX_LORAS && (
               <Autocomplete
                 options={loraLibrary
                   .filter((l) => !loras.some((s) => s.lora_id === l.id))

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,25 @@
+// Job defaults
+export const DEFAULT_WIDTH = 640;
+export const DEFAULT_HEIGHT = 640;
+export const DEFAULT_FPS = 60;
+export const DEFAULT_DURATION = 5.0;
+export const DEFAULT_SPEED = 1.0;
+
+// Faceswap defaults
+export const DEFAULT_FACESWAP_ENABLED = false;
+export const DEFAULT_FACESWAP_SOURCE_TYPE = "preset" as const;
+export const DEFAULT_FACESWAP_METHOD = "reactor";
+export const DEFAULT_FACESWAP_FACES_INDEX = "0";
+export const DEFAULT_FACESWAP_FACES_ORDER = "left-right";
+
+// LoRA defaults
+export const DEFAULT_LORA_WEIGHT = 1.0;
+export const MAX_LORAS = 3;
+
+// API defaults
+export const DEFAULT_JOB_FETCH_LIMIT = 200;
+export const LOCAL_STORAGE_TOKEN_KEY = "token";
+
+// Polling intervals (ms)
+export const POLL_INTERVAL_FAST = 5_000;
+export const POLL_INTERVAL_SLOW = 10_000;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -25,6 +25,7 @@ import {
 } from "@mui/icons-material";
 import { getStats, getWorkers } from "../api/client";
 import type { StatsResponse, WorkerResponse } from "../api/types";
+import { POLL_INTERVAL_SLOW } from "../constants";
 
 function formatRunTime(seconds: number): string {
   if (seconds < 60) return `${Math.round(seconds)}s`;
@@ -115,7 +116,7 @@ export default function Dashboard() {
           setWorkers(w);
         })
         .catch(() => {});
-    }, 10000);
+    }, POLL_INTERVAL_SLOW);
     return () => clearInterval(interval);
   }, []);
 

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -83,6 +83,16 @@ import type {
   ImageFile,
 } from "../api/types";
 import StatusChip from "../components/StatusChip";
+import {
+  DEFAULT_DURATION,
+  DEFAULT_SPEED,
+  DEFAULT_FACESWAP_ENABLED,
+  DEFAULT_FACESWAP_METHOD,
+  DEFAULT_FACESWAP_FACES_INDEX,
+  DEFAULT_FACESWAP_FACES_ORDER,
+  MAX_LORAS,
+  POLL_INTERVAL_FAST,
+} from "../constants";
 
 function formatDate(iso: string | null) {
   if (!iso) return "-";
@@ -174,7 +184,7 @@ export default function JobDetail() {
 
   useEffect(() => {
     fetchJob();
-    const interval = setInterval(fetchJob, 5000);
+    const interval = setInterval(fetchJob, POLL_INTERVAL_FAST);
     return () => clearInterval(interval);
   }, [fetchJob]);
 
@@ -1741,16 +1751,16 @@ function SegmentModal({
   const { loras: loraLibrary, fetchLoras } = useLoraStore();
   const { presets: promptPresets, fetchPresets } = usePromptPresetStore();
   const [prompt, setPrompt] = useState("");
-  const [duration, setDuration] = useState(5.0);
-  const [speed, setSpeed] = useState(1.0);
-  const [faceswapEnabled, setFaceswapEnabled] = useState(false);
+  const [duration, setDuration] = useState(DEFAULT_DURATION);
+  const [speed, setSpeed] = useState(DEFAULT_SPEED);
+  const [faceswapEnabled, setFaceswapEnabled] = useState(DEFAULT_FACESWAP_ENABLED);
   const [faceswapSourceType, setFaceswapSourceType] = useState<"upload" | "preset" | "start_frame">("upload");
-  const [faceswapMethod, setFaceswapMethod] = useState("reactor");
+  const [faceswapMethod, setFaceswapMethod] = useState(DEFAULT_FACESWAP_METHOD);
   const [faceswapFile, setFaceswapFile] = useState<File | null>(null);
   const [faceswapPresetUri, setFaceswapPresetUri] = useState<string | null>(null);
   const [faceswapPresets, setFaceswapPresets] = useState<FaceswapPreset[]>([]);
-  const [faceswapFacesIndex, setFaceswapFacesIndex] = useState("0");
-  const [faceswapFacesOrder, setFaceswapFacesOrder] = useState("left-right");
+  const [faceswapFacesIndex, setFaceswapFacesIndex] = useState(DEFAULT_FACESWAP_FACES_INDEX);
+  const [faceswapFacesOrder, setFaceswapFacesOrder] = useState(DEFAULT_FACESWAP_FACES_ORDER);
   const [loraSlots, setLoraSlots] = useState<LoraSlot[]>([]);
   const [startImageMode, setStartImageMode] = useState<"auto" | "generated" | "repo" | "upload">("auto");
   const [startImagePath, setStartImagePath] = useState<string | null>(null);
@@ -1801,11 +1811,11 @@ function SegmentModal({
           ? "start_frame"
           : "upload";
       setFaceswapSourceType(srcType);
-      setFaceswapMethod(lastSegment.faceswap_method ?? "reactor");
+      setFaceswapMethod(lastSegment.faceswap_method ?? DEFAULT_FACESWAP_METHOD);
       setFaceswapFile(null);
       setFaceswapPresetUri(srcType === "preset" ? lastSegment.faceswap_image ?? null : null);
-      setFaceswapFacesIndex(lastSegment.faceswap_faces_index ?? "0");
-      setFaceswapFacesOrder(lastSegment.faceswap_faces_order ?? "left-right");
+      setFaceswapFacesIndex(lastSegment.faceswap_faces_index ?? DEFAULT_FACESWAP_FACES_INDEX);
+      setFaceswapFacesOrder(lastSegment.faceswap_faces_order ?? DEFAULT_FACESWAP_FACES_ORDER);
       setStartImageMode("auto");
       setStartImagePath(null);
       setStartImageFile(null);
@@ -1844,7 +1854,7 @@ function SegmentModal({
   }, [startImageMode, browseFolders.length]);
 
   const addLoraFromLibrary = (item: LoraListItem | null) => {
-    if (!item || loraSlots.length >= 3) return;
+    if (!item || loraSlots.length >= MAX_LORAS) return;
     if (loraSlots.some((l) => l.lora_id === item.id)) return;
     setLoraSlots([
       ...loraSlots,
@@ -2323,7 +2333,7 @@ function SegmentModal({
             </Typography>
           </AccordionSummary>
           <AccordionDetails sx={{ pt: 0 }}>
-            {loraSlots.length < 3 && (
+            {loraSlots.length < MAX_LORAS && (
               <Autocomplete
                 options={loraLibrary
                   .filter((l) => !loraSlots.some((s) => s.lora_id === l.id))

--- a/src/pages/JobQueue.tsx
+++ b/src/pages/JobQueue.tsx
@@ -31,6 +31,7 @@ import { getJobs, getFileUrl, reorderJobs } from "../api/client";
 import type { JobResponse, JobStatus } from "../api/types";
 import StatusChip from "../components/StatusChip";
 import CreateJobDialog from "../components/CreateJobDialog";
+import { POLL_INTERVAL_FAST } from "../constants";
 
 const ALL_STATUSES: JobStatus[] = [
   "awaiting",
@@ -114,7 +115,7 @@ export default function JobQueue() {
   useEffect(() => {
     setLoading(true);
     fetchPage();
-    const interval = setInterval(fetchPage, 5000);
+    const interval = setInterval(fetchPage, POLL_INTERVAL_FAST);
     return () => clearInterval(interval);
   }, [fetchPage]);
 

--- a/src/pages/LoraLibrary.tsx
+++ b/src/pages/LoraLibrary.tsx
@@ -36,6 +36,7 @@ import {
   getFileUrl,
 } from "../api/client";
 import type { LoraListItem, LoraResponse, LoraCreate, LoraUpdate } from "../api/types";
+import { DEFAULT_LORA_WEIGHT } from "../constants";
 
 export default function LoraLibrary() {
   const { loras, loading, fetchLoras } = useLoraStore();
@@ -245,8 +246,8 @@ function AddLoraDialog({
   const [triggerWords, setTriggerWords] = useState("");
   const [defaultPrompt, setDefaultPrompt] = useState("");
   const [description, setDescription] = useState("");
-  const [highWeight, setHighWeight] = useState(1.0);
-  const [lowWeight, setLowWeight] = useState(1.0);
+  const [highWeight, setHighWeight] = useState(DEFAULT_LORA_WEIGHT);
+  const [lowWeight, setLowWeight] = useState(DEFAULT_LORA_WEIGHT);
   const [highFile, setHighFile] = useState<File | null>(null);
   const [lowFile, setLowFile] = useState<File | null>(null);
   const [previewFile, setPreviewFile] = useState<File | null>(null);
@@ -262,8 +263,8 @@ function AddLoraDialog({
     setTriggerWords("");
     setDefaultPrompt("");
     setDescription("");
-    setHighWeight(1.0);
-    setLowWeight(1.0);
+    setHighWeight(DEFAULT_LORA_WEIGHT);
+    setLowWeight(DEFAULT_LORA_WEIGHT);
     setHighFile(null);
     setLowFile(null);
     setPreviewFile(null);

--- a/src/pages/PromptLibrary.tsx
+++ b/src/pages/PromptLibrary.tsx
@@ -41,6 +41,7 @@ import {
 import { usePromptPresetStore } from "../stores/promptPresetStore";
 import { useLoraStore } from "../stores/loraStore";
 import type { WildcardResponse, PromptPreset, PromptPresetLoraSlot, LoraListItem } from "../api/types";
+import { MAX_LORAS } from "../constants";
 
 export default function PromptLibrary() {
   const [wildcards, setWildcards] = useState<WildcardResponse[]>([]);
@@ -539,7 +540,7 @@ function PromptPresetDialog({
   }, [open, loraLibrary]);
 
   const addLora = (item: LoraListItem | null) => {
-    if (!item || loraSlots.length >= 3) return;
+    if (!item || loraSlots.length >= MAX_LORAS) return;
     if (loraSlots.some((l) => l.lora_id === item.id)) return;
     setLoraSlots([
       ...loraSlots,
@@ -645,7 +646,7 @@ function PromptPresetDialog({
           <Typography variant="subtitle2" sx={{ mb: 1 }}>
             LoRAs
           </Typography>
-          {loraSlots.length < 3 && (
+          {loraSlots.length < MAX_LORAS && (
             <Autocomplete
               options={loraLibrary
                 .filter((l) => !loraSlots.some((s) => s.lora_id === l.id))

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -19,6 +19,7 @@ import { Close, Error as ErrorIcon, NavigateBefore, NavigateNext, PlayCircleOutl
 import { useNavigate } from "react-router";
 import { getJobs, getJob, getFileUrl } from "../api/client";
 import type { JobDetailResponse, JobResponse } from "../api/types";
+import { DEFAULT_JOB_FETCH_LIMIT, POLL_INTERVAL_FAST } from "../constants";
 
 function formatDuration(seconds: number) {
   const m = Math.floor(seconds / 60);
@@ -67,7 +68,7 @@ export default function Videos() {
 
   useEffect(() => {
     fetchVideos();
-    const interval = setInterval(fetchVideos, 5000);
+    const interval = setInterval(fetchVideos, POLL_INTERVAL_FAST);
     return () => clearInterval(interval);
   }, [fetchVideos]);
 
@@ -103,7 +104,7 @@ export default function Videos() {
     setLoadingRandom(true);
     try {
       // Fetch all finalized jobs
-      const res = await getJobs({ status: "finalized", limit: 200, offset: 0 });
+      const res = await getJobs({ status: "finalized", limit: DEFAULT_JOB_FETCH_LIMIT, offset: 0 });
       const allJobs = res.items;
 
       // Fetch details for any we don't already have

--- a/src/pages/WorkerDetail.tsx
+++ b/src/pages/WorkerDetail.tsx
@@ -20,6 +20,7 @@ import { useParams, useNavigate, Link as RouterLink } from "react-router";
 import { getWorker, getWorkerSegments } from "../api/client";
 import StatusChip from "../components/StatusChip";
 import type { WorkerResponse, WorkerStatus, WorkerSegmentResponse } from "../api/types";
+import { POLL_INTERVAL_SLOW } from "../constants";
 
 const STATUS_CONFIG: Record<WorkerStatus, { color: string; label: string }> = {
   "online-idle": { color: "#4caf50", label: "Idle" },
@@ -96,7 +97,7 @@ export default function WorkerDetail() {
   useEffect(() => {
     fetchWorker();
     fetchSegments();
-    const interval = setInterval(fetchWorker, 10000);
+    const interval = setInterval(fetchWorker, POLL_INTERVAL_SLOW);
     return () => clearInterval(interval);
   }, [fetchWorker, fetchSegments]);
 

--- a/src/pages/Workers.tsx
+++ b/src/pages/Workers.tsx
@@ -33,6 +33,7 @@ import {
 import { useNavigate } from "react-router";
 import { getWorkers, deleteWorker, drainWorker, cancelDrain, renameWorker } from "../api/client";
 import type { WorkerResponse, WorkerStatus } from "../api/types";
+import { POLL_INTERVAL_SLOW } from "../constants";
 
 const STATUS_CONFIG: Record<WorkerStatus, { color: string; label: string }> = {
   "online-idle": { color: "#4caf50", label: "Idle" },
@@ -88,7 +89,7 @@ export default function Workers() {
 
   useEffect(() => {
     fetchWorkers();
-    const interval = setInterval(fetchWorkers, 10000);
+    const interval = setInterval(fetchWorkers, POLL_INTERVAL_SLOW);
     return () => clearInterval(interval);
   }, [fetchWorkers]);
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { login as apiLogin } from "../api/client";
+import { LOCAL_STORAGE_TOKEN_KEY } from "../constants";
 
 interface AuthState {
   token: string | null;
@@ -8,16 +9,16 @@ interface AuthState {
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
-  token: localStorage.getItem("token"),
+  token: localStorage.getItem(LOCAL_STORAGE_TOKEN_KEY),
 
   login: async (username, password) => {
     const res = await apiLogin(username, password);
-    localStorage.setItem("token", res.access_token);
+    localStorage.setItem(LOCAL_STORAGE_TOKEN_KEY, res.access_token);
     set({ token: res.access_token });
   },
 
   logout: () => {
-    localStorage.removeItem("token");
+    localStorage.removeItem(LOCAL_STORAGE_TOKEN_KEY);
     set({ token: null });
   },
 }));

--- a/src/stores/jobStore.ts
+++ b/src/stores/jobStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { getJobs } from "../api/client";
 import type { JobResponse } from "../api/types";
+import { DEFAULT_JOB_FETCH_LIMIT } from "../constants";
 
 interface JobState {
   jobs: JobResponse[];
@@ -17,7 +18,7 @@ export const useJobStore = create<JobState>((set) => ({
   fetchJobs: async () => {
     set({ loading: true, error: null });
     try {
-      const res = await getJobs({ limit: 200 });
+      const res = await getJobs({ limit: DEFAULT_JOB_FETCH_LIMIT });
       set({ jobs: res.items, loading: false });
     } catch (e) {
       set({


### PR DESCRIPTION
## Summary
- Created `src/constants.ts` with shared defaults for job settings, faceswap, LoRAs, polling intervals, API limits, and localStorage keys
- Fixed root cause of intermittent wrong defaults: `resetForm()` used fps=30 and faceswap=true while `useState()` used fps=60 and faceswap=false
- Replaced 50+ hardcoded magic values across 12 files with named constants to prevent future drift

## Test plan
- [ ] Create a job, verify defaults are fps=60 and faceswap=off
- [ ] Create a second job without refreshing — verify defaults are still correct after resetForm()
- [ ] Verify polling still works on Dashboard, JobQueue, Videos, Workers, WorkerDetail pages
- [ ] Verify LoRA limit of 3 still enforced in CreateJobDialog, JobDetail, PromptLibrary
- [ ] Verify login/logout still works (localStorage token key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)