### PR TITLE
fix: Crop & Resize canvas CORS taint on save (#129)

### DIFF
--- a/src/components/CropResizeDialog.tsx
+++ b/src/components/CropResizeDialog.tsx
@@ -45,13 +45,18 @@ interface Props {
   onSaved: () => void;
 }
 
-function loadImage(src: string): Promise<HTMLImageElement> {
+async function loadImage(src: string): Promise<HTMLImageElement> {
+  // Fetch as a blob first so the resulting object URL is always same-origin,
+  // which prevents canvas taint regardless of the API's CORS headers.
+  const res = await fetch(src);
+  if (!res.ok) throw new Error(`Failed to fetch image (${res.status})`);
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
   return new Promise((resolve, reject) => {
     const img = new Image();
-    img.crossOrigin = "anonymous";
-    img.onload = () => resolve(img);
-    img.onerror = reject;
-    img.src = src;
+    img.onload = () => { URL.revokeObjectURL(objectUrl); resolve(img); };
+    img.onerror = () => { URL.revokeObjectURL(objectUrl); reject(new Error("Failed to decode image")); };
+    img.src = objectUrl;
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes the "Failed to save cropped image" error in the Crop & Resize dialog.

**Root cause**: `loadImage()` created a `new Image()` with `crossOrigin="anonymous"`, which causes the browser to require an explicit `Access-Control-Allow-Origin` header on the `/files` endpoint response before it will allow canvas access. Without it, the canvas becomes tainted and `toBlob()` silently fails.

**Fix**: Fetch the image bytes via `fetch()` first, wrap in a `blob:` URL via `URL.createObjectURL()`, and load the canvas from that. Object URLs are always same-origin — the canvas never gets tainted, no CORS headers required on the API side.

## Test plan

- [ ] Open Crop & Resize on any image
- [ ] Select a preset or custom size
- [ ] Click Save as New Image — should succeed and new image appears in grid
- [ ] Original image unchanged