### PR TITLE
feat: Mode dropdown in New Job modal, remove raw sampler knobs

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -93,10 +93,7 @@ export interface JobCreate {
   height: number;
   fps: number;
   seed?: number | null;
-  lightx2v_strength_high?: number | null;
-  lightx2v_strength_low?: number | null;
-  cfg_high?: number | null;
-  cfg_low?: number | null;
+  mode?: string;
   starting_image_uri?: string | null;
   starting_image_hash?: string | null;
   first_segment: SegmentCreate;
@@ -111,10 +108,7 @@ export interface JobResponse {
   fps: number;
   seed: number;
   starting_image: string | null;
-  lightx2v_strength_high: number | null;
-  lightx2v_strength_low: number | null;
-  cfg_high: number | null;
-  cfg_low: number | null;
+  mode: string;
   priority: number;
   status: JobStatus;
   segment_count: number;
@@ -395,10 +389,6 @@ export interface FramePreviewResponse {
 }
 
 export interface AppSettingsResponse {
-  cfg_high: number;
-  cfg_low: number;
-  lightx2v_strength_high: number;
-  lightx2v_strength_low: number;
   negative_prompt: string;
 }
 
@@ -417,10 +407,6 @@ export interface FavoriteListResponse {
 }
 
 export interface AppSettingsUpdate {
-  cfg_high?: number;
-  cfg_low?: number;
-  lightx2v_strength_high?: number;
-  lightx2v_strength_low?: number;
   negative_prompt?: string;
 }
 

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -66,7 +66,7 @@ export default function CreateJobDialog({
   initialImageTags,
 }: CreateJobDialogProps) {
   const isMobile = useIsMobile();
-  const { defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, negativePrompt: defaultNegativePrompt, fetchSettings } = useSettingsStore();
+  const { negativePrompt: defaultNegativePrompt, fetchSettings } = useSettingsStore();
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
   const [negativePrompt, setNegativePrompt] = useState("");
@@ -111,10 +111,7 @@ export default function CreateJobDialog({
   const [duration, setDuration] = useState(DEFAULT_DURATION);
   const [speed, setSpeed] = useState(DEFAULT_SPEED);
   const [seed, setSeed] = useState("");
-  const [lightx2vHigh, setLightx2vHigh] = useState(defaultLightx2vHigh);
-  const [lightx2vLow, setLightx2vLow] = useState(defaultLightx2vLow);
-  const [cfgHigh, setCfgHigh] = useState(defaultCfgHigh);
-  const [cfgLow, setCfgLow] = useState(defaultCfgLow);
+  const [mode, setMode] = useState("identity");  // GenerationMode — locked for all segments
   const [startingImage, setStartingImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [startingImageUri, setStartingImageUri] = useState<string | null>(null);
@@ -301,10 +298,7 @@ export default function CreateJobDialog({
     setDuration(DEFAULT_DURATION);
     setSpeed(DEFAULT_SPEED);
     setSeed("");
-    setLightx2vHigh(defaultLightx2vHigh);
-    setLightx2vLow(defaultLightx2vLow);
-    setCfgHigh(defaultCfgHigh);
-    setCfgLow(defaultCfgLow);
+    setMode("identity");
     setStartingImage(null);
     if (prevPreviewUrlRef.current?.startsWith("blob:")) {
       URL.revokeObjectURL(prevPreviewUrlRef.current);
@@ -319,7 +313,7 @@ export default function CreateJobDialog({
     setNameManuallyEdited(false);
     setTags("");
     setError("");
-  }, [defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow]);
+  }, []);
 
   const handleSubmit = async () => {
     if (!name.trim() || !prompt.trim()) {
@@ -353,10 +347,7 @@ export default function CreateJobDialog({
         height,
         fps,
         seed: seed ? parseInt(seed) : null,
-        lightx2v_strength_high: lightx2vHigh ? parseFloat(lightx2vHigh) : null,
-        lightx2v_strength_low: lightx2vLow ? parseFloat(lightx2vLow) : null,
-        cfg_high: cfgHigh ? parseFloat(cfgHigh) : null,
-        cfg_low: cfgLow ? parseFloat(cfgLow) : null,
+        mode,
         starting_image_uri: !startingImage && startingImageUri ? startingImageUri : null,
         starting_image_hash: reuseHash,
         tags: tags || null,
@@ -585,7 +576,7 @@ export default function CreateJobDialog({
             <Typography variant="subtitle2">
               Video Settings
               <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
-                {width}x{height} / {fps}fps / {duration}s / {speed}x / CFG {cfgHigh}/{cfgLow}
+                {width}x{height} / {fps}fps / {duration}s / {speed}x / {mode}
               </Typography>
             </Typography>
           </AccordionSummary>
@@ -684,47 +675,18 @@ export default function CreateJobDialog({
             </Box>
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>
               <TextField
-                label="LightX2V High"
-                type="number"
+                select
+                label="Mode"
                 size="small"
-                value={lightx2vHigh}
-                onChange={(e) => setLightx2vHigh(e.target.value)}
+                value={mode}
+                onChange={(e) => setMode(e.target.value)}
                 sx={{ flex: 1, minWidth: 100 }}
-                slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
-                helperText="1.0–5.6"
-              />
-              <TextField
-                label="LightX2V Low"
-                type="number"
-                size="small"
-                value={lightx2vLow}
-                onChange={(e) => setLightx2vLow(e.target.value)}
-                sx={{ flex: 1, minWidth: 100 }}
-                slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
-                helperText="1.0–2.0"
-              />
-            </Box>
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>
-              <TextField
-                label="CFG High"
-                type="number"
-                size="small"
-                value={cfgHigh}
-                onChange={(e) => setCfgHigh(e.target.value)}
-                sx={{ flex: 1, minWidth: 100 }}
-                slotProps={{ htmlInput: { step: 0.5, min: 0 } }}
-                helperText="High noise"
-              />
-              <TextField
-                label="CFG Low"
-                type="number"
-                size="small"
-                value={cfgLow}
-                onChange={(e) => setCfgLow(e.target.value)}
-                sx={{ flex: 1, minWidth: 100 }}
-                slotProps={{ htmlInput: { step: 0.5, min: 0 } }}
-                helperText="Low noise"
-              />
+                helperText="Generation profile — set once, locked for all segments"
+              >
+                <MenuItem value="identity">Wan22 Base (Character Identity) · ~16m</MenuItem>
+                <MenuItem value="expression">Wan22 Base (Identity + Expression) · ~21m</MenuItem>
+                <MenuItem value="dasiwa">DaSiWa (Fast) · ~13m</MenuItem>
+              </TextField>
             </Box>
           </AccordionDetails>
         </Accordion>

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -600,22 +600,7 @@ export default function JobDetail() {
               <MetaItem label="Dimensions" value={`${job.width}x${job.height}`} />
               <MetaItem label="FPS" value={`${job.fps}`} />
               <MetaItem label="Seed" value={`${job.seed}`} />
-              <MetaItem
-                label="LightX2V High"
-                value={`${job.lightx2v_strength_high ?? 2.0}`}
-              />
-              <MetaItem
-                label="LightX2V Low"
-                value={`${job.lightx2v_strength_low ?? 1.0}`}
-              />
-              <MetaItem
-                label="CFG High"
-                value={`${job.cfg_high ?? 1}`}
-              />
-              <MetaItem
-                label="CFG Low"
-                value={`${job.cfg_low ?? 1}`}
-              />
+              <MetaItem label="Mode" value={job.mode ?? "identity"} />
               <MetaItem
                 label="Segments"
                 value={`${job.completed_segment_count}`}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -23,18 +23,10 @@ export default function SettingsPage() {
   const [input1, setInput1] = useState("");
   const [input2, setInput2] = useState("");
   const {
-    defaultLightx2vHigh,
-    defaultLightx2vLow,
-    defaultCfgHigh,
-    defaultCfgLow,
     negativePrompt,
     loaded,
     fetchSettings,
     saveSettings,
-    setDefaultLightx2vHigh,
-    setDefaultLightx2vLow,
-    setDefaultCfgHigh,
-    setDefaultCfgLow,
     setNegativePrompt,
   } = useSettingsStore();
   const [saving, setSaving] = useState(false);
@@ -61,13 +53,7 @@ export default function SettingsPage() {
     setSaved(false);
     setSaveError(null);
     try {
-      await saveSettings({
-        lightx2v_strength_high: parseFloat(defaultLightx2vHigh) || 2.0,
-        lightx2v_strength_low: parseFloat(defaultLightx2vLow) || 1.0,
-        cfg_high: parseFloat(defaultCfgHigh) || 1,
-        cfg_low: parseFloat(defaultCfgLow) || 1,
-        negative_prompt: negativePrompt,
-      });
+      await saveSettings({ negative_prompt: negativePrompt });
       setSaved(true);
     } catch (err) {
       console.error("Failed to save app settings:", err);
@@ -195,50 +181,6 @@ export default function SettingsPage() {
             </Box>
           ) : (
             <>
-              <Box sx={{ display: "flex", gap: 2, maxWidth: 500, flexWrap: "wrap" }}>
-                <TextField
-                  label="LightX2V High"
-                  type="number"
-                  size="small"
-                  value={defaultLightx2vHigh}
-                  onChange={(e) => setDefaultLightx2vHigh(e.target.value)}
-                  slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
-                  helperText="Range: 1.0–5.6"
-                  sx={{ flex: 1, minWidth: 110 }}
-                />
-                <TextField
-                  label="LightX2V Low"
-                  type="number"
-                  size="small"
-                  value={defaultLightx2vLow}
-                  onChange={(e) => setDefaultLightx2vLow(e.target.value)}
-                  slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
-                  helperText="Range: 1.0–2.0"
-                  sx={{ flex: 1, minWidth: 110 }}
-                />
-              </Box>
-              <Box sx={{ display: "flex", gap: 2, maxWidth: 500, mt: 2, flexWrap: "wrap" }}>
-                <TextField
-                  label="CFG High"
-                  type="number"
-                  size="small"
-                  value={defaultCfgHigh}
-                  onChange={(e) => setDefaultCfgHigh(e.target.value)}
-                  slotProps={{ htmlInput: { step: 0.5, min: 0 } }}
-                  helperText="High noise sampler"
-                  sx={{ flex: 1, minWidth: 110 }}
-                />
-                <TextField
-                  label="CFG Low"
-                  type="number"
-                  size="small"
-                  value={defaultCfgLow}
-                  onChange={(e) => setDefaultCfgLow(e.target.value)}
-                  slotProps={{ htmlInput: { step: 0.5, min: 0 } }}
-                  helperText="Low noise sampler"
-                  sx={{ flex: 1, minWidth: 110 }}
-                />
-              </Box>
               <TextField
                 label="Negative Prompt"
                 size="small"

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -3,39 +3,20 @@ import { getAppSettings, updateAppSettings } from "../api/client";
 import type { AppSettingsUpdate } from "../api/types";
 
 interface SettingsState {
-  defaultLightx2vHigh: string;
-  defaultLightx2vLow: string;
-  defaultCfgHigh: string;
-  defaultCfgLow: string;
   negativePrompt: string;
   loaded: boolean;
   fetchSettings: () => Promise<void>;
   saveSettings: (updates: AppSettingsUpdate) => Promise<void>;
-  setDefaultLightx2vHigh: (value: string) => void;
-  setDefaultLightx2vLow: (value: string) => void;
-  setDefaultCfgHigh: (value: string) => void;
-  setDefaultCfgLow: (value: string) => void;
   setNegativePrompt: (value: string) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()((set) => ({
-  defaultLightx2vHigh: "2.0",
-  defaultLightx2vLow: "1.0",
-  defaultCfgHigh: "1",
-  defaultCfgLow: "1",
   negativePrompt: "",
   loaded: false,
   fetchSettings: async () => {
     try {
       const s = await getAppSettings();
-      set({
-        defaultLightx2vHigh: String(s.lightx2v_strength_high),
-        defaultLightx2vLow: String(s.lightx2v_strength_low),
-        defaultCfgHigh: String(s.cfg_high),
-        defaultCfgLow: String(s.cfg_low),
-        negativePrompt: s.negative_prompt,
-        loaded: true,
-      });
+      set({ negativePrompt: s.negative_prompt, loaded: true });
     } catch {
       // Use defaults if API is unreachable
       set({ loaded: true });
@@ -43,17 +24,7 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
   },
   saveSettings: async (updates) => {
     const s = await updateAppSettings(updates);
-    set({
-      defaultLightx2vHigh: String(s.lightx2v_strength_high),
-      defaultLightx2vLow: String(s.lightx2v_strength_low),
-      defaultCfgHigh: String(s.cfg_high),
-      defaultCfgLow: String(s.cfg_low),
-      negativePrompt: s.negative_prompt,
-    });
+    set({ negativePrompt: s.negative_prompt });
   },
-  setDefaultLightx2vHigh: (value) => set({ defaultLightx2vHigh: value }),
-  setDefaultLightx2vLow: (value) => set({ defaultLightx2vLow: value }),
-  setDefaultCfgHigh: (value) => set({ defaultCfgHigh: value }),
-  setDefaultCfgLow: (value) => set({ defaultCfgLow: value }),
   setNegativePrompt: (value) => set({ negativePrompt: value }),
 }));


### PR DESCRIPTION
Replaces the **LightX2V High/Low + CFG High/Low** fields (in the New Job modal **and** Settings) with a single **Mode** dropdown:

- Wan22 Base (Character Identity) · ~16m
- Wan22 Base (Identity + Expression) · ~21m
- DaSiWa (Fast) · ~13m

### Changes
- `CreateJobDialog`: Mode `<Select>` → sends `job.mode`; all four knob fields + their state/reset/submit wiring removed
- `SettingsPage`: Job Defaults card now holds only Negative Prompt
- `settingsStore` + `types.ts`: drop lightx2v/cfg; `JobCreate`/`JobResponse`/`AppSettings` carry `mode`
- `JobDetail`: shows **Mode** instead of the four sampler readouts

`npx tsc --noEmit` clean. Pairs with wanly-api #92 + the wanly-gpu-daemon PR.