### PR TITLE
fix: Make Job Detail page responsive on mobile

### DIFF
--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -411,10 +411,19 @@ export default function JobDetail() {
   return (
     <Box>
       <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 3 }}>
-        <IconButton onClick={() => navigate("/jobs")}>
+        <IconButton onClick={() => navigate("/jobs")} size={isMobile ? "small" : "medium"}>
           <ArrowBack />
         </IconButton>
-        <Typography variant="h4" sx={{ flex: 1 }}>
+        <Typography
+          variant={isMobile ? "h6" : "h4"}
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
           {job.name}
         </Typography>
         <Tooltip title="Delete job">
@@ -422,6 +431,7 @@ export default function JobDetail() {
             color="error"
             onClick={() => setDeleteJobConfirm(true)}
             disabled={deletingJob}
+            size={isMobile ? "small" : "medium"}
           >
             {deletingJob ? <CircularProgress size={20} /> : <DeleteOutline />}
           </IconButton>
@@ -528,6 +538,8 @@ export default function JobDetail() {
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
+            flexWrap: "wrap",
+            gap: 1,
             px: 2,
             py: 1.5,
             borderBottom: "1px solid",
@@ -535,7 +547,7 @@ export default function JobDetail() {
           }}
         >
           <Typography variant="h6">Segments</Typography>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Box sx={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 1 }}>
             {(job.status === "processing" || job.status === "pending") && (
               <>
                 <CircularProgress size={18} />
@@ -558,10 +570,10 @@ export default function JobDetail() {
               <Button
                 variant="contained"
                 size="small"
-                startIcon={<PlayArrow />}
+                startIcon={isMobile ? undefined : <PlayArrow />}
                 onClick={() => setSegmentModalOpen(true)}
               >
-                Next Segment
+                {isMobile ? "Next" : "Next Segment"}
               </Button>
             )}
             {job.status === "awaiting" && (
@@ -577,7 +589,7 @@ export default function JobDetail() {
                   ) : undefined
                 }
               >
-                {finalizing ? "Finalizing..." : "Finalize & Merge"}
+                {finalizing ? "Finalizing..." : isMobile ? "Finalize" : "Finalize & Merge"}
               </Button>
             )}
             {job.status === "finalized" && (
@@ -590,12 +602,12 @@ export default function JobDetail() {
                 startIcon={
                   reopening ? (
                     <CircularProgress size={16} color="inherit" />
-                  ) : (
+                  ) : isMobile ? undefined : (
                     <Replay />
                   )
                 }
               >
-                {reopening ? "Re-opening..." : "Re-open Job"}
+                {reopening ? "Re-opening..." : isMobile ? "Re-open" : "Re-open Job"}
               </Button>
             )}
             {["awaiting", "failed", "paused"].includes(job.status) && (
@@ -1448,7 +1460,7 @@ export default function JobDetail() {
                         <Box
                           component="img"
                           src={f.data_url}
-                          sx={{ width: 120, height: "auto", display: "block", borderRadius: 0.5 }}
+                          sx={{ width: isMobile ? 56 : 120, height: "auto", display: "block", borderRadius: 0.5 }}
                         />
                         {isTrimmed && (
                           <Box
@@ -1507,6 +1519,8 @@ function SegmentDetailModal({
   onClose: () => void;
 }) {
   const { loras: loraLibrary } = useLoraStore();
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
 
   if (!seg) return null;
 
@@ -1527,7 +1541,7 @@ function SegmentDetailModal({
   });
 
   return (
-    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth fullScreen={fullScreen}>
       <DialogTitle>Segment #{seg.index} Details</DialogTitle>
       <DialogContent dividers>
         {/* Prompt */}
@@ -1544,7 +1558,7 @@ function SegmentDetailModal({
         )}
 
         {/* Duration / Speed */}
-        <Box sx={{ display: "flex", gap: 4, mb: 2 }}>
+        <Box sx={{ display: "flex", gap: 4, mb: 2, flexWrap: "wrap" }}>
           <Box>
             <Typography variant="subtitle2" color="text.secondary">Duration</Typography>
             <Typography variant="body2">{seg.duration_seconds}s</Typography>
@@ -1628,7 +1642,7 @@ function SegmentDetailModal({
         )}
 
         {/* Timing */}
-        <Box sx={{ display: "flex", gap: 4, mb: 2 }}>
+        <Box sx={{ display: "flex", gap: 4, mb: 2, flexWrap: "wrap" }}>
           <Box>
             <Typography variant="subtitle2" color="text.secondary">Created</Typography>
             <Typography variant="body2">{formatDate(seg.created_at)}</Typography>


### PR DESCRIPTION
## Summary

Same mobile responsive treatment as #124 (Image Repo), applied to the Job Detail page.

- Job header: scales h4→h6 on mobile and truncates long job names with ellipsis instead of forcing horizontal scroll
- Segments toolbar: header row and button row wrap; "Next Segment" → "Next", "Finalize & Merge" → "Finalize", "Re-open Job" → "Re-open" on mobile so the action buttons fit
- Segment detail modal goes fullScreen on mobile; the Duration/Speed/Status/Timing meta rows wrap instead of overflowing
- Frame preview popover: thumbnails shrink from 120px to 56px on mobile so all 5 frames fit on a phone screen

## Test plan
- [ ] Open a job detail page on a narrow viewport (<600px) — header fits, name truncates with ellipsis
- [ ] Segments toolbar buttons wrap onto a second line if needed; no horizontal scroll
- [ ] Tap a segment's info icon — detail modal opens fullScreen on mobile
- [ ] Tap the trim "preview" icon — frame preview popover fits within the viewport