### PR TITLE
feat: bulk-delete in Untagged/Favorites views + preserve folder pagination on Back

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,9 +32,19 @@ export function nearestSizePreset(width: number, height: number): SizePreset {
   );
 }
 
-// Job defaults — SDXL-match portrait so SDXL 832×1216 starts flow through untouched.
-export const DEFAULT_WIDTH = 832;
-export const DEFAULT_HEIGHT = 1216;
+// Job defaults — smallest portrait (Light 768×1024). Reduced res is the norm now
+// (full-res 1216×832 is the only failure mode). Landscape's smallest is Classic 1024×768.
+export const DEFAULT_WIDTH = 768;
+export const DEFAULT_HEIGHT = 1024;
+
+// Generation mode → full display label (used in the New Job dropdown + Job Detail).
+export const MODE_LABELS: Record<string, string> = {
+  identity: "Wan22 Base (Character Identity)",
+  expression: "Wan22 Base (Identity + Expression)",
+  dasiwa: "DaSiWa (Fast)",
+};
+export const modeLabel = (mode: string | null | undefined): string =>
+  MODE_LABELS[mode ?? "identity"] ?? (mode ?? "identity");
 export const DEFAULT_FPS = 60;
 export const DEFAULT_DURATION = 5.0;
 export const DEFAULT_SPEED = 1.0;

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -237,7 +237,9 @@ export default function ImageRepo() {
     try {
       const data = await getImageFolders();
       setFolders(data);
-      setFolderPage(0);
+      // NOTE: do NOT reset folderPage here — this fetch also runs when returning to the
+      // folder list (currentFolder→null), and resetting sent Back to page 1 every time.
+      // folderPage defaults to 0 on mount, so pagination is preserved across Back.
     } catch {
       // ignore
     } finally {
@@ -398,11 +400,16 @@ export default function ImageRepo() {
     if (bulkDeleteKeys.length === 0) return;
     setBulkDeleting(true);
     try {
+      // Work against whichever list is showing (in-folder, favorites, or untagged).
+      const activeImages = favoritesView ? favImages : untaggedView ? untaggedImages : images;
       for (const key of bulkDeleteKeys) {
-        const img = images.find((i) => i.key === key);
+        const img = activeImages.find((i) => i.key === key);
         if (img) await deleteImage(img.path);
       }
-      setImages((prev) => prev.filter((img) => !bulkDeleteKeys.includes(img.key)));
+      const removeDeleted = (prev: ImageFile[]) => prev.filter((img) => !bulkDeleteKeys.includes(img.key));
+      setImages(removeDeleted);
+      setFavImages(removeDeleted);
+      setUntaggedImages(removeDeleted);
       if (lightboxImage && bulkDeleteKeys.includes(lightboxImage.key)) {
         setLightboxImage(null);
       }
@@ -999,6 +1006,32 @@ export default function ImageRepo() {
           >
             {isMobile ? "Untag" : "Untagged"}
           </Button>
+          {(favoritesView || untaggedView) && (
+            <>
+              <Button
+                variant={selectMode ? "contained" : "outlined"}
+                color="inherit"
+                size={isMobile ? "small" : "medium"}
+                onClick={() => {
+                  setSelectMode((p) => !p);
+                  setSelectedKeys(new Set());
+                }}
+              >
+                {selectMode ? "Cancel" : "Select"}
+              </Button>
+              {selectMode && selectedKeys.size > 0 && (
+                <Button
+                  variant="contained"
+                  color="error"
+                  startIcon={isMobile ? undefined : <Delete />}
+                  size={isMobile ? "small" : "medium"}
+                  onClick={() => handleOpenBulkDelete(Array.from(selectedKeys))}
+                >
+                  {isMobile ? `Del (${selectedKeys.size})` : `Delete ${selectedKeys.size}`}
+                </Button>
+              )}
+            </>
+          )}
           {(favoritesView && favImages.length > 0) || (debouncedSearch && searchResults.length > 0) ? (
             <Button
               variant="outlined"
@@ -1201,8 +1234,12 @@ export default function ImageRepo() {
               <Grid container spacing={2}>
                 {untaggedImages.map((image) => (
                   <Grid key={image.key} size={{ xs: 6, sm: 4, md: 3, lg: 2 }}>
-                    <Card>
-                      <CardActionArea onClick={() => handleOpenLightbox(image)}>
+                    <Card sx={{ position: "relative" }}>
+                      <CardActionArea
+                        onClick={() =>
+                          selectMode ? toggleSelect(image.key) : handleOpenLightbox(image)
+                        }
+                      >
                         <CardMedia
                           component="img"
                           image={getFileUrl(image.path)}
@@ -1215,6 +1252,20 @@ export default function ImageRepo() {
                           </Typography>
                         </Box>
                       </CardActionArea>
+                      {selectMode && (
+                        <Checkbox
+                          checked={selectedKeys.has(image.key)}
+                          onChange={() => toggleSelect(image.key)}
+                          sx={{
+                            position: "absolute",
+                            top: 0,
+                            left: 0,
+                            bgcolor: "rgba(255,255,255,0.8)",
+                            borderRadius: "0 0 4px 0",
+                            p: 0.5,
+                          }}
+                        />
+                      )}
                     </Card>
                   </Grid>
                 ))}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -96,6 +96,7 @@ import {
   DEFAULT_FACESWAP_FACES_ORDER,
   MAX_LORAS,
   POLL_INTERVAL_FAST,
+  modeLabel,
 } from "../constants";
 
 function formatDate(iso: string | null) {
@@ -600,7 +601,7 @@ export default function JobDetail() {
               <MetaItem label="Dimensions" value={`${job.width}x${job.height}`} />
               <MetaItem label="FPS" value={`${job.fps}`} />
               <MetaItem label="Seed" value={`${job.seed}`} />
-              <MetaItem label="Mode" value={job.mode ?? "identity"} />
+              <MetaItem label="Mode" value={modeLabel(job.mode)} />
               <MetaItem
                 label="Segments"
                 value={`${job.completed_segment_count}`}


### PR DESCRIPTION
David's #3 + #4.

**#3 — bulk delete while filtering Untagged:** the Untagged (and Favorites) grids were view-only. Added a **Select** toggle + per-tile checkboxes + a **Delete N** button to the folder-list toolbar (shown when in those views), and made `handleBulkDeleteConfirm` operate on the **active** list (finds in favImages/untaggedImages/images, removes from all three so the view updates). Existing in-folder multi-delete + the Untagged view are unchanged.

**#4 — Back preserved pagination:** `fetchFolders` reset `folderPage` to 0, and the effect re-runs it whenever you return to the folder list (currentFolder→null) — so Back always jumped to page 1. Removed the reset; `folderPage` defaults to 0 on mount and now **persists across Back**. (Scan note: this was the main culprit; per-page scroll-position restore is a possible future nicety.)

tsc clean.