### PR TITLE
fix: restore optimistic in-use indicator update on image repo job creation

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -729,10 +729,25 @@ export default function ImageRepo() {
         onClose={() => {
           setJobDialogOpen(false);
           setJobDialogImageUri(null);
+          pendingImagePathRef.current = null;
         }}
         onCreated={() => {
+          const path = pendingImagePathRef.current;
           setJobDialogOpen(false);
           setJobDialogImageUri(null);
+          pendingImagePathRef.current = null;
+          if (path) {
+            setImages((prev) =>
+              prev.map((img) =>
+                img.path === path ? { ...img, in_use: true } : img,
+              ),
+            );
+            setFavImages((prev) =>
+              prev.map((img) =>
+                img.path === path ? { ...img, in_use: true } : img,
+              ),
+            );
+          }
         }}
         initialStartingImageUri={jobDialogImageUri}
       />


### PR DESCRIPTION
Restores the optimistic UI update that sets `in_use=true` on images when a job is created from the image repo. This was accidentally stripped during the lightbox dialog extraction refactoring (b104abe).

**Root cause**: When the dialog JSX was extracted into a shared `dialogs` variable in commit b104abe, the `onCreated` and `onClose` callbacks lost their optimistic state update logic. The `pendingImagePathRef` was still being populated in `handleUseAsStartingImage`, but the callbacks no longer consumed it.

**Fix**: Restore the original callback logic — clear `pendingImagePathRef` on close, and on created, map over both `images` and `favImages` state to set `in_use: true` on the matching image path.