### PR TITLE
feat: auto-select title tag dropdowns from image repo tags

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -43,6 +43,7 @@ interface CreateJobDialogProps {
   onCreated: () => void;
   initialStartingImage?: File | null;
   initialStartingImageUri?: string | null;
+  initialImageTags?: string | null;
 }
 
 export default function CreateJobDialog({
@@ -51,6 +52,7 @@ export default function CreateJobDialog({
   onCreated,
   initialStartingImage,
   initialStartingImageUri,
+  initialImageTags,
 }: CreateJobDialogProps) {
   const isMobile = useIsMobile();
   const { defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, negativePrompt: defaultNegativePrompt, fetchSettings } = useSettingsStore();
@@ -139,6 +141,35 @@ export default function CreateJobDialog({
       setName(parts.join("_"));
     }
   }, [selectedTag1, selectedTag2, fps, nameManuallyEdited]);
+
+  const autoSelectApplied = useRef(false);
+
+  // Reset dropdowns when dialog opens with image tags
+  useEffect(() => {
+    if (open && initialImageTags) {
+      setSelectedTag1("");
+      setSelectedTag2("");
+      autoSelectApplied.current = false;
+    }
+  }, [open, initialImageTags]);
+
+  // Auto-select title tag dropdowns from image tags
+  useEffect(() => {
+    if (!open || !initialImageTags) return;
+    if (autoSelectApplied.current) return;
+    if (titleTags1.length === 0 && titleTags2.length === 0) return;
+
+    const tags = initialImageTags.split(",").map((t) => t.trim()).filter(Boolean);
+    const tagSet = new Set(tags);
+
+    const match1 = titleTags1.find((t) => tagSet.has(t.name));
+    const match2 = titleTags2.find((t) => tagSet.has(t.name));
+
+    if (match1) setSelectedTag1(match1.name);
+    if (match2) setSelectedTag2(match2.name);
+
+    autoSelectApplied.current = true;
+  }, [open, initialImageTags, titleTags1, titleTags2]);
 
   // Preset state
   const { presets, fetchPresets } = usePromptPresetStore();

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -76,6 +76,7 @@ export default function ImageRepo() {
   const [deleteConfirm, setDeleteConfirm] = useState<ImageFile | null>(null);
   const [jobDialogOpen, setJobDialogOpen] = useState(false);
   const [jobDialogImageUri, setJobDialogImageUri] = useState<string | null>(null);
+  const [jobDialogImageTags, setJobDialogImageTags] = useState<string | null>(null);
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
   const [folderPage, setFolderPage] = useState(0);
   const [foldersPerPage, setFoldersPerPage] = useState(12);
@@ -266,6 +267,7 @@ export default function ImageRepo() {
   const handleUseAsStartingImage = (image: ImageFile) => {
     pendingImagePathRef.current = image.path;
     setJobDialogImageUri(image.path);
+    setJobDialogImageTags(image.tags ?? null);
     setLightboxImage(null);
     setJobDialogOpen(true);
   };
@@ -729,12 +731,14 @@ export default function ImageRepo() {
         onClose={() => {
           setJobDialogOpen(false);
           setJobDialogImageUri(null);
+          setJobDialogImageTags(null);
           pendingImagePathRef.current = null;
         }}
         onCreated={() => {
           const path = pendingImagePathRef.current;
           setJobDialogOpen(false);
           setJobDialogImageUri(null);
+          setJobDialogImageTags(null);
           pendingImagePathRef.current = null;
           if (path) {
             setImages((prev) =>
@@ -750,6 +754,7 @@ export default function ImageRepo() {
           }
         }}
         initialStartingImageUri={jobDialogImageUri}
+        initialImageTags={jobDialogImageTags}
       />
     </>
   );


### PR DESCRIPTION
When creating a job from an image in the image repo, the image's tags are now used to auto-select matching options in the Title Tag 1 and Title Tag 2 dropdowns.

**How it works**:
- `ImageRepo` now passes `image.tags` as an `initialImageTags` prop to `CreateJobDialog`
- On dialog open, if `initialImageTags` is set, dropdowns are reset, then the auto-select effect matches each tag against the title tag groups
- The first match (by dropdown option order) is selected for each group
- The existing auto-name logic then generates the job name from the selected tags + FPS

**Example**: Image tagged `Kelly,BrownHair,Tall` with Title Tag 1 options `[Kelly, Jenny, Sarah]` and Title Tag 2 options `[BlondeHair, BrownHair]` → auto-selects Tag 1 = `Kelly`, Tag 2 = `BrownHair` → job name = `Kelly_BrownHair_30fps`