### PR TITLE
Add negative prompt field to New Job modal and JobDetail

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -147,6 +147,7 @@ export interface SegmentResponse {
   motion_keywords: string[] | null;
   motion_magnitude: number | null;
   reference_frames: string[] | null;
+  negative_prompt: string | null;
   status: SegmentStatus;
   worker_id: string | null;
   worker_name: string | null;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -20,6 +20,7 @@ export interface SegmentCreate {
   faceswap_image?: string | null;
   faceswap_faces_order?: string | null;
   faceswap_faces_index?: string | null;
+  negative_prompt?: string | null;
   auto_finalize?: boolean;
   transition?: string | null;
 }

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -60,9 +60,10 @@ export default function CreateJobDialog({
   initialStartingImageUri,
 }: CreateJobDialogProps) {
   const isMobile = useIsMobile();
-  const { defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, fetchSettings } = useSettingsStore();
+  const { defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, negativePrompt: defaultNegativePrompt, fetchSettings } = useSettingsStore();
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
+  const [negativePrompt, setNegativePrompt] = useState("");
   const [origWidth, setOrigWidth] = useState(DEFAULT_WIDTH);
   const [origHeight, setOrigHeight] = useState(DEFAULT_HEIGHT);
   const [width, setWidth] = useState(DEFAULT_WIDTH);
@@ -173,6 +174,13 @@ export default function CreateJobDialog({
     }
   }, [open, fetchLoras, fetchTags]);
 
+  // Pre-populate negative prompt from settings default when dialog opens
+  useEffect(() => {
+    if (open && defaultNegativePrompt) {
+      setNegativePrompt(defaultNegativePrompt);
+    }
+  }, [open, defaultNegativePrompt]);
+
   // Apply initialStartingImage (File) when dialog opens
   useEffect(() => {
     if (open && initialStartingImage) {
@@ -243,6 +251,7 @@ export default function CreateJobDialog({
   const resetForm = useCallback(() => {
     setName("");
     setPrompt("");
+    setNegativePrompt("");
     setOrigWidth(DEFAULT_WIDTH);
     setOrigHeight(DEFAULT_HEIGHT);
     setWidth(DEFAULT_WIDTH);
@@ -332,6 +341,7 @@ export default function CreateJobDialog({
           faceswap_source_type: faceswapEnabled ? faceswapSourceType : null,
           faceswap_image: faceswapEnabled && faceswapSourceType === "preset" ? faceswapPresetUri : null,
           faceswap_faces_index: faceswapEnabled ? faceswapFacesIndex : null,
+          negative_prompt: negativePrompt.trim() || null,
           faceswap_faces_order: faceswapEnabled ? faceswapFacesOrder : null,
         },
       };
@@ -495,6 +505,42 @@ export default function CreateJobDialog({
             <ClearOutlined sx={{ fontSize: 14 }} />
           </IconButton>
         </Box>
+
+        {/* ── Negative Prompt (accordion) ── */}
+        <Accordion defaultExpanded={false} disableGutters sx={accordionSx}>
+          <AccordionSummary expandIcon={<ExpandMore />}>
+            <Typography variant="subtitle2">
+              Negative Prompt
+              {negativePrompt && (
+                <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                  {negativePrompt.length > 60 ? negativePrompt.slice(0, 60) + '…' : negativePrompt}
+                </Typography>
+              )}
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ pt: 0 }}>
+            <TextField
+              label="Negative Prompt"
+              fullWidth
+              multiline
+              rows={3}
+              value={negativePrompt}
+              onChange={(e) => setNegativePrompt(e.target.value)}
+              helperText="Passed as negative conditioning to ComfyUI"
+            />
+            <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: -0.5 }}>
+              <IconButton
+                size="small"
+                onClick={() => setNegativePrompt("")}
+                disabled={!negativePrompt}
+                sx={{ color: "text.disabled", p: 0.25 }}
+                title="Clear negative prompt"
+              >
+                <ClearOutlined sx={{ fontSize: 14 }} />
+              </IconButton>
+            </Box>
+          </AccordionDetails>
+        </Accordion>
 
         {/* ── Video Settings (accordion) ── */}
         <Accordion defaultExpanded={false} disableGutters sx={accordionSx}>

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -176,8 +176,8 @@ export default function CreateJobDialog({
 
   // Pre-populate negative prompt from settings default when dialog opens
   useEffect(() => {
-    if (open && defaultNegativePrompt) {
-      setNegativePrompt(defaultNegativePrompt);
+    if (open) {
+      setNegativePrompt(defaultNegativePrompt || '');
     }
   }, [open, defaultNegativePrompt]);
 
@@ -535,6 +535,7 @@ export default function CreateJobDialog({
                 disabled={!negativePrompt}
                 sx={{ color: "text.disabled", p: 0.25 }}
                 title="Clear negative prompt"
+                aria-label="Clear negative prompt"
               >
                 <ClearOutlined sx={{ fontSize: 14 }} />
               </IconButton>

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -715,6 +715,15 @@ export default function JobDetail() {
                           Resolved: {seg.prompt}
                         </Typography>
                       )}
+                      {seg.negative_prompt && (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ display: "block", mt: 0.5, fontStyle: "italic" }}
+                        >
+                          Negative: {seg.negative_prompt}
+                        </Typography>
+                      )}
                       {seg.error_message && (
                         <Alert severity="error" sx={{ mt: 1 }}>
                           {seg.error_message}
@@ -1147,6 +1156,15 @@ export default function JobDetail() {
                     {seg.prompt_template && (
                       <Typography variant="caption" color="text.secondary" sx={{ fontStyle: "italic", display: "block" }}>
                         Resolved: {seg.prompt}
+                      </Typography>
+                    )}
+                    {seg.negative_prompt && (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ fontStyle: "italic", display: "block" }}
+                      >
+                        Negative: {seg.negative_prompt}
                       </Typography>
                     )}
                     {seg.error_message && (


### PR DESCRIPTION
Closes https://github.com/DavidJBarnes/wanly-console/issues/154

- Adds collapsible negative prompt accordion in CreateJobDialog, positioned below the prompt textarea
- Pre-populates negative prompt from the Settings default when dialog opens
- Passes `negative_prompt` in `first_segment` on job creation
- Displays negative prompt in both desktop table and mobile card views on JobDetail page