### PR TITLE
fix: Remove unused jobId prop from ReprocessDialog

### DIFF
--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -1534,7 +1534,6 @@ export default function JobDetail() {
         <ReprocessDialog
           open={!!reprocessSeg}
           segment={reprocessSeg}
-          jobId={job.id}
           onClose={() => setReprocessSeg(null)}
           onSubmitted={() => {
             setReprocessSeg(null);
@@ -2837,13 +2836,11 @@ function SegmentModal({
 function ReprocessDialog({
   open,
   segment,
-  jobId,
   onClose,
   onSubmitted,
 }: {
   open: boolean;
   segment: SegmentResponse;
-  jobId: string;
   onClose: () => void;
   onSubmitted: () => void;
 }) {


### PR DESCRIPTION
## Summary
- Removes unused `jobId` prop from `ReprocessDialog` component and its call site
- Fixes `tsc -b` build failure (TS6133: noUnusedLocals) introduced by PR #169

## Test plan
- [ ] `npm run build` passes locally
- [ ] CI passes