### PR TITLE
Auto-select output size preset from start-image dimensions

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -32,6 +32,7 @@ import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
   SIZE_PRESETS,
+  nearestSizePreset,
   DEFAULT_FPS,
   DEFAULT_DURATION,
   DEFAULT_SPEED,
@@ -85,8 +86,9 @@ export default function CreateJobDialog({
     };
   }, []);
 
-  // Set the starting-image preview. Output dimensions come from the chosen size
-  // preset (not the image), so we no longer derive width/height from the source.
+  // Set the starting-image preview and auto-default the output size to the preset
+  // closest to the image's aspect (Wan-legal dimensions). Manual preset override
+  // afterward still wins.
   const loadImageFromUrl = useCallback((url: string) => {
     // Revoke previous blob URL to prevent memory leaks
     if (prevPreviewUrlRef.current?.startsWith("blob:")) {
@@ -94,6 +96,15 @@ export default function CreateJobDialog({
     }
     prevPreviewUrlRef.current = url;
     setImagePreview(url);
+
+    const img = new window.Image();
+    img.onload = () => {
+      if (!mountedRef.current) return;
+      const preset = nearestSizePreset(img.naturalWidth, img.naturalHeight);
+      setWidth(preset.width);
+      setHeight(preset.height);
+    };
+    img.src = url;
   }, []);
 
   const [fps, setFps] = useState(DEFAULT_FPS);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,17 @@ export const SIZE_PRESETS: { portrait: SizePreset[]; landscape: SizePreset[] } =
   ],
 };
 
+// Pick the preset whose aspect is closest to the given image dimensions, matching
+// orientation first (square → portrait). Used to auto-default output size from the
+// start image so the frame is neither stretched nor cropped.
+export function nearestSizePreset(width: number, height: number): SizePreset {
+  const targetAspect = width / height;
+  const pool = height >= width ? SIZE_PRESETS.portrait : SIZE_PRESETS.landscape;
+  return pool.reduce((best, p) =>
+    Math.abs(p.width / p.height - targetAspect) < Math.abs(best.width / best.height - targetAspect) ? p : best
+  );
+}
+
 // Job defaults — SDXL-match portrait so SDXL 832×1216 starts flow through untouched.
 export const DEFAULT_WIDTH = 832;
 export const DEFAULT_HEIGHT = 1216;


### PR DESCRIPTION
On image load in the new-job modal, detects the start image's natural dimensions and pre-selects the closest size preset (orientation first, then nearest aspect) instead of the static 832x1216 default.

- New `nearestSizePreset(w,h)` in `constants.ts`
- `CreateJobDialog.loadImageFromUrl` sets width/height from it on `img.onload`
- Dimensions stay Wan-legal (presets only); manual override still wins
- Job-level only (segments inherit job size); no API/daemon changes
- tsc clean