### PR TITLE
fix: surface save errors on settings page instead of failing silently

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -39,6 +39,7 @@ export default function SettingsPage() {
   } = useSettingsStore();
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     fetchTags();
@@ -58,6 +59,7 @@ export default function SettingsPage() {
   const handleSaveDefaults = async () => {
     setSaving(true);
     setSaved(false);
+    setSaveError(null);
     try {
       await saveSettings({
         lightx2v_strength_high: parseFloat(defaultLightx2vHigh) || 2.0,
@@ -67,8 +69,11 @@ export default function SettingsPage() {
         negative_prompt: negativePrompt,
       });
       setSaved(true);
-    } catch {
-      // error handled silently
+    } catch (err) {
+      console.error("Failed to save app settings:", err);
+      const message =
+        err instanceof Error ? err.message : "Failed to save settings. Please try again.";
+      setSaveError(message);
     } finally {
       setSaving(false);
     }
@@ -257,6 +262,11 @@ export default function SettingsPage() {
                 {saved && (
                   <Alert severity="success" sx={{ mt: 1 }}>
                     Defaults saved
+                  </Alert>
+                )}
+                {saveError && (
+                  <Alert severity="error" sx={{ mt: 1 }} onClose={() => setSaveError(null)}>
+                    {saveError}
                   </Alert>
                 )}
               </Box>


### PR DESCRIPTION
## Problem

When saving defaults on the Settings page (including the negative prompt field), any failure from the `PUT /settings` endpoint was silently swallowed. There was no error message, no console log, and no user feedback — the "Save Defaults" button simply returned to its idle state. This made failures indistinguishable from success, leading users to believe values weren't persisting.

## Root Cause

The `catch` block in `handleSaveDefaults` was empty:

```tsx
} catch {
  // error handled silently
}
```

## Solution

- **Added `console.error` logging** so failures are visible in dev tools
- **Added a user-visible `Alert` (severity: error)** with the error message
- **Clears previous error state** on each save attempt
- **Dismissible alert** so it doesn't permanently block the UI

### After

```tsx
} catch (err) {
  console.error("Failed to save app settings:", err);
  const message =
    err instanceof Error ? err.message : "Failed to save settings. Please try again.";
  setSaveError(message);
}
```

## Notes

The underlying save pipeline (Zustand store → axios PUT → FastAPI → PostgreSQL) was traced end-to-end and found to be correct. Once errors are surfaced, the actual root cause (e.g., expired auth token, network issue, backend error) will be visible and can be addressed directly.