### PR TITLE
fix: invalid date in image lightbox job history

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -696,7 +696,7 @@ export default function ImageRepo() {
                               variant: "body2",
                               sx: { color: "primary.main", cursor: "pointer" },
                             }}
-                            secondary={new Date(job.created_at + "Z").toLocaleString()}
+                            secondary={new Date(job.created_at).toLocaleString()}
                           />
                         </ListItemButton>
                       ))}


### PR DESCRIPTION
The `created_at` field from the API is already a valid ISO 8601 string (may include `+00:00` timezone offset). Appending `"Z"` produced an unparseable string like `"2026-02-27T12:34:56+00:00Z"`, causing `new Date()` to return `Invalid Date`.

**Fix:** Remove the spurious `+ "Z"` suffix — `new Date(job.created_at)` parses correctly as-is.