### PR TITLE
fix: use window.scrollTo instead of scrollIntoView for reliable top s…

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -98,16 +98,14 @@ export default function ImageRepo() {
   const navigate = useNavigate();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
-  const folderTopRef = useRef<HTMLDivElement>(null);
-  const imageTopRef = useRef<HTMLDivElement>(null);
 
   // Scroll to top when page changes
   useEffect(() => {
-    folderTopRef.current?.scrollIntoView({ behavior: "smooth" });
+    window.scrollTo({ top: 0, behavior: "smooth" });
   }, [folderPage]);
 
   useEffect(() => {
-    imageTopRef.current?.scrollIntoView({ behavior: "smooth" });
+    window.scrollTo({ top: 0, behavior: "smooth" });
   }, [imagePage]);
 
   const fetchFavorites = useCallback(async () => {
@@ -395,7 +393,6 @@ export default function ImageRepo() {
 
         {!favoritesView && (
           <>
-        <div ref={folderTopRef} />
         <Grid container spacing={2}>
           {[...folders]
             .sort((a, b) => (b.created_at || "").localeCompare(a.created_at || ""))
@@ -657,7 +654,6 @@ export default function ImageRepo() {
         </Box>
       )}
 
-      <div ref={imageTopRef} />
       <Grid container spacing={2}>
         {[...(favoritesOnly ? images.filter((img) => favoritesSet.has(img.path)) : images)]
           .sort((a, b) => {

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -59,11 +59,10 @@ export default function Videos() {
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const [favoritesSet, setFavoritesSet] = useState<Set<string>>(new Set());
   const [favoritesOnly, setFavoritesOnly] = useState(false);
-  const contentTopRef = useRef<HTMLDivElement>(null);
 
   // Scroll to top when page changes
   useEffect(() => {
-    contentTopRef.current?.scrollIntoView({ behavior: "smooth" });
+    window.scrollTo({ top: 0, behavior: "smooth" });
   }, [page]);
 
   // Debounce search input to avoid hammering the API on every keystroke
@@ -261,7 +260,6 @@ export default function Videos() {
 
       {finalizedJobs.length > 0 ? (
         <>
-        <div ref={contentTopRef} />
         <Grid container spacing={3}>
           {finalizedJobs.map((job) => {
             const videoInfo = getVideoInfo(job.id);


### PR DESCRIPTION
…croll

scrollIntoView aligns to the nearest scrollable ancestor, which doesn't always reach the page top when there are fixed headers or nested scroll containers. window.scrollTo({ top: 0 }) is more predictable.