### PR TITLE
feat: add first/last page buttons to image repo pagination

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -749,6 +749,8 @@ export default function ImageRepo() {
               setFolderPage(0);
             }}
             rowsPerPageOptions={[12, 24, 48]}
+            showFirstButton
+            showLastButton
             sx={{
               "& .MuiTablePagination-toolbar": {
                 flexWrap: "wrap",
@@ -1085,6 +1087,8 @@ export default function ImageRepo() {
             setImagePage(0);
           }}
           rowsPerPageOptions={[24, 48, 96]}
+          showFirstButton
+          showLastButton
           sx={{
             "& .MuiTablePagination-toolbar": {
               flexWrap: "wrap",


### PR DESCRIPTION
Adds `showFirstButton` and `showLastButton` props to both pagination views in ImageRepo:

- **Folder grid view**: navigation buttons for jumping to first/last page of folder list
- **Image grid view**: navigation buttons for jumping to first/last page of images inside a folder

These render as `<<` (go to first page) and `>>` (go to last page) buttons in the TablePagination toolbar.