### PR TITLE
feat: add video tags UI — tag editor and tag search

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -32,6 +32,7 @@ import type {
   FavoriteListResponse,
   AppSettingsResponse,
   AppSettingsUpdate,
+  VideoResponse,
 } from "./types";
 import { LOCAL_STORAGE_TOKEN_KEY } from "../constants";
 
@@ -77,6 +78,7 @@ export async function getJobs(params?: {
   status?: string;
   sort?: string;
   name?: string;
+  q?: string;
 }): Promise<JobListResponse> {
   const { data } = await api.get<JobListResponse>("/jobs", { params });
   return data;
@@ -456,6 +458,11 @@ export async function uploadFile(
 
 export async function toggleFavorite(body: FavoriteToggleRequest): Promise<FavoriteToggleResponse> {
   const { data } = await api.post<FavoriteToggleResponse>("/favorites/toggle", body);
+  return data;
+}
+
+export async function updateVideoTags(videoId: string, tags: string | null): Promise<VideoResponse> {
+  const { data } = await api.patch<VideoResponse>(`/videos/${videoId}/tags`, { tags });
   return data;
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -120,6 +120,7 @@ export interface JobResponse {
   completed_segment_count: number;
   estimated_run_time: number | null;
   faceswap_enabled: boolean;
+  tags: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -181,6 +182,7 @@ export interface VideoResponse {
   duration_seconds: number | null;
   status: string;
   error_message: string | null;
+  tags: string | null;
   created_at: string;
   completed_at: string | null;
 }

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -406,9 +406,17 @@ export default function JobDetail() {
     setTrimValues(newTrimValues);
   }, [job]);
 
-  // Initialize tags from the finalized video when job loads
+  // Cleanup tag save timer on unmount
+  useEffect(() => {
+    return () => {
+      if (tagSaveTimer.current) clearTimeout(tagSaveTimer.current);
+    };
+  }, []);
+
+  // Initialize tags from the finalized video when job loads (only if no pending edits)
   useEffect(() => {
     if (!job) return;
+    if (tagSaveTimer.current) return;
     const video = job.videos?.find((v) => v.status === "completed" && v.output_path);
     setVideoTags(video?.tags ?? "");
   }, [job]);
@@ -417,9 +425,12 @@ export default function JobDetail() {
     setVideoTags(newTags);
     if (tagSaveTimer.current) clearTimeout(tagSaveTimer.current);
     tagSaveTimer.current = setTimeout(() => {
+      tagSaveTimer.current = undefined;
       const video = job?.videos?.find((v) => v.status === "completed" && v.output_path);
       if (video) {
-        updateVideoTags(video.id, newTags || null).catch(() => {});
+        updateVideoTags(video.id, newTags || null).catch((err) => {
+          console.error("Failed to save video tags:", err);
+        });
       }
     }, 500);
   };
@@ -665,6 +676,7 @@ export default function JobDetail() {
               placeholder="Add tags (comma separated)"
               value={videoTags}
               onChange={(e) => handleVideoTagsChange(e.target.value)}
+              aria-label="Video tags"
             />
             {videoTags && (
               <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mt: 0.5 }}>

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -68,6 +68,7 @@ import {
   getSegmentFrames,
   getImageFolders,
   getImageFolder,
+  updateVideoTags,
 } from "../api/client";
 import { useLoraStore } from "../stores/loraStore";
 import { usePromptPresetStore } from "../stores/promptPresetStore";
@@ -254,6 +255,8 @@ export default function JobDetail() {
   const [archiving, setArchiving] = useState(false);
   const [trimValues, setTrimValues] = useState<Record<string, { start: number; end: number }>>({});
   const trimTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const [videoTags, setVideoTags] = useState("");
+  const tagSaveTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const [framePreview, setFramePreview] = useState<{
     anchorEl: HTMLElement | null;
     segId: string;
@@ -402,6 +405,24 @@ export default function JobDetail() {
     }
     setTrimValues(newTrimValues);
   }, [job]);
+
+  // Initialize tags from the finalized video when job loads
+  useEffect(() => {
+    if (!job) return;
+    const video = job.videos?.find((v) => v.status === "completed" && v.output_path);
+    setVideoTags(video?.tags ?? "");
+  }, [job]);
+
+  const handleVideoTagsChange = (newTags: string) => {
+    setVideoTags(newTags);
+    if (tagSaveTimer.current) clearTimeout(tagSaveTimer.current);
+    tagSaveTimer.current = setTimeout(() => {
+      const video = job?.videos?.find((v) => v.status === "completed" && v.output_path);
+      if (video) {
+        updateVideoTags(video.id, newTags || null).catch(() => {});
+      }
+    }, 500);
+  };
 
   const handleTrimChange = (segId: string, field: "start" | "end", value: number) => {
     setTrimValues((prev) => ({
@@ -613,30 +634,58 @@ export default function JobDetail() {
                   loop={loopVideo}
                   sx={{ width: "100%", borderRadius: 1, display: "block" }}
                 />
-                <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mt: 1 }}>
-                  <Typography variant="caption" color="text.secondary">
-                    {finalVideo.duration_seconds != null ? formatDuration(finalVideo.duration_seconds) : ""}
-                  </Typography>
-                  <Box sx={{ display: "flex", alignItems: "center" }}>
-                    <IconButton
+          <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mt: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              {finalVideo.duration_seconds != null ? formatDuration(finalVideo.duration_seconds) : ""}
+            </Typography>
+            <Box sx={{ display: "flex", alignItems: "center" }}>
+              <IconButton
+                size="small"
+                onClick={() => setLoopVideo((v) => !v)}
+                color={loopVideo ? "primary" : "default"}
+                title={loopVideo ? "Loop on" : "Loop off"}
+              >
+                <Repeat fontSize="small" />
+              </IconButton>
+              <IconButton
+                size="small"
+                component="a"
+                href={getFileUrl(finalVideo.output_path, finalVideo.completed_at ?? undefined)}
+                download
+                target="_blank"
+              >
+                <Download fontSize="small" />
+              </IconButton>
+            </Box>
+          </Box>
+          <Box sx={{ mt: 1.5 }}>
+            <TextField
+              size="small"
+              fullWidth
+              placeholder="Add tags (comma separated)"
+              value={videoTags}
+              onChange={(e) => handleVideoTagsChange(e.target.value)}
+            />
+            {videoTags && (
+              <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mt: 0.5 }}>
+                {videoTags.split(",").map((tag, i) => {
+                  const trimmed = tag.trim();
+                  if (!trimmed) return null;
+                  return (
+                    <Chip
+                      key={i}
+                      label={trimmed}
                       size="small"
-                      onClick={() => setLoopVideo((v) => !v)}
-                      color={loopVideo ? "primary" : "default"}
-                      title={loopVideo ? "Loop on" : "Loop off"}
-                    >
-                      <Repeat fontSize="small" />
-                    </IconButton>
-                    <IconButton
-                      size="small"
-                      component="a"
-                      href={getFileUrl(finalVideo.output_path, finalVideo.completed_at ?? undefined)}
-                      download
-                      target="_blank"
-                    >
-                      <Download fontSize="small" />
-                    </IconButton>
-                  </Box>
-                </Box>
+                      onDelete={() => {
+                        const tags = videoTags.split(",").map((t) => t.trim()).filter((t) => t && t !== trimmed);
+                        handleVideoTagsChange(tags.join(", "));
+                      }}
+                    />
+                  );
+                })}
+              </Box>
+            )}
+          </Box>
               </CardContent>
             </Card>
           );

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -84,7 +84,7 @@ export default function Videos() {
         limit: rowsPerPage,
         offset: page * rowsPerPage,
         sort: "updated_at_desc",
-        name: debouncedQuery || undefined,
+        q: debouncedQuery || undefined,
       });
       setJobs(res.items);
       setTotal(res.total);
@@ -152,7 +152,7 @@ export default function Videos() {
         status: "finalized",
         limit: DEFAULT_JOB_FETCH_LIMIT,
         offset: 0,
-        name: debouncedQuery || undefined,
+        q: debouncedQuery || undefined,
       });
       const allJobs = favoritesOnly
         ? res.items.filter((j) => favoritesSet.has(j.id))
@@ -389,6 +389,17 @@ export default function Videos() {
                     <Typography variant="subtitle2" noWrap sx={{ mb: 0.5 }}>
                       {job.name}
                     </Typography>
+                    {job.tags && (
+                      <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mb: 0.5 }}>
+                        {job.tags.split(",").map((tag, i) => {
+                          const trimmed = tag.trim();
+                          if (!trimmed) return null;
+                          return (
+                            <Chip key={i} label={trimmed} size="small" sx={{ height: 20, fontSize: 11 }} />
+                          );
+                        })}
+                      </Box>
+                    )}
                     <Typography variant="caption" color="text.secondary" component="div">
                       {detail ? `${detail.completed_segment_count} segments` : "..."} &middot;{" "}
                       {detail ? formatDuration(detail.total_video_time) : "..."} &middot;{" "}


### PR DESCRIPTION
## Summary

- Adds a tags editor in the finalized video card on the Job Detail page (text input + Chip display with delete)
- Displays tags as Chips on each video card on the Videos page
- Extends the videos search bar to search both job name and video tags (via the `q` query parameter)

## Frontend Changes

- **Types**: Added `tags?: string` to `JobResponse` and `VideoResponse`
- **API Client**: Added `updateVideoTags()` function; added `q` param to `getJobs()`
- **JobDetail page**: Tags editor with debounced auto-save
- **Videos page**: Tags displayed as chips; search now queries both name and tags

## Related

Closes #155