### PR TITLE
feat: Skip re-uploading starting images already in S3

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -96,6 +96,24 @@ export async function createJob(formData: FormData): Promise<JobResponse> {
   return data;
 }
 
+export async function sha256Hex(file: File): Promise<string> {
+  const buf = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest("SHA-256", buf);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function checkStartingImageExists(
+  sha256: string,
+): Promise<{ exists: boolean; uri: string | null }> {
+  const { data } = await api.get<{ exists: boolean; uri: string | null }>(
+    "/jobs/starting-image-exists",
+    { params: { sha256 } },
+  );
+  return data;
+}
+
 export async function updateJob(
   id: string,
   body: JobUpdate,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -97,6 +97,7 @@ export interface JobCreate {
   cfg_high?: number | null;
   cfg_low?: number | null;
   starting_image_uri?: string | null;
+  starting_image_hash?: string | null;
   first_segment: SegmentCreate;
 }
 

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -28,7 +28,7 @@ import { useLoraStore } from "../stores/loraStore";
 import { useSettingsStore } from "../stores/settingsStore";
 import { useTagStore } from "../stores/tagStore";
 import { usePromptPresetStore } from "../stores/promptPresetStore";
-import { createJob, getFileUrl, getFaceswapPresets } from "../api/client";
+import { createJob, getFileUrl, getFaceswapPresets, sha256Hex, checkStartingImageExists } from "../api/client";
 import type { JobCreate, LoraListItem, FaceswapPreset, PromptPreset } from "../api/types";
 import {
   DEFAULT_WIDTH,
@@ -251,6 +251,19 @@ export default function CreateJobDialog({
     setError("");
     setSubmitting(true);
     try {
+      // Bandwidth dedup: if this file's SHA-256 is already known to the server
+      // for this user, skip the upload and reference the existing image by hash.
+      let reuseHash: string | null = null;
+      if (startingImage) {
+        try {
+          const hash = await sha256Hex(startingImage);
+          const { exists } = await checkStartingImageExists(hash);
+          if (exists) reuseHash = hash;
+        } catch {
+          // Fall through to full upload on any hash/check failure.
+        }
+      }
+
       const jobData: JobCreate = {
         name: name.trim(),
         width,
@@ -262,6 +275,7 @@ export default function CreateJobDialog({
         cfg_high: cfgHigh ? parseFloat(cfgHigh) : null,
         cfg_low: cfgLow ? parseFloat(cfgLow) : null,
         starting_image_uri: !startingImage && startingImageUri ? startingImageUri : null,
+        starting_image_hash: reuseHash,
         first_segment: {
           prompt: prompt.trim(),
           duration_seconds: duration,
@@ -285,7 +299,7 @@ export default function CreateJobDialog({
 
       const formData = new FormData();
       formData.append("data", JSON.stringify(jobData));
-      if (startingImage) {
+      if (startingImage && !reuseHash) {
         formData.append("starting_image", startingImage);
       }
       if (faceswapEnabled && faceswapSourceType === "upload" && faceswapImage) {


### PR DESCRIPTION
## Summary
- `CreateJobDialog` now hashes the selected starting image with `crypto.subtle.digest('SHA-256', …)` and calls `GET /jobs/starting-image-exists` before POSTing.
- When the server already has the image for this user, the dialog passes `starting_image_hash` in the JSON body and **omits the multipart file** — no duplicate bytes over the wire.
- Hash/check failure falls through to a normal upload, so dedup can never block job creation.

Depends on DavidJBarnes/wanly-api#new (dedup starting-image uploads). Closes #64.

## Test plan
- [ ] Create job with a brand-new image → network tab shows multipart upload.
- [ ] Create a second job with the identical image → network tab shows the hash-check call and no `starting_image` file in the multipart body.
- [ ] Create job with a tiny 1-byte change to the image → full upload path runs.
- [ ] API endpoint unreachable mid-flow → job still creates via full upload (fallback).