### PR TITLE
feat: add Refresh button to image repo folder view

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -33,6 +33,7 @@ import {
   Delete,
   DriveFileMove,
   NavigateNext,
+  Refresh,
 } from "@mui/icons-material";
 import { useNavigate } from "react-router";
 import {
@@ -83,6 +84,7 @@ export default function ImageRepo() {
   const [cropResizeImage, setCropResizeImage] = useState<ImageFile | null>(null);
   const [lightboxJobs, setLightboxJobs] = useState<ImageJobInfo[]>([]);
   const [loadingJobs, setLoadingJobs] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const navigate = useNavigate();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
@@ -452,6 +454,28 @@ export default function ImageRepo() {
           }}
         >
           {selectMode ? "Cancel" : "Select"}
+        </Button>
+        <Button
+          variant="outlined"
+          startIcon={
+            isMobile
+              ? undefined
+              : refreshing
+                ? <CircularProgress size={16} />
+                : <Refresh />
+          }
+          size={isMobile ? "small" : "medium"}
+          disabled={refreshing}
+          onClick={async () => {
+            setRefreshing(true);
+            try {
+              await fetchImages(currentFolder!);
+            } finally {
+              setRefreshing(false);
+            }
+          }}
+        >
+          {refreshing ? (isMobile ? "..." : "Refreshing...") : "Refresh"}
         </Button>
         <Button
           variant="outlined"


### PR DESCRIPTION
Adds a **Refresh** button next to Upload in the image grid view (when you're inside a folder looking at images).

**Problem:** When viewing images inside a folder, there's no way to refresh the image list without doing a full browser refresh — which loses the current folder state (since `currentFolder` lives in React state) and drops you back to the folder list.

**Fix:** A Refresh button that calls `fetchImages(currentFolder)` in-place, with a spinner while loading, keeping you exactly where you were.