### PR TITLE
feat: sort image folders by created_at

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -356,6 +356,7 @@ export interface ImageJobInfo {
 export interface ImageFolder {
   name: string;
   thumbnail: string | null;
+  created_at: string | null;
 }
 
 export interface ImageFile {

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -282,7 +282,8 @@ export default function ImageRepo() {
         )}
 
         <Grid container spacing={2}>
-          {folders
+          {[...folders]
+            .sort((a, b) => (b.created_at || "").localeCompare(a.created_at || ""))
             .slice(folderPage * foldersPerPage, (folderPage + 1) * foldersPerPage)
             .map((folder) => (
             <Grid key={folder.name} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>


### PR DESCRIPTION
Adds `created_at` to the `ImageFolder` type and sorts the folder grid by creation date descending (newest first).

Paired with the API-side PR (wanly-api) which now returns folders ordered by actual creation time.