### PR TITLE
feat: Add loop toggle to all video players

### DIFF
--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -45,6 +45,7 @@ import {
   StopCircle,
   Download,
   ExpandMore,
+  Repeat,
   Visibility,
   ChevronLeft,
   ChevronRight,
@@ -142,6 +143,7 @@ export default function JobDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [videoModal, setVideoModal] = useState<{ path: string; v?: string; segIndex?: number } | null>(null);
+  const [loopVideo, setLoopVideo] = useState(false);
   const [finalizing, setFinalizing] = useState(false);
   const [segmentModalOpen, setSegmentModalOpen] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState<SegmentResponse | null>(
@@ -509,21 +511,32 @@ export default function JobDetail() {
                   component="video"
                   src={getFileUrl(finalVideo.output_path, finalVideo.completed_at ?? undefined)}
                   controls
+                  loop={loopVideo}
                   sx={{ width: "100%", borderRadius: 1, display: "block" }}
                 />
                 <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mt: 1 }}>
                   <Typography variant="caption" color="text.secondary">
                     {finalVideo.duration_seconds != null ? formatDuration(finalVideo.duration_seconds) : ""}
                   </Typography>
-                  <IconButton
-                    size="small"
-                    component="a"
-                    href={getFileUrl(finalVideo.output_path, finalVideo.completed_at ?? undefined)}
-                    download
-                    target="_blank"
-                  >
-                    <Download fontSize="small" />
-                  </IconButton>
+                  <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <IconButton
+                      size="small"
+                      onClick={() => setLoopVideo((v) => !v)}
+                      color={loopVideo ? "primary" : "default"}
+                      title={loopVideo ? "Loop on" : "Loop off"}
+                    >
+                      <Repeat fontSize="small" />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      component="a"
+                      href={getFileUrl(finalVideo.output_path, finalVideo.completed_at ?? undefined)}
+                      download
+                      target="_blank"
+                    >
+                      <Download fontSize="small" />
+                    </IconButton>
+                  </Box>
                 </Box>
               </CardContent>
             </Card>
@@ -1409,10 +1422,21 @@ export default function JobDetail() {
               component="video"
               controls
               autoPlay
+              loop={loopVideo}
               src={getFileUrl(videoModal.path, videoModal.v)}
               sx={{ width: "100%", maxHeight: "80vh", objectFit: "contain", display: "block" }}
             />
           )}
+          <Box sx={{ p: 1, display: "flex", justifyContent: "flex-start", bgcolor: "rgba(0,0,0,0.8)" }}>
+            <IconButton
+              size="small"
+              onClick={() => setLoopVideo((v) => !v)}
+              sx={{ color: loopVideo ? "primary.main" : "rgba(255,255,255,0.5)" }}
+              title={loopVideo ? "Loop on" : "Loop off"}
+            >
+              <Repeat fontSize="small" />
+            </IconButton>
+          </Box>
         </DialogContent>
       </Dialog>
 

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -15,7 +15,7 @@ import {
   Alert,
   TablePagination,
 } from "@mui/material";
-import { Close, Error as ErrorIcon, NavigateBefore, NavigateNext, PlayCircleOutline, Shuffle, VideoLibrary } from "@mui/icons-material";
+import { Close, Error as ErrorIcon, NavigateBefore, NavigateNext, PlayCircleOutline, Repeat, Shuffle, VideoLibrary } from "@mui/icons-material";
 import { useNavigate } from "react-router";
 import { getJobs, getJob, getFileUrl } from "../api/client";
 import type { JobDetailResponse, JobResponse } from "../api/types";
@@ -48,6 +48,7 @@ export default function Videos() {
   const [playlist, setPlaylist] = useState<{ jobId: string; videoPath: string; jobName: string }[]>([]);
   const [playlistIndex, setPlaylistIndex] = useState(0);
   const [loadingRandom, setLoadingRandom] = useState(false);
+  const [loopVideo, setLoopVideo] = useState(false);
 
   const fetchVideos = useCallback(async () => {
     try {
@@ -358,6 +359,7 @@ export default function Videos() {
               component="video"
               controls
               autoPlay
+              loop={loopVideo}
               src={getFileUrl(modalVideo.output_path)}
               sx={{ width: "100%", maxHeight: "80vh", objectFit: "contain", display: "block" }}
             />
@@ -384,7 +386,15 @@ export default function Videos() {
             </Box>
           ) : null}
           {videoModal && (
-            <Box sx={{ p: 1.5, display: "flex", justifyContent: "flex-end", bgcolor: "rgba(0,0,0,0.8)" }}>
+            <Box sx={{ p: 1.5, display: "flex", alignItems: "center", justifyContent: "space-between", bgcolor: "rgba(0,0,0,0.8)" }}>
+              <IconButton
+                size="small"
+                onClick={() => setLoopVideo((v) => !v)}
+                sx={{ color: loopVideo ? "primary.main" : "rgba(255,255,255,0.5)" }}
+                title={loopVideo ? "Loop on" : "Loop off"}
+              >
+                <Repeat fontSize="small" />
+              </IconButton>
               <Button
                 size="small"
                 variant="contained"
@@ -423,6 +433,7 @@ export default function Videos() {
               key={playlistIndex}
               controls
               autoPlay
+              loop={loopVideo}
               src={getFileUrl(currentPlaylistItem.videoPath)}
               onEnded={() => {
                 if (playlistIndex < playlist.length - 1) {
@@ -452,6 +463,14 @@ export default function Videos() {
                 sx={{ color: "white" }}
               >
                 <NavigateNext />
+              </IconButton>
+              <IconButton
+                size="small"
+                onClick={() => setLoopVideo((v) => !v)}
+                sx={{ color: loopVideo ? "primary.main" : "rgba(255,255,255,0.5)" }}
+                title={loopVideo ? "Loop on" : "Loop off"}
+              >
+                <Repeat fontSize="small" />
               </IconButton>
               <Typography variant="body2" noWrap sx={{ color: "rgba(255,255,255,0.7)", flex: 1, ml: 1 }}>
                 {currentPlaylistItem.jobName}


### PR DESCRIPTION
## Summary

- Adds a `Repeat` icon toggle button to all three video player locations
- **Videos.tsx** single modal — loop button in the bottom bar alongside View Job
- **Videos.tsx** playlist modal — loop button in the nav controls bar
- **JobDetail.tsx** Finalized Video card — loop button alongside the download button
- **JobDetail.tsx** video modal — loop button in a bar below the player
- Button is primary-colored when active, dimmed when off
- `loopVideo` state is per-page so preference persists while navigating within the page
- When loop is on in playlist mode, `onEnded` never fires so the playlist stays on the current video (correct behavior)

## Test plan

- [ ] Videos page: open video modal, click loop button → video loops; click again → stops looping
- [ ] Videos page: open playlist modal, loop button present alongside prev/next nav
- [ ] Job Detail: loop button visible next to download button under the video card
- [ ] Job Detail: open segment video modal, loop button in bar below player