### PR TITLE
feat: make dialogs mobile responsive with fullScreen and flex-wrap

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -21,9 +21,8 @@ import {
   IconButton,
   ToggleButton,
   ToggleButtonGroup,
-  useMediaQuery,
-  useTheme,
 } from "@mui/material";
+import { useIsMobile } from "../hooks/useIsMobile";
 import { ClearOutlined, ExpandMore } from "@mui/icons-material";
 import { useLoraStore } from "../stores/loraStore";
 import { useSettingsStore } from "../stores/settingsStore";
@@ -60,8 +59,7 @@ export default function CreateJobDialog({
   initialStartingImage,
   initialStartingImageUri,
 }: CreateJobDialogProps) {
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
   const { defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, fetchSettings } = useSettingsStore();
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
@@ -365,7 +363,7 @@ export default function CreateJobDialog({
   const accordionSx = { "&:before": { display: "none" }, boxShadow: "none", border: "1px solid", borderColor: "divider", borderRadius: "8px !important", mb: 1 };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth fullScreen={fullScreen}>
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth fullScreen={isMobile}>
       <DialogTitle>Create New Job</DialogTitle>
       <DialogContent>
         {error && (
@@ -376,7 +374,7 @@ export default function CreateJobDialog({
 
         {/* ── Name ── */}
         {(titleTags1.length > 0 || titleTags2.length > 0) && (
-          <Box sx={{ display: "flex", gap: 2, mt: 2, flexWrap: "wrap" }}>
+          <Box sx={{ display: "flex", gap: 2, mt: 2, flexWrap: "wrap", "& > *": { minWidth: { xs: "100%", sm: 0 } } }}>
             {titleTags1.length > 0 && (
               <TextField
                 label="Title Tag 1"
@@ -437,7 +435,7 @@ export default function CreateJobDialog({
 
         {/* ── Starting Image (moved up — needed for auto-generate) ── */}
         <Box sx={{ mt: 1, mb: 1 }}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap", "& > .MuiButton-root": { minWidth: { xs: "100%", sm: 0 } } }}>
             <Button variant="outlined" component="label" size="small">
               {startingImage ? startingImage.name : startingImageUri ? "Image from repo" : "Choose Image *"}
               <input

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -376,7 +376,7 @@ export default function CreateJobDialog({
 
         {/* ── Name ── */}
         {(titleTags1.length > 0 || titleTags2.length > 0) && (
-          <Box sx={{ display: "flex", gap: 2, mt: 2 }}>
+          <Box sx={{ display: "flex", gap: 2, mt: 2, flexWrap: "wrap" }}>
             {titleTags1.length > 0 && (
               <TextField
                 label="Title Tag 1"
@@ -437,7 +437,7 @@ export default function CreateJobDialog({
 
         {/* ── Starting Image (moved up — needed for auto-generate) ── */}
         <Box sx={{ mt: 1, mb: 1 }}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
             <Button variant="outlined" component="label" size="small">
               {startingImage ? startingImage.name : startingImageUri ? "Image from repo" : "Choose Image *"}
               <input

--- a/src/components/CropResizeDialog.tsx
+++ b/src/components/CropResizeDialog.tsx
@@ -17,9 +17,8 @@ import {
   Slider,
   TextField,
   Typography,
-  useMediaQuery,
-  useTheme,
 } from "@mui/material";
+import { useIsMobile } from "../hooks/useIsMobile";
 import { ContentCut, Lock, LockOpen } from "@mui/icons-material";
 import { getFileUrl, getImageDownloadUrl, uploadImage } from "../api/client";
 import type { ImageFile } from "../api/types";
@@ -91,8 +90,7 @@ async function cropAndResize(
 }
 
 export default function CropResizeDialog({ open, image, onClose, onSaved }: Props) {
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
   const [imageUrl, setImageUrl] = useState<string>("");
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
@@ -190,7 +188,7 @@ export default function CropResizeDialog({ open, image, onClose, onSaved }: Prop
     !!croppedAreaPixels && outputWidth > 0 && outputHeight > 0 && !saving;
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth fullScreen={fullScreen}>
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth fullScreen={isMobile}>
       {image && (
         <>
           <DialogTitle sx={{ pb: 1 }}>

--- a/src/components/CropResizeDialog.tsx
+++ b/src/components/CropResizeDialog.tsx
@@ -17,6 +17,8 @@ import {
   Slider,
   TextField,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from "@mui/material";
 import { ContentCut, Lock, LockOpen } from "@mui/icons-material";
 import { getFileUrl, getImageDownloadUrl, uploadImage } from "../api/client";
@@ -89,6 +91,8 @@ async function cropAndResize(
 }
 
 export default function CropResizeDialog({ open, image, onClose, onSaved }: Props) {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const [imageUrl, setImageUrl] = useState<string>("");
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
@@ -186,7 +190,7 @@ export default function CropResizeDialog({ open, image, onClose, onSaved }: Prop
     !!croppedAreaPixels && outputWidth > 0 && outputHeight > 0 && !saving;
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth fullScreen={fullScreen}>
       {image && (
         <>
           <DialogTitle sx={{ pb: 1 }}>

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,10 @@
+import { useMediaQuery, useTheme } from "@mui/material";
+
+/**
+ * Returns true when the viewport is below the "sm" breakpoint (600px).
+ * Used for fullScreen dialogs and responsive layout adjustments.
+ */
+export function useIsMobile() {
+  const theme = useTheme();
+  return useMediaQuery(theme.breakpoints.down("sm"));
+}

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -903,7 +903,7 @@ export default function ImageRepo() {
       <Dialog
         open={!!deleteConfirm}
         onClose={() => setDeleteConfirm(null)}
-        fullScreen={isMobile}
+        fullScreen={{ xs: true, sm: false }}
       >
         <DialogTitle>Delete Image?</DialogTitle>
         <DialogContent>

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -448,7 +448,7 @@ export default function ImageRepo() {
         )}
 
         {/* New Folder Dialog */}
-        <Dialog open={newFolderOpen} onClose={() => setNewFolderOpen(false)}>
+        <Dialog open={newFolderOpen} onClose={() => setNewFolderOpen(false)} fullScreen={isMobile}>
           <DialogTitle>Create New Folder</DialogTitle>
           <DialogContent>
             <TextField
@@ -903,6 +903,7 @@ export default function ImageRepo() {
       <Dialog
         open={!!deleteConfirm}
         onClose={() => setDeleteConfirm(null)}
+        fullScreen={isMobile}
       >
         <DialogTitle>Delete Image?</DialogTitle>
         <DialogContent>
@@ -925,6 +926,7 @@ export default function ImageRepo() {
         onClose={() => setMoveDialogOpen(false)}
         maxWidth="xs"
         fullWidth
+        fullScreen={isMobile}
       >
         <DialogTitle>
           Move {moveTargetKeys.length} image{moveTargetKeys.length > 1 ? "s" : ""} to...

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -16,6 +16,8 @@ import {
   TablePagination,
   InputAdornment,
   TextField,
+  useMediaQuery,
+  useTheme,
 } from "@mui/material";
 import { Close, Error as ErrorIcon, Favorite, NavigateBefore, NavigateNext, PlayCircleOutline, Repeat, Search, Shuffle, VideoLibrary } from "@mui/icons-material";
 import { useNavigate } from "react-router";
@@ -40,6 +42,8 @@ function formatDate(iso: string) {
 }
 
 export default function Videos() {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const navigate = useNavigate();
   const [jobs, setJobs] = useState<JobResponse[]>([]);
   const [total, setTotal] = useState(0);
@@ -433,6 +437,7 @@ export default function Videos() {
         onClose={() => setVideoModal(null)}
         maxWidth="md"
         fullWidth
+        fullScreen={fullScreen}
       >
         <DialogContent sx={{ p: 0, position: "relative", bgcolor: "#000" }}>
           <Box sx={{ position: "absolute", top: 8, right: 8, zIndex: 1 }}>
@@ -506,6 +511,7 @@ export default function Videos() {
         onClose={() => setPlaylist([])}
         maxWidth="md"
         fullWidth
+        fullScreen={fullScreen}
       >
         <DialogContent sx={{ p: 0, position: "relative", bgcolor: "#000" }}>
           <Box sx={{ position: "absolute", top: 8, right: 8, zIndex: 1 }}>

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -437,13 +437,14 @@ export default function Videos() {
         onClose={() => setVideoModal(null)}
         maxWidth="md"
         fullWidth
-        fullScreen={fullScreen}
+        fullScreen={isMobile}
       >
         <DialogContent sx={{ p: 0, position: "relative", bgcolor: "#000" }}>
           <Box sx={{ position: "absolute", top: 8, right: 8, zIndex: 1 }}>
             <IconButton
               onClick={() => setVideoModal(null)}
               sx={{ color: "white" }}
+              aria-label="Close video"
             >
               <Close />
             </IconButton>
@@ -511,13 +512,14 @@ export default function Videos() {
         onClose={() => setPlaylist([])}
         maxWidth="md"
         fullWidth
-        fullScreen={fullScreen}
+        fullScreen={isMobile}
       >
         <DialogContent sx={{ p: 0, position: "relative", bgcolor: "#000" }}>
           <Box sx={{ position: "absolute", top: 8, right: 8, zIndex: 1 }}>
             <IconButton
               onClick={() => setPlaylist([])}
               sx={{ color: "white" }}
+              aria-label="Close playlist"
             >
               <Close />
             </IconButton>

--- a/src/pages/Workers.tsx
+++ b/src/pages/Workers.tsx
@@ -19,8 +19,6 @@ import {
   RadioGroup,
   FormControlLabel,
   Radio,
-  useMediaQuery,
-  useTheme,
 } from "@mui/material";
 import {
   Circle,
@@ -66,8 +64,6 @@ function formatDate(iso: string) {
 }
 
 export default function Workers() {
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const navigate = useNavigate();
   const [workers, setWorkers] = useState<WorkerResponse[]>([]);
   const [loading, setLoading] = useState(true);
@@ -197,7 +193,7 @@ export default function Workers() {
         onClose={() => setDeleteConfirm(null)}
         maxWidth="xs"
         fullWidth
-        fullScreen={fullScreen}
+        fullScreen={{ xs: true, sm: false }}
       >
         <DialogTitle>Delete Worker</DialogTitle>
         <DialogContent>
@@ -224,7 +220,7 @@ export default function Workers() {
         onClose={() => setDrainConfirm(null)}
         maxWidth="xs"
         fullWidth
-        fullScreen={fullScreen}
+        fullScreen={{ xs: true, sm: false }}
       >
         <DialogTitle>Drain Worker</DialogTitle>
         <DialogContent>

--- a/src/pages/Workers.tsx
+++ b/src/pages/Workers.tsx
@@ -19,6 +19,8 @@ import {
   RadioGroup,
   FormControlLabel,
   Radio,
+  useMediaQuery,
+  useTheme,
 } from "@mui/material";
 import {
   Circle,
@@ -64,6 +66,8 @@ function formatDate(iso: string) {
 }
 
 export default function Workers() {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const navigate = useNavigate();
   const [workers, setWorkers] = useState<WorkerResponse[]>([]);
   const [loading, setLoading] = useState(true);
@@ -193,6 +197,7 @@ export default function Workers() {
         onClose={() => setDeleteConfirm(null)}
         maxWidth="xs"
         fullWidth
+        fullScreen={fullScreen}
       >
         <DialogTitle>Delete Worker</DialogTitle>
         <DialogContent>
@@ -219,6 +224,7 @@ export default function Workers() {
         onClose={() => setDrainConfirm(null)}
         maxWidth="xs"
         fullWidth
+        fullScreen={fullScreen}
       >
         <DialogTitle>Drain Worker</DialogTitle>
         <DialogContent>


### PR DESCRIPTION
Closes #144

## Changes
- **CreateJobDialog**: Added `flexWrap: "wrap"` to the title tags row and image upload row so they don't overflow on narrow viewports
- **Workers.tsx**: Added `fullScreen` to Delete Worker and Drain Worker confirmation dialogs
- **ImageRepo.tsx**: Added `fullScreen` to New Folder, Delete Image, and Move to Folder dialogs
- **CropResizeDialog.tsx**: Added `fullScreen` 
- **Videos.tsx**: Added `fullScreen` to single video and playlist modals

All dialogs now follow the same mobile-responsive pattern established for the Lora modal (commit 68b855c).