### PR TITLE
fix: separate Close from Delete in lightbox action bar

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -859,7 +859,7 @@ export default function ImageRepo() {
                 </Box>
               </Box>
             </DialogContent>
-            <DialogActions sx={{ flexWrap: "wrap", gap: 0.5, justifyContent: isMobile ? "space-between" : undefined }}>
+            <DialogActions sx={{ flexWrap: "wrap", gap: isMobile ? 1.5 : 1 }}>
               <Button
                 color="error"
                 size={btnSize}
@@ -910,7 +910,7 @@ export default function ImageRepo() {
               >
                 {isMobile ? "New Job" : "Use as Starting Image"}
               </Button>
-              <Button size={btnSize} onClick={() => setLightboxImage(null)}>Close</Button>
+              <Button size={btnSize} onClick={() => setLightboxImage(null)} sx={{ ml: "auto" }}>Close</Button>
             </DialogActions>
           </>
         )}


### PR DESCRIPTION
- Pin Close to far right with ml: auto so it never sits next to Delete
- Increase gap from 0.5 to 1.5 on mobile for better tap-target spacing
- Remove space-between justification (ml: auto handles separation better)