### PR TITLE
fix: use Job-level tags so tags editor is always available

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -32,7 +32,6 @@ import type {
   FavoriteListResponse,
   AppSettingsResponse,
   AppSettingsUpdate,
-  VideoResponse,
 } from "./types";
 import { LOCAL_STORAGE_TOKEN_KEY } from "../constants";
 
@@ -458,11 +457,6 @@ export async function uploadFile(
 
 export async function toggleFavorite(body: FavoriteToggleRequest): Promise<FavoriteToggleResponse> {
   const { data } = await api.post<FavoriteToggleResponse>("/favorites/toggle", body);
-  return data;
-}
-
-export async function updateVideoTags(videoId: string, tags: string | null): Promise<VideoResponse> {
-  const { data } = await api.patch<VideoResponse>(`/videos/${videoId}/tags`, { tags });
   return data;
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -206,6 +206,7 @@ export interface JobDetailResponse extends JobResponse {
 export interface JobUpdate {
   name?: string;
   status?: string;
+  tags?: string | null;
 }
 
 export type JobStatus =

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -69,7 +69,6 @@ import {
   getSegmentFrames,
   getImageFolders,
   getImageFolder,
-  updateVideoTags,
 } from "../api/client";
 import { useLoraStore } from "../stores/loraStore";
 import { usePromptPresetStore } from "../stores/promptPresetStore";
@@ -414,12 +413,11 @@ export default function JobDetail() {
     };
   }, []);
 
-  // Initialize tags from the finalized video when job loads (only if no pending edits)
+  // Initialize tags from the job when loaded (only if no pending edits)
   useEffect(() => {
     if (!job) return;
     if (tagSaveTimer.current) return;
-    const video = job.videos?.find((v) => v.status === "completed" && v.output_path);
-    setVideoTags(video?.tags ?? "");
+    setVideoTags(job.tags ?? "");
   }, [job]);
 
   const handleVideoTagsChange = (newTags: string) => {
@@ -427,10 +425,9 @@ export default function JobDetail() {
     if (tagSaveTimer.current) clearTimeout(tagSaveTimer.current);
     tagSaveTimer.current = setTimeout(() => {
       tagSaveTimer.current = undefined;
-      const video = job?.videos?.find((v) => v.status === "completed" && v.output_path);
-      if (video) {
-        updateVideoTags(video.id, newTags || null).catch((err) => {
-          console.error("Failed to save video tags:", err);
+      if (id) {
+        updateJob(id, { tags: newTags || null }).catch((err) => {
+          console.error("Failed to save tags:", err);
         });
       }
     }, 500);
@@ -670,40 +667,45 @@ export default function JobDetail() {
               </IconButton>
             </Box>
           </Box>
-          <Box sx={{ mt: 1.5 }}>
-            <TextField
-              size="small"
-              fullWidth
-              placeholder="Add tags (comma separated)"
-              value={videoTags}
-              onChange={(e) => handleVideoTagsChange(e.target.value)}
-              aria-label="Video tags"
-            />
-            {videoTags && (
-              <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mt: 0.5 }}>
-                {videoTags.split(",").map((tag, i) => {
-                  const trimmed = tag.trim();
-                  if (!trimmed) return null;
-                  return (
-                    <Chip
-                      key={i}
-                      label={trimmed}
-                      size="small"
-                      onDelete={() => {
-                        const tags = videoTags.split(",").map((t) => t.trim()).filter((t) => t && t !== trimmed);
-                        handleVideoTagsChange(tags.join(", "));
-                      }}
-                    />
-                  );
-                })}
-              </Box>
-            )}
-          </Box>
               </CardContent>
             </Card>
           );
         })()}
       </Box>
+
+      {/* Tags editor — always visible */}
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>Tags</Typography>
+          <TextField
+            size="small"
+            fullWidth
+            placeholder="Add tags (comma separated)"
+            value={videoTags}
+            onChange={(e) => handleVideoTagsChange(e.target.value)}
+            aria-label="Job tags"
+          />
+          {videoTags && (
+            <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mt: 1 }}>
+              {videoTags.split(",").map((tag, i) => {
+                const trimmed = tag.trim();
+                if (!trimmed) return null;
+                return (
+                  <Chip
+                    key={i}
+                    label={trimmed}
+                    size="small"
+                    onDelete={() => {
+                      const tags = videoTags.split(",").map((t) => t.trim()).filter((t) => t && t !== trimmed);
+                      handleVideoTagsChange(tags.join(", "));
+                    }}
+                  />
+                );
+              })}
+            </Box>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Segments table */}
       <Card sx={{ mb: 3 }}>

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -255,7 +255,7 @@ export default function JobDetail() {
   const [archiving, setArchiving] = useState(false);
   const [trimValues, setTrimValues] = useState<Record<string, { start: number; end: number }>>({});
   const trimTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
-  const [videoTags, setVideoTags] = useState("");
+  const [jobTags, setJobTags] = useState("");
   const tagSaveTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const [framePreview, setFramePreview] = useState<{
     anchorEl: HTMLElement | null;
@@ -417,17 +417,19 @@ export default function JobDetail() {
   useEffect(() => {
     if (!job) return;
     if (tagSaveTimer.current) return;
-    setVideoTags(job.tags ?? "");
+    const tags = job.tags ?? job.videos?.find((v) => v.tags)?.tags ?? "";
+    setJobTags(tags);
   }, [job]);
 
-  const handleVideoTagsChange = (newTags: string) => {
-    setVideoTags(newTags);
+  const handleTagsChange = (newTags: string) => {
+    setJobTags(newTags);
     if (tagSaveTimer.current) clearTimeout(tagSaveTimer.current);
     tagSaveTimer.current = setTimeout(() => {
       tagSaveTimer.current = undefined;
       if (id) {
         updateJob(id, { tags: newTags || null }).catch((err) => {
           console.error("Failed to save tags:", err);
+          setError("Failed to save tags");
         });
       }
     }, 500);
@@ -681,13 +683,13 @@ export default function JobDetail() {
             size="small"
             fullWidth
             placeholder="Add tags (comma separated)"
-            value={videoTags}
-            onChange={(e) => handleVideoTagsChange(e.target.value)}
+            value={jobTags}
+            onChange={(e) => handleTagsChange(e.target.value)}
             aria-label="Job tags"
           />
-          {videoTags && (
+          {jobTags && (
             <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mt: 1 }}>
-              {videoTags.split(",").map((tag, i) => {
+              {jobTags.split(",").map((tag, i) => {
                 const trimmed = tag.trim();
                 if (!trimmed) return null;
                 return (
@@ -696,8 +698,8 @@ export default function JobDetail() {
                     label={trimmed}
                     size="small"
                     onDelete={() => {
-                      const tags = videoTags.split(",").map((t) => t.trim()).filter((t) => t && t !== trimmed);
-                      handleVideoTagsChange(tags.join(", "));
+                      const tags = jobTags.split(",").map((t) => t.trim()).filter((t) => t && t !== trimmed);
+                      handleTagsChange(tags.join(", "));
                     }}
                   />
                 );


### PR DESCRIPTION
## Summary

Moves the tags source from Video model to Job model so the tags editor on the Job Detail page works at any stage, not only after finalization.

## Changes

- **Types**: Removed `VideoResponse.tags` (didn't need it); `JobResponse.tags` stays
- **API client**: Removed `updateVideoTags()` — tags are now saved via `PATCH /jobs/{id}` with `{tags: ...}`
- **JobDetail page**: Tags editor moved to its own card outside the finalized video conditional block; saves via `updateJob()` instead of `updateVideoTags()`
- **Videos page**: Already uses `job.tags` — works unchanged