### PR TITLE
feat: add tags accordion to CreateJobDialog with image tag inheritance

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -100,6 +100,7 @@ export interface JobCreate {
   starting_image_uri?: string | null;
   starting_image_hash?: string | null;
   first_segment: SegmentCreate;
+  tags?: string | null;
 }
 
 export interface JobResponse {

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -139,6 +139,7 @@ export default function CreateJobDialog({
   const { titleTags1, titleTags2, fetchTags } = useTagStore();
   const [selectedTag1, setSelectedTag1] = useState("");
   const [selectedTag2, setSelectedTag2] = useState("");
+  const [tags, setTags] = useState("");
   const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
 
   // Auto-generate name from tags + fps
@@ -158,6 +159,7 @@ export default function CreateJobDialog({
     if (open && initialImageTags) {
       setSelectedTag1("");
       setSelectedTag2("");
+      setTags(initialImageTags);
       autoSelectApplied.current = false;
       presetAutoSelectApplied.current = false;
     }
@@ -327,6 +329,7 @@ export default function CreateJobDialog({
     setSelectedTag1("");
     setSelectedTag2("");
     setNameManuallyEdited(false);
+    setTags("");
     setError("");
   }, [defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow]);
 
@@ -368,6 +371,7 @@ export default function CreateJobDialog({
         cfg_low: cfgLow ? parseFloat(cfgLow) : null,
         starting_image_uri: !startingImage && startingImageUri ? startingImageUri : null,
         starting_image_hash: reuseHash,
+        tags: tags || null,
         first_segment: {
           prompt: prompt.trim(),
           duration_seconds: duration,
@@ -900,6 +904,24 @@ export default function CreateJobDialog({
                 </Box>
               </Card>
             ))}
+          </AccordionDetails>
+        </Accordion>
+
+        {/* ── Tags (accordion, collapsed by default) ── */}
+        <Accordion defaultExpanded={false} sx={accordionSx}>
+          <AccordionSummary expandIcon={<ExpandMore />}>
+            <Typography variant="subtitle2">Tags</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <TextField
+              label="Tags"
+              fullWidth
+              size="small"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+              placeholder="comma,separated,tags"
+              helperText="Comma-separated tags"
+            />
           </AccordionDetails>
         </Accordion>
 


### PR DESCRIPTION
Adds a collapsible Tags accordion (collapsed by default) to the CreateJobDialog, pre-filled with image tags when creating a job from the image repo.

- New `tags` field on `JobCreate` interface
- Tags state pre-filled from `initialImageTags` prop
- Tags accordion placed just above Faceswap section
- Tags included in job creation payload