### PR TITLE
feat: auto-scale starting image to 75% when dimensions exceed target

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -88,11 +88,13 @@ export default function CreateJobDialog({
     const img = new window.Image();
     img.onload = () => {
       if (!mountedRef.current) return;
+      const oversize = img.naturalWidth > 1216 || img.naturalHeight > 832;
+      const scalePct = oversize ? 75 : 100;
       setOrigWidth(img.naturalWidth);
       setOrigHeight(img.naturalHeight);
-      setWidth(img.naturalWidth);
-      setHeight(img.naturalHeight);
-      setScale(100);
+      setWidth(Math.round(img.naturalWidth * scalePct / 100));
+      setHeight(Math.round(img.naturalHeight * scalePct / 100));
+      setScale(scalePct);
     };
     img.onerror = () => {
       if (!mountedRef.current) return;


### PR DESCRIPTION
## What

When a starting image exceeds the target render resolution (1216×832), the scale slider automatically defaults to 75% instead of 100%.

## Why

Large starting images waste GPU memory and processing time. A 2000×1500 image at 75% becomes 1500×1125 — much closer to the 1216×832 working resolution while preserving the user's ability to adjust further.

## How

In `loadImageFromUrl`'s `img.onload` callback, the dimensions are checked before setting scale:

```tsx
const oversize = img.naturalWidth > 1216 || img.naturalHeight > 832;
const scalePct = oversize ? 75 : 100;
```

Both `width` and `height` are also adjusted to `Math.round(natural * scalePct / 100)` so the displayed input values match the slider.

## Trigger conditions

- Any image where **either** dimension exceeds the threshold:
  - Width > 1216
  - Height > 832
- Covers both landscape (e.g., 2000×1000) and portrait (e.g., 1000×2000) oversize images
- Images within bounds (≤1216 and ≤832) remain at 100%

## Scope

- 1 file: `src/components/CreateJobDialog.tsx`
- 5 lines added, 3 removed
- No new dependencies