### PR TITLE
fix: fullScreen responsive object syntax not supported by MUI Dialog

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -903,7 +903,7 @@ export default function ImageRepo() {
       <Dialog
         open={!!deleteConfirm}
         onClose={() => setDeleteConfirm(null)}
-        fullScreen={{ xs: true, sm: false }}
+        fullScreen={isMobile}
       >
         <DialogTitle>Delete Image?</DialogTitle>
         <DialogContent>

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -16,9 +16,8 @@ import {
   TablePagination,
   InputAdornment,
   TextField,
-  useMediaQuery,
-  useTheme,
 } from "@mui/material";
+import { useIsMobile } from "../hooks/useIsMobile";
 import { Close, Error as ErrorIcon, Favorite, NavigateBefore, NavigateNext, PlayCircleOutline, Repeat, Search, Shuffle, VideoLibrary } from "@mui/icons-material";
 import { useNavigate } from "react-router";
 import { getJobs, getJob, getFileUrl, getFavorites, toggleFavorite } from "../api/client";
@@ -42,8 +41,7 @@ function formatDate(iso: string) {
 }
 
 export default function Videos() {
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
   const navigate = useNavigate();
   const [jobs, setJobs] = useState<JobResponse[]>([]);
   const [total, setTotal] = useState(0);

--- a/src/pages/Workers.tsx
+++ b/src/pages/Workers.tsx
@@ -20,6 +20,7 @@ import {
   FormControlLabel,
   Radio,
 } from "@mui/material";
+import { useIsMobile } from "../hooks/useIsMobile";
 import {
   Circle,
   Computer,
@@ -64,6 +65,7 @@ function formatDate(iso: string) {
 }
 
 export default function Workers() {
+  const isMobile = useIsMobile();
   const navigate = useNavigate();
   const [workers, setWorkers] = useState<WorkerResponse[]>([]);
   const [loading, setLoading] = useState(true);
@@ -193,7 +195,7 @@ export default function Workers() {
         onClose={() => setDeleteConfirm(null)}
         maxWidth="xs"
         fullWidth
-        fullScreen={{ xs: true, sm: false }}
+        fullScreen={isMobile}
       >
         <DialogTitle>Delete Worker</DialogTitle>
         <DialogContent>
@@ -220,7 +222,7 @@ export default function Workers() {
         onClose={() => setDrainConfirm(null)}
         maxWidth="xs"
         fullWidth
-        fullScreen={{ xs: true, sm: false }}
+        fullScreen={isMobile}
       >
         <DialogTitle>Drain Worker</DialogTitle>
         <DialogContent>


### PR DESCRIPTION
MUI's Dialog `fullScreen` prop only accepts `boolean`, not responsive breakpoint objects like `{ xs: true, sm: false }`. PR #148 used the object syntax in 3 dialogs which causes a TypeScript build error.

### Fixes
- **Workers.tsx** — delete/drain confirmation dialogs: replaced `fullScreen={{ xs: true, sm: false }}` with `useIsMobile()` hook
- **ImageRepo.tsx** — delete confirmation dialog: same fix  
- **Videos.tsx** — cleaned up stale `useMediaQuery`/`useTheme` imports and fixed variable-name mismatch (declared `fullScreen` but JSX referenced `isMobile`)