### PR TITLE
fix: Crop & Resize use /images/download to avoid S3 CORS on fetch

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -215,6 +215,14 @@ export function getFileUrl(s3Path: string, version?: string): string {
   return url;
 }
 
+// Returns bytes directly (no S3 redirect) so fetch() + canvas works across origins.
+export function getImageDownloadUrl(s3Path: string): string {
+  const token = localStorage.getItem(LOCAL_STORAGE_TOKEN_KEY);
+  let url = `${API_URL}/images/download?path=${encodeURIComponent(s3Path)}`;
+  if (token) url += `&token=${encodeURIComponent(token)}`;
+  return url;
+}
+
 export async function getStats(): Promise<StatsResponse> {
   const { data } = await api.get<StatsResponse>("/stats");
   return data;

--- a/src/components/CropResizeDialog.tsx
+++ b/src/components/CropResizeDialog.tsx
@@ -19,7 +19,7 @@ import {
   Typography,
 } from "@mui/material";
 import { ContentCut, Lock, LockOpen } from "@mui/icons-material";
-import { getFileUrl, uploadImage } from "../api/client";
+import { getFileUrl, getImageDownloadUrl, uploadImage } from "../api/client";
 import type { ImageFile } from "../api/types";
 
 interface PresetSize {
@@ -158,7 +158,7 @@ export default function CropResizeDialog({ open, image, onClose, onSaved }: Prop
     setError(null);
     try {
       const blob = await cropAndResize(
-        getFileUrl(image.path),
+        getImageDownloadUrl(image.path),
         croppedAreaPixels,
         outputWidth,
         outputHeight,


### PR DESCRIPTION
## Summary

Fixes "Failed to fetch" error in the Crop & Resize dialog when saving.

**Root cause**: The previous fix (`fetch()` + blob URL) still failed because `/files` does a `307` redirect to a presigned S3 URL, and the S3 bucket has no CORS headers. The browser blocks `fetch()` when following that redirect cross-origin.

**Fix**: Uses a new `/images/download` endpoint (wanly-api PR #71) that streams image bytes directly through the API. FastAPI's existing `CORSMiddleware` covers the response — no S3 CORS config needed.

- `getImageDownloadUrl()` added to `api/client.ts` — same auth pattern as `getFileUrl()`
- `CropResizeDialog` uses `getImageDownloadUrl` only for the canvas fetch; `getFileUrl` still used for the Cropper display `<img>` tag (no canvas, no taint issue)

## Depends on

wanly-api PR #71 must be deployed first.

## Test plan

- [ ] Open Crop & Resize on any image
- [ ] Drag crop rect, select a preset, click Save as New Image
- [ ] New image appears in grid — no error