### PR TITLE
fix: target main element for scroll, not window

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -101,11 +101,11 @@ export default function ImageRepo() {
 
   // Scroll to top when page changes
   useEffect(() => {
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    document.querySelector("main")?.scrollTo({ top: 0, behavior: "smooth" });
   }, [folderPage]);
 
   useEffect(() => {
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    document.querySelector("main")?.scrollTo({ top: 0, behavior: "smooth" });
   }, [imagePage]);
 
   const fetchFavorites = useCallback(async () => {

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -62,7 +62,7 @@ export default function Videos() {
 
   // Scroll to top when page changes
   useEffect(() => {
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    document.querySelector("main")?.scrollTo({ top: 0, behavior: "smooth" });
   }, [page]);
 
   // Debounce search input to avoid hammering the API on every keystroke


### PR DESCRIPTION
The app uses a fixed-height layout with overflow:auto on <main>, so window.scrollTo does nothing. Use document.querySelector('main') to target the actual scrollable container.