### PR TITLE
feat: add 'Wan22 Remix (Enhanced Motions)' to mode dropdown

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -686,6 +686,7 @@ export default function CreateJobDialog({
                 <MenuItem value="identity">Wan22 Base (Character Identity) · ~16m</MenuItem>
                 <MenuItem value="expression">Wan22 Base (Identity + Expression) · ~21m</MenuItem>
                 <MenuItem value="dasiwa">DaSiWa (Fast) · ~13m</MenuItem>
+                <MenuItem value="remix">Wan22 Remix (Enhanced Motions) · ~13m</MenuItem>
               </TextField>
             </Box>
           </AccordionDetails>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,7 @@ export const MODE_LABELS: Record<string, string> = {
   identity: "Wan22 Base (Character Identity)",
   expression: "Wan22 Base (Identity + Expression)",
   dasiwa: "DaSiWa (Fast)",
+  remix: "Wan22 Remix (Enhanced Motions)",
 };
 export const modeLabel = (mode: string | null | undefined): string =>
   MODE_LABELS[mode ?? "identity"] ?? (mode ?? "identity");


### PR DESCRIPTION
Adds the `remix` option to the New Job mode dropdown + `MODE_LABELS` (so Job Detail shows the full name). Pairs with daemon PR #51 (the preset, V2.1 models). tsc clean.