### PR TITLE
feat: optimistic in-use indicator update when job is created from image repo

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -86,7 +86,7 @@ export default function ImageRepo() {
   const [moveTargetKeys, setMoveTargetKeys] = useState<string[]>([]);
   const [moving, setMoving] = useState(false);
   const [sortDesc, setSortDesc] = useState(true);
-  const [pendingImagePath, setPendingImagePath] = useState<string | null>(null);
+  const pendingImagePathRef = useRef<string | null>(null);
   const [cropResizeImage, setCropResizeImage] = useState<ImageFile | null>(null);
   const [lightboxJobs, setLightboxJobs] = useState<ImageJobInfo[]>([]);
   const [loadingJobs, setLoadingJobs] = useState(false);
@@ -189,7 +189,7 @@ export default function ImageRepo() {
   };
 
   const handleUseAsStartingImage = (image: ImageFile) => {
-    setPendingImagePath(image.path);
+    pendingImagePathRef.current = image.path;
     setJobDialogImageUri(image.path);
     setLightboxImage(null);
     setJobDialogOpen(true);
@@ -1009,22 +1009,24 @@ export default function ImageRepo() {
         onClose={() => {
           setJobDialogOpen(false);
           setJobDialogImageUri(null);
+          pendingImagePathRef.current = null;
         }}
         onCreated={() => {
+          const path = pendingImagePathRef.current;
           setJobDialogOpen(false);
           setJobDialogImageUri(null);
-          if (pendingImagePath) {
+          pendingImagePathRef.current = null;
+          if (path) {
             setImages((prev) =>
               prev.map((img) =>
-                img.path === pendingImagePath ? { ...img, in_use: true } : img,
+                img.path === path ? { ...img, in_use: true } : img,
               ),
             );
             setFavImages((prev) =>
               prev.map((img) =>
-                img.path === pendingImagePath ? { ...img, in_use: true } : img,
+                img.path === path ? { ...img, in_use: true } : img,
               ),
             );
-            setPendingImagePath(null);
           }
         }}
         initialStartingImageUri={jobDialogImageUri}

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -86,6 +86,7 @@ export default function ImageRepo() {
   const [moveTargetKeys, setMoveTargetKeys] = useState<string[]>([]);
   const [moving, setMoving] = useState(false);
   const [sortDesc, setSortDesc] = useState(true);
+  const [pendingImagePath, setPendingImagePath] = useState<string | null>(null);
   const [cropResizeImage, setCropResizeImage] = useState<ImageFile | null>(null);
   const [lightboxJobs, setLightboxJobs] = useState<ImageJobInfo[]>([]);
   const [loadingJobs, setLoadingJobs] = useState(false);
@@ -188,6 +189,7 @@ export default function ImageRepo() {
   };
 
   const handleUseAsStartingImage = (image: ImageFile) => {
+    setPendingImagePath(image.path);
     setJobDialogImageUri(image.path);
     setLightboxImage(null);
     setJobDialogOpen(true);
@@ -1011,6 +1013,19 @@ export default function ImageRepo() {
         onCreated={() => {
           setJobDialogOpen(false);
           setJobDialogImageUri(null);
+          if (pendingImagePath) {
+            setImages((prev) =>
+              prev.map((img) =>
+                img.path === pendingImagePath ? { ...img, in_use: true } : img,
+              ),
+            );
+            setFavImages((prev) =>
+              prev.map((img) =>
+                img.path === pendingImagePath ? { ...img, in_use: true } : img,
+              ),
+            );
+            setPendingImagePath(null);
+          }
         }}
         initialStartingImageUri={jobDialogImageUri}
       />


### PR DESCRIPTION
## What

When a user creates a new job via 'Use as Starting Image' from the Image Repo, the grey/green in-use indicator dot on the image card now **immediately flips to green** without requiring a page refresh.

## How

- `handleUseAsStartingImage` captures the image path via `pendingImagePath` state
- The `CreateJobDialog`'s `onCreated` callback maps over both `images` and `favImages` arrays and toggles `in_use: true` for the matching image
- Both state arrays are updated so the indicator works in **folder grid view** and **favorites view**

## Why

Previously, after submitting a job, the green indicator would only appear after manually refreshing the page or navigating away and back. This is purely a local-state optimistic update — no additional API calls needed.

## Scope

- 1 file changed (`src/pages/ImageRepo.tsx`)
- 15 lines added
- No new dependencies, no API changes