### PR TITLE
feat: smallest default output size + full mode name on Job Detail

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,9 +32,19 @@ export function nearestSizePreset(width: number, height: number): SizePreset {
   );
 }
 
-// Job defaults — SDXL-match portrait so SDXL 832×1216 starts flow through untouched.
-export const DEFAULT_WIDTH = 832;
-export const DEFAULT_HEIGHT = 1216;
+// Job defaults — smallest portrait (Light 768×1024). Reduced res is the norm now
+// (full-res 1216×832 is the only failure mode). Landscape's smallest is Classic 1024×768.
+export const DEFAULT_WIDTH = 768;
+export const DEFAULT_HEIGHT = 1024;
+
+// Generation mode → full display label (used in the New Job dropdown + Job Detail).
+export const MODE_LABELS: Record<string, string> = {
+  identity: "Wan22 Base (Character Identity)",
+  expression: "Wan22 Base (Identity + Expression)",
+  dasiwa: "DaSiWa (Fast)",
+};
+export const modeLabel = (mode: string | null | undefined): string =>
+  MODE_LABELS[mode ?? "identity"] ?? (mode ?? "identity");
 export const DEFAULT_FPS = 60;
 export const DEFAULT_DURATION = 5.0;
 export const DEFAULT_SPEED = 1.0;

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -96,6 +96,7 @@ import {
   DEFAULT_FACESWAP_FACES_ORDER,
   MAX_LORAS,
   POLL_INTERVAL_FAST,
+  modeLabel,
 } from "../constants";
 
 function formatDate(iso: string | null) {
@@ -600,7 +601,7 @@ export default function JobDetail() {
               <MetaItem label="Dimensions" value={`${job.width}x${job.height}`} />
               <MetaItem label="FPS" value={`${job.fps}`} />
               <MetaItem label="Seed" value={`${job.seed}`} />
-              <MetaItem label="Mode" value={job.mode ?? "identity"} />
+              <MetaItem label="Mode" value={modeLabel(job.mode)} />
               <MetaItem
                 label="Segments"
                 value={`${job.completed_segment_count}`}


### PR DESCRIPTION
Two small console tweaks (David's #1 + #2):

1. **Default Output Size → smallest** (portrait Light **768×1024**; landscape's smallest is Classic 1024×768). Reduced res is the norm now — full-res 1216×832 is the only failure mode. (`constants.ts` DEFAULT_WIDTH/HEIGHT.)
2. **Job Detail shows the full mode name** — new `modeLabel()` helper maps `identity`→"Wan22 Base (Character Identity)", `expression`→"Wan22 Base (Identity + Expression)", `dasiwa`→"DaSiWa (Fast)" (was showing the raw `identity` key).

tsc clean.