### PR TITLE
feat: make image lightbox modal mobile responsive

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -98,6 +98,7 @@ export default function ImageRepo() {
   const navigate = useNavigate();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const btnSize = isMobile ? "small" : "medium";
 
   // Scroll to top when page changes
   useEffect(() => {
@@ -861,13 +862,14 @@ export default function ImageRepo() {
             <DialogActions sx={{ flexWrap: "wrap", gap: 0.5, justifyContent: isMobile ? "space-between" : undefined }}>
               <Button
                 color="error"
-                size={isMobile ? "small" : "medium"}
+                size={btnSize}
                 onClick={() => setDeleteConfirm(lightboxImage)}
               >
                 Delete
               </Button>
               <IconButton
-                size={isMobile ? "small" : undefined}
+                size={btnSize}
+                aria-label={favoritesSet.has(lightboxImage.path) ? "Unfavorite" : "Favorite"}
                 onClick={async () => {
                   if (!lightboxImage) return;
                   const prev = new Set(favoritesSet);
@@ -886,14 +888,14 @@ export default function ImageRepo() {
               </IconButton>
               <Button
                 startIcon={isMobile ? undefined : <DriveFileMove />}
-                size={isMobile ? "small" : "medium"}
+                size={btnSize}
                 onClick={() => handleOpenMoveDialog([lightboxImage.key])}
               >
                 Move to
               </Button>
               <Button
                 startIcon={isMobile ? undefined : <ContentCut />}
-                size={isMobile ? "small" : "medium"}
+                size={btnSize}
                 onClick={() => {
                   setCropResizeImage(lightboxImage);
                   setLightboxImage(null);
@@ -903,12 +905,12 @@ export default function ImageRepo() {
               </Button>
               <Button
                 variant="contained"
-                size={isMobile ? "small" : "medium"}
+                size={btnSize}
                 onClick={() => handleUseAsStartingImage(lightboxImage)}
               >
                 {isMobile ? "New Job" : "Use as Starting Image"}
               </Button>
-              <Button size={isMobile ? "small" : "medium"} onClick={() => setLightboxImage(null)}>Close</Button>
+              <Button size={btnSize} onClick={() => setLightboxImage(null)}>Close</Button>
             </DialogActions>
           </>
         )}

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -769,6 +769,7 @@ export default function ImageRepo() {
         onClose={() => setLightboxImage(null)}
         maxWidth="lg"
         fullWidth
+        fullScreen={isMobile}
       >
         {lightboxImage && (
           <>
@@ -857,14 +858,16 @@ export default function ImageRepo() {
                 </Box>
               </Box>
             </DialogContent>
-            <DialogActions>
+            <DialogActions sx={{ flexWrap: "wrap", gap: 0.5, justifyContent: isMobile ? "space-between" : undefined }}>
               <Button
                 color="error"
+                size={isMobile ? "small" : "medium"}
                 onClick={() => setDeleteConfirm(lightboxImage)}
               >
                 Delete
               </Button>
               <IconButton
+                size={isMobile ? "small" : undefined}
                 onClick={async () => {
                   if (!lightboxImage) return;
                   const prev = new Set(favoritesSet);
@@ -882,13 +885,15 @@ export default function ImageRepo() {
                 <Favorite />
               </IconButton>
               <Button
-                startIcon={<DriveFileMove />}
+                startIcon={isMobile ? undefined : <DriveFileMove />}
+                size={isMobile ? "small" : "medium"}
                 onClick={() => handleOpenMoveDialog([lightboxImage.key])}
               >
                 Move to
               </Button>
               <Button
-                startIcon={<ContentCut />}
+                startIcon={isMobile ? undefined : <ContentCut />}
+                size={isMobile ? "small" : "medium"}
                 onClick={() => {
                   setCropResizeImage(lightboxImage);
                   setLightboxImage(null);
@@ -898,11 +903,12 @@ export default function ImageRepo() {
               </Button>
               <Button
                 variant="contained"
+                size={isMobile ? "small" : "medium"}
                 onClick={() => handleUseAsStartingImage(lightboxImage)}
               >
-                Use as Starting Image
+                {isMobile ? "New Job" : "Use as Starting Image"}
               </Button>
-              <Button onClick={() => setLightboxImage(null)}>Close</Button>
+              <Button size={isMobile ? "small" : "medium"} onClick={() => setLightboxImage(null)}>Close</Button>
             </DialogActions>
           </>
         )}


### PR DESCRIPTION
Closes #144

Makes the image lightbox dialog (the one that appears when clicking an image in the repo) follow the same mobile-responsive pattern as the New Job Modal and Lora Modal:

- **`fullScreen`** on the Dialog at sm breakpoint so it uses the full viewport on mobile
- **DialogActions** now wraps with `flexWrap: "wrap"` and uses `size="small"` buttons on mobile
- **Hidden start icons** on mobile for Move to and Crop & Resize to save horizontal space
- **Shortened label** 'New Job' instead of 'Use as Starting Image' on mobile