### PR TITLE
feat: favorite videos and images with heart icons

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -27,6 +27,9 @@ import type {
   ImageFolder,
   ImageFile,
   ImageJobInfo,
+  FavoriteToggleRequest,
+  FavoriteToggleResponse,
+  FavoriteListResponse,
   AppSettingsResponse,
   AppSettingsUpdate,
 } from "./types";
@@ -440,6 +443,20 @@ export async function uploadFile(
   if (jobId) formData.append("job_id", jobId);
   const { data } = await api.post<{ path: string }>("/upload", formData, {
     headers: { "Content-Type": "multipart/form-data" },
+  });
+  return data;
+}
+
+// --- Favorites ---
+
+export async function toggleFavorite(body: FavoriteToggleRequest): Promise<FavoriteToggleResponse> {
+  const { data } = await api.post<FavoriteToggleResponse>("/favorites/toggle", body);
+  return data;
+}
+
+export async function getFavorites(itemType?: "video" | "image"): Promise<FavoriteListResponse> {
+  const { data } = await api.get<FavoriteListResponse>("/favorites", {
+    params: itemType ? { item_type: itemType } : undefined,
   });
   return data;
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -387,6 +387,20 @@ export interface AppSettingsResponse {
   negative_prompt: string;
 }
 
+export interface FavoriteToggleRequest {
+  item_type: "video" | "image";
+  item_ref: string;
+}
+
+export interface FavoriteToggleResponse {
+  favorited: boolean;
+  item_ref: string;
+}
+
+export interface FavoriteListResponse {
+  item_refs: string[];
+}
+
 export interface AppSettingsUpdate {
   cfg_high?: number;
   cfg_low?: number;

--- a/src/components/FavoriteHeart.tsx
+++ b/src/components/FavoriteHeart.tsx
@@ -1,0 +1,27 @@
+import { IconButton } from "@mui/material";
+import { Favorite, FavoriteBorder } from "@mui/icons-material";
+
+interface FavoriteHeartProps {
+  favorited: boolean;
+  onToggle: () => void;
+  size?: "small" | "medium";
+}
+
+export default function FavoriteHeart({ favorited, onToggle, size = "small" }: FavoriteHeartProps) {
+  return (
+    <IconButton
+      size={size}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      sx={{
+        color: favorited ? "#e91e63" : "rgba(255,255,255,0.7)",
+        bgcolor: "rgba(0,0,0,0.4)",
+        "&:hover": { bgcolor: "rgba(0,0,0,0.6)" },
+      }}
+    >
+      {favorited ? <Favorite fontSize="inherit" /> : <FavoriteBorder fontSize="inherit" />}
+    </IconButton>
+  );
+}

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -32,6 +32,7 @@ import {
   CreateNewFolder,
   Delete,
   DriveFileMove,
+  Favorite,
   NavigateNext,
   Refresh,
 } from "@mui/icons-material";
@@ -45,10 +46,13 @@ import {
   createImageFolder,
   uploadImage,
   moveImages,
+  getFavorites,
+  toggleFavorite,
 } from "../api/client";
 import type { ImageFolder, ImageFile, ImageJobInfo } from "../api/types";
 import CreateJobDialog from "../components/CreateJobDialog";
 import CropResizeDialog from "../components/CropResizeDialog";
+import FavoriteHeart from "../components/FavoriteHeart";
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -85,9 +89,22 @@ export default function ImageRepo() {
   const [lightboxJobs, setLightboxJobs] = useState<ImageJobInfo[]>([]);
   const [loadingJobs, setLoadingJobs] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [favoritesSet, setFavoritesSet] = useState<Set<string>>(new Set());
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
   const navigate = useNavigate();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const fetchFavorites = useCallback(async () => {
+    try {
+      const res = await getFavorites("image");
+      setFavoritesSet(new Set(res.item_refs));
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => { fetchFavorites(); }, [fetchFavorites]);
 
   const fetchFolders = useCallback(async () => {
     setLoading(true);
@@ -446,6 +463,18 @@ export default function ImageRepo() {
           {sortDesc ? "Newest" : "Oldest"}
         </Button>
         <Button
+          variant={favoritesOnly ? "contained" : "outlined"}
+          color={favoritesOnly ? "error" : "inherit"}
+          startIcon={isMobile ? undefined : <Favorite />}
+          size={isMobile ? "small" : "medium"}
+          onClick={() => {
+            setFavoritesOnly((v) => !v);
+            setImagePage(0);
+          }}
+        >
+          {isMobile ? (favoritesOnly ? "Fav" : "Fav") : "Favorites"}
+        </Button>
+        <Button
           variant={selectMode ? "contained" : "outlined"}
           startIcon={isMobile ? undefined : <CheckBoxIcon />}
           size={isMobile ? "small" : "medium"}
@@ -520,8 +549,16 @@ export default function ImageRepo() {
         </Box>
       )}
 
+      {images.length > 0 && favoritesOnly && !images.some((img) => favoritesSet.has(img.path)) && !loading && (
+        <Box sx={{ textAlign: "center", py: 8 }}>
+          <Typography color="text.secondary">
+            No favorited images in this folder.
+          </Typography>
+        </Box>
+      )}
+
       <Grid container spacing={2}>
-        {[...images]
+        {[...(favoritesOnly ? images.filter((img) => favoritesSet.has(img.path)) : images)]
           .sort((a, b) => {
             const cmp = a.last_modified.localeCompare(b.last_modified);
             return sortDesc ? -cmp : cmp;
@@ -565,6 +602,24 @@ export default function ImageRepo() {
                   }}
                 />
               )}
+              {!selectMode && (
+                <Box sx={{ position: "absolute", top: 4, left: 4 }}>
+                  <FavoriteHeart
+                    favorited={favoritesSet.has(image.path)}
+                    onToggle={async () => {
+                      const prev = new Set(favoritesSet);
+                      const nowFav = !prev.has(image.path);
+                      if (nowFav) prev.add(image.path); else prev.delete(image.path);
+                      setFavoritesSet(prev);
+                      try {
+                        await toggleFavorite({ item_type: "image", item_ref: image.path });
+                      } catch {
+                        setFavoritesSet(favoritesSet);
+                      }
+                    }}
+                  />
+                </Box>
+              )}
               {!selectMode && hoveredCard === image.key && (
                 <IconButton
                   size="small"
@@ -591,7 +646,7 @@ export default function ImageRepo() {
       {images.length > 0 && (
         <TablePagination
           component="div"
-          count={images.length}
+          count={favoritesOnly ? images.filter((img) => favoritesSet.has(img.path)).length : images.length}
           page={imagePage}
           onPageChange={(_, p) => setImagePage(p)}
           rowsPerPage={imagesPerPage}
@@ -712,6 +767,23 @@ export default function ImageRepo() {
               >
                 Delete
               </Button>
+              <IconButton
+                onClick={async () => {
+                  if (!lightboxImage) return;
+                  const prev = new Set(favoritesSet);
+                  const nowFav = !prev.has(lightboxImage.path);
+                  if (nowFav) prev.add(lightboxImage.path); else prev.delete(lightboxImage.path);
+                  setFavoritesSet(prev);
+                  try {
+                    await toggleFavorite({ item_type: "image", item_ref: lightboxImage.path });
+                  } catch {
+                    setFavoritesSet(favoritesSet);
+                  }
+                }}
+                sx={{ color: favoritesSet.has(lightboxImage.path) ? "#e91e63" : undefined }}
+              >
+                <Favorite />
+              </IconButton>
               <Button
                 startIcon={<DriveFileMove />}
                 onClick={() => handleOpenMoveDialog([lightboxImage.key])}

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -17,11 +17,12 @@ import {
   InputAdornment,
   TextField,
 } from "@mui/material";
-import { Close, Error as ErrorIcon, NavigateBefore, NavigateNext, PlayCircleOutline, Repeat, Search, Shuffle, VideoLibrary } from "@mui/icons-material";
+import { Close, Error as ErrorIcon, Favorite, NavigateBefore, NavigateNext, PlayCircleOutline, Repeat, Search, Shuffle, VideoLibrary } from "@mui/icons-material";
 import { useNavigate } from "react-router";
-import { getJobs, getJob, getFileUrl } from "../api/client";
+import { getJobs, getJob, getFileUrl, getFavorites, toggleFavorite } from "../api/client";
 import type { JobDetailResponse, JobResponse } from "../api/types";
 import { DEFAULT_JOB_FETCH_LIMIT, POLL_INTERVAL_FAST } from "../constants";
+import FavoriteHeart from "../components/FavoriteHeart";
 
 function formatDuration(seconds: number) {
   const m = Math.floor(seconds / 60);
@@ -54,6 +55,8 @@ export default function Videos() {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const [favoritesSet, setFavoritesSet] = useState<Set<string>>(new Set());
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
 
   // Debounce search input to avoid hammering the API on every keystroke
   useEffect(() => {
@@ -91,7 +94,22 @@ export default function Videos() {
     return () => clearInterval(interval);
   }, [fetchVideos]);
 
-  const finalizedJobs = jobs;
+  const fetchFavorites = useCallback(async () => {
+    try {
+      const res = await getFavorites("video");
+      setFavoritesSet(new Set(res.item_refs));
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => { fetchFavorites(); }, [fetchFavorites]);
+
+  const filteredJobs = favoritesOnly
+    ? jobs.filter((j) => favoritesSet.has(j.id))
+    : jobs;
+
+  const finalizedJobs = filteredJobs;
 
   // Fetch details for jobs to get video info
   useEffect(() => {
@@ -129,7 +147,9 @@ export default function Videos() {
         offset: 0,
         name: debouncedQuery || undefined,
       });
-      const allJobs = res.items;
+      const allJobs = favoritesOnly
+        ? res.items.filter((j) => favoritesSet.has(j.id))
+        : res.items;
 
       // Fetch details for any we don't already have
       const details = await Promise.all(
@@ -193,6 +213,16 @@ export default function Videos() {
             Play Random
           </Button>
         )}
+        <Button
+          variant={favoritesOnly ? "contained" : "outlined"}
+          color={favoritesOnly ? "error" : "inherit"}
+          startIcon={<Favorite />}
+          size="small"
+          onClick={() => setFavoritesOnly((v) => !v)}
+          sx={{ textTransform: "none" }}
+        >
+          Favorites
+        </Button>
         <Box sx={{ flex: 1 }} />
         <TextField
           size="small"
@@ -330,6 +360,22 @@ export default function Videos() {
                           }}
                         />
                       )}
+                      <Box sx={{ position: "absolute", top: 4, left: 4 }}>
+                        <FavoriteHeart
+                          favorited={favoritesSet.has(job.id)}
+                          onToggle={async () => {
+                            const prev = new Set(favoritesSet);
+                            const nowFav = !prev.has(job.id);
+                            if (nowFav) prev.add(job.id); else prev.delete(job.id);
+                            setFavoritesSet(prev);
+                            try {
+                              await toggleFavorite({ item_type: "video", item_ref: job.id });
+                            } catch {
+                              setFavoritesSet(favoritesSet);
+                            }
+                          }}
+                        />
+                      </Box>
                     </Box>
                   </CardActionArea>
                   <CardContent sx={{ pb: "12px !important" }}>


### PR DESCRIPTION
Adds a heart/favorites system to Videos and Image Repo pages:

**FavoriteHeart component:** Reusable heart icon that toggles red when favorited, with optimistic updates and rollback on failure.

**Videos page:**
- Red heart on each video card (top-left corner)
- **Favorites** toggle button in the header — shows only favorited videos
- Filter applies to grid and Play Random

**Image Repo:**
- Red heart on each image card (top-left corner)
- **Favorites** toggle button in the folder view header
- Heart in the image lightbox dialog
- Pagination correctly reflects filtered count

Paired with the API-side PR that provides the favorites endpoints.