### PR TITLE
fix: start-from-image auto-size picks smallest preset (not largest by aspect)

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -32,7 +32,7 @@ import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
   SIZE_PRESETS,
-  nearestSizePreset,
+  smallestSizePreset,
   DEFAULT_FPS,
   DEFAULT_DURATION,
   DEFAULT_SPEED,
@@ -100,7 +100,7 @@ export default function CreateJobDialog({
     const img = new window.Image();
     img.onload = () => {
       if (!mountedRef.current) return;
-      const preset = nearestSizePreset(img.naturalWidth, img.naturalHeight);
+      const preset = smallestSizePreset(img.naturalWidth, img.naturalHeight);
       setWidth(preset.width);
       setHeight(preset.height);
     };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,14 +21,14 @@ export const SIZE_PRESETS: { portrait: SizePreset[]; landscape: SizePreset[] } =
   ],
 };
 
-// Pick the preset whose aspect is closest to the given image dimensions, matching
-// orientation first (square → portrait). Used to auto-default output size from the
-// start image so the frame is neither stretched nor cropped.
-export function nearestSizePreset(width: number, height: number): SizePreset {
-  const targetAspect = width / height;
+// Pick the SMALLEST preset in the image's orientation (portrait if tall/square, else
+// landscape). Used to auto-default output size from a start image — reduced res is the
+// norm now (full-res 1216×832 is the failure mode), so a landscape image → Classic
+// 1024×768, a portrait image → Light 768×1024.
+export function smallestSizePreset(width: number, height: number): SizePreset {
   const pool = height >= width ? SIZE_PRESETS.portrait : SIZE_PRESETS.landscape;
-  return pool.reduce((best, p) =>
-    Math.abs(p.width / p.height - targetAspect) < Math.abs(best.width / best.height - targetAspect) ? p : best
+  return pool.reduce((smallest, p) =>
+    p.width * p.height < smallest.width * smallest.height ? p : smallest
   );
 }
 


### PR DESCRIPTION
Follow-up to the default-size change (#195). Starting a new job **from a library image** still used `nearestSizePreset` (aspect-match), which lands on the *largest* preset for that aspect — a 3:2 landscape image → Wide **1216×832** (the failure-mode res). Replaced with `smallestSizePreset`: a landscape image → **Classic 1024×768**, a portrait image → **Light 768×1024**. tsc clean.