### PR TITLE
feat: sub-1x speeds + settings-honored defaults + sampler presets

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -405,6 +405,9 @@ export interface AppSettingsResponse {
   cfg_low: number;
   lightx2v_strength_high: number;
   lightx2v_strength_low: number;
+  steps_total: number;
+  high_noise_steps: number;
+  flow_shift: number;
   negative_prompt: string;
 }
 
@@ -427,6 +430,9 @@ export interface AppSettingsUpdate {
   cfg_low?: number;
   lightx2v_strength_high?: number;
   lightx2v_strength_low?: number;
+  steps_total?: number;
+  high_noise_steps?: number;
+  flow_shift?: number;
   negative_prompt?: string;
 }
 

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -63,7 +63,7 @@ export default function CreateJobDialog({
   initialImageTags,
 }: CreateJobDialogProps) {
   const isMobile = useIsMobile();
-  const { defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, negativePrompt: defaultNegativePrompt, fetchSettings } = useSettingsStore();
+  const { defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, defaultStepsTotal, defaultHighNoiseSteps, defaultFlowShift, negativePrompt: defaultNegativePrompt, fetchSettings } = useSettingsStore();
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
   const [negativePrompt, setNegativePrompt] = useState("");
@@ -127,9 +127,10 @@ export default function CreateJobDialog({
   const [lightx2vLow, setLightx2vLow] = useState(defaultLightx2vLow);
   const [cfgHigh, setCfgHigh] = useState(defaultCfgHigh);
   const [cfgLow, setCfgLow] = useState(defaultCfgLow);
-  const [stepsTotal, setStepsTotal] = useState("4");
-  const [highNoiseSteps, setHighNoiseSteps] = useState("2");
-  const [flowShift, setFlowShift] = useState("5");
+  const [stepsTotal, setStepsTotal] = useState(defaultStepsTotal);
+  const [highNoiseSteps, setHighNoiseSteps] = useState(defaultHighNoiseSteps);
+  const [flowShift, setFlowShift] = useState(defaultFlowShift);
+  const [preset, setPreset] = useState("");
   const [startingImage, setStartingImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [startingImageUri, setStartingImageUri] = useState<string | null>(null);
@@ -320,6 +321,9 @@ export default function CreateJobDialog({
     setLightx2vLow(defaultLightx2vLow);
     setCfgHigh(defaultCfgHigh);
     setCfgLow(defaultCfgLow);
+    setStepsTotal(defaultStepsTotal);
+    setHighNoiseSteps(defaultHighNoiseSteps);
+    setFlowShift(defaultFlowShift);
     setStartingImage(null);
     if (prevPreviewUrlRef.current?.startsWith("blob:")) {
       URL.revokeObjectURL(prevPreviewUrlRef.current);
@@ -334,7 +338,39 @@ export default function CreateJobDialog({
     setNameManuallyEdited(false);
     setTags("");
     setError("");
-  }, [defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow]);
+  }, [defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, defaultStepsTotal, defaultHighNoiseSteps, defaultFlowShift]);
+
+  // Re-sync sampler fields from saved settings each time the dialog opens.
+  // Fixes the stale useState init (defaults load async after first mount).
+  useEffect(() => {
+    if (open) {
+      setLightx2vHigh(defaultLightx2vHigh);
+      setLightx2vLow(defaultLightx2vLow);
+      setCfgHigh(defaultCfgHigh);
+      setCfgLow(defaultCfgLow);
+      setStepsTotal(defaultStepsTotal);
+      setHighNoiseSteps(defaultHighNoiseSteps);
+      setFlowShift(defaultFlowShift);
+    }
+  }, [open, defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, defaultStepsTotal, defaultHighNoiseSteps, defaultFlowShift]);
+
+  const SAMPLER_PRESETS: Record<string, Record<string, string>> = {
+    Lightning: { lightx2vHigh: "1", lightx2vLow: "1", cfgHigh: "1", cfgLow: "1", stepsTotal: "4", highNoiseSteps: "2", flowShift: "5" },
+    "Prompt-Aware": { lightx2vHigh: "0", lightx2vLow: "1", cfgHigh: "2.75", cfgLow: "1", stepsTotal: "12", highNoiseSteps: "8", flowShift: "5" },
+    "High Motion": { lightx2vHigh: "0", lightx2vLow: "1", cfgHigh: "3.5", cfgLow: "1", stepsTotal: "12", highNoiseSteps: "8", flowShift: "5" },
+  };
+  const applyPreset = (name: string) => {
+    setPreset(name);
+    const p = SAMPLER_PRESETS[name];
+    if (!p) return;
+    setLightx2vHigh(p.lightx2vHigh);
+    setLightx2vLow(p.lightx2vLow);
+    setCfgHigh(p.cfgHigh);
+    setCfgLow(p.cfgLow);
+    setStepsTotal(p.stepsTotal);
+    setHighNoiseSteps(p.highNoiseSteps);
+    setFlowShift(p.flowShift);
+  };
 
   const handleSubmit = async () => {
     if (!name.trim() || !prompt.trim()) {
@@ -683,6 +719,8 @@ export default function CreateJobDialog({
                 onChange={(e) => setSpeed(parseFloat(e.target.value))}
                 sx={{ flex: 1, minWidth: 80 }}
               >
+                <MenuItem value={0.5}>0.5x</MenuItem>
+                <MenuItem value={0.75}>0.75x</MenuItem>
                 <MenuItem value={1.0}>1.0x</MenuItem>
                 <MenuItem value={1.25}>1.25x</MenuItem>
                 <MenuItem value={1.5}>1.5x</MenuItem>
@@ -696,6 +734,22 @@ export default function CreateJobDialog({
                 onChange={(e) => setSeed(e.target.value)}
                 sx={{ flex: 1, minWidth: 80 }}
               />
+            </Box>
+            <Box sx={{ mt: 1.5 }}>
+              <TextField
+                select
+                label="Preset"
+                size="small"
+                value={preset}
+                onChange={(e) => applyPreset(e.target.value)}
+                sx={{ minWidth: 240 }}
+                helperText="Load a known-good sampler bundle"
+              >
+                <MenuItem value="">Custom</MenuItem>
+                <MenuItem value="Lightning">Lightning — fast, cfg 1</MenuItem>
+                <MenuItem value="Prompt-Aware">Prompt-Aware — cfg 2.75, motion</MenuItem>
+                <MenuItem value="High Motion">High Motion — cfg 3.5</MenuItem>
+              </TextField>
             </Box>
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>
               <TextField

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -130,7 +130,7 @@ export default function CreateJobDialog({
   const [stepsTotal, setStepsTotal] = useState(defaultStepsTotal);
   const [highNoiseSteps, setHighNoiseSteps] = useState(defaultHighNoiseSteps);
   const [flowShift, setFlowShift] = useState(defaultFlowShift);
-  const [preset, setPreset] = useState("");
+  const [samplerPreset, setSamplerPreset] = useState("");
   const [startingImage, setStartingImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [startingImageUri, setStartingImageUri] = useState<string | null>(null);
@@ -359,8 +359,8 @@ export default function CreateJobDialog({
     "Prompt-Aware": { lightx2vHigh: "0", lightx2vLow: "1", cfgHigh: "2.75", cfgLow: "1", stepsTotal: "12", highNoiseSteps: "8", flowShift: "5" },
     "High Motion": { lightx2vHigh: "0", lightx2vLow: "1", cfgHigh: "3.5", cfgLow: "1", stepsTotal: "12", highNoiseSteps: "8", flowShift: "5" },
   };
-  const applyPreset = (name: string) => {
-    setPreset(name);
+  const applySamplerPreset = (name: string) => {
+    setSamplerPreset(name);
     const p = SAMPLER_PRESETS[name];
     if (!p) return;
     setLightx2vHigh(p.lightx2vHigh);
@@ -740,8 +740,8 @@ export default function CreateJobDialog({
                 select
                 label="Preset"
                 size="small"
-                value={preset}
-                onChange={(e) => applyPreset(e.target.value)}
+                value={samplerPreset}
+                onChange={(e) => applySamplerPreset(e.target.value)}
                 sx={{ minWidth: 240 }}
                 helperText="Load a known-good sampler bundle"
               >

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -27,6 +27,9 @@ export default function SettingsPage() {
     defaultLightx2vLow,
     defaultCfgHigh,
     defaultCfgLow,
+    defaultStepsTotal,
+    defaultHighNoiseSteps,
+    defaultFlowShift,
     negativePrompt,
     loaded,
     fetchSettings,
@@ -35,6 +38,9 @@ export default function SettingsPage() {
     setDefaultLightx2vLow,
     setDefaultCfgHigh,
     setDefaultCfgLow,
+    setDefaultStepsTotal,
+    setDefaultHighNoiseSteps,
+    setDefaultFlowShift,
     setNegativePrompt,
   } = useSettingsStore();
   const [saving, setSaving] = useState(false);
@@ -66,6 +72,9 @@ export default function SettingsPage() {
         lightx2v_strength_low: parseFloat(defaultLightx2vLow) || 1.0,
         cfg_high: parseFloat(defaultCfgHigh) || 1,
         cfg_low: parseFloat(defaultCfgLow) || 1,
+        steps_total: parseInt(defaultStepsTotal, 10) || 4,
+        high_noise_steps: parseInt(defaultHighNoiseSteps, 10) || 2,
+        flow_shift: parseFloat(defaultFlowShift) || 5,
         negative_prompt: negativePrompt,
       });
       setSaved(true);
@@ -236,6 +245,38 @@ export default function SettingsPage() {
                   onChange={(e) => setDefaultCfgLow(e.target.value)}
                   slotProps={{ htmlInput: { step: 0.5, min: 0 } }}
                   helperText="Low noise sampler"
+                  sx={{ flex: 1, minWidth: 110 }}
+                />
+              </Box>
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 2 }}>
+                <TextField
+                  label="Steps Total"
+                  type="number"
+                  size="small"
+                  value={defaultStepsTotal}
+                  onChange={(e) => setDefaultStepsTotal(e.target.value)}
+                  slotProps={{ htmlInput: { step: 1, min: 1 } }}
+                  helperText="Total sampler steps"
+                  sx={{ flex: 1, minWidth: 110 }}
+                />
+                <TextField
+                  label="High-Noise Steps"
+                  type="number"
+                  size="small"
+                  value={defaultHighNoiseSteps}
+                  onChange={(e) => setDefaultHighNoiseSteps(e.target.value)}
+                  slotProps={{ htmlInput: { step: 1, min: 0 } }}
+                  helperText="High/low split boundary"
+                  sx={{ flex: 1, minWidth: 110 }}
+                />
+                <TextField
+                  label="Flow Shift"
+                  type="number"
+                  size="small"
+                  value={defaultFlowShift}
+                  onChange={(e) => setDefaultFlowShift(e.target.value)}
+                  slotProps={{ htmlInput: { step: 0.5, min: 1 } }}
+                  helperText="Motion schedule shift"
                   sx={{ flex: 1, minWidth: 110 }}
                 />
               </Box>

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -7,6 +7,9 @@ interface SettingsState {
   defaultLightx2vLow: string;
   defaultCfgHigh: string;
   defaultCfgLow: string;
+  defaultStepsTotal: string;
+  defaultHighNoiseSteps: string;
+  defaultFlowShift: string;
   negativePrompt: string;
   loaded: boolean;
   fetchSettings: () => Promise<void>;
@@ -15,6 +18,9 @@ interface SettingsState {
   setDefaultLightx2vLow: (value: string) => void;
   setDefaultCfgHigh: (value: string) => void;
   setDefaultCfgLow: (value: string) => void;
+  setDefaultStepsTotal: (value: string) => void;
+  setDefaultHighNoiseSteps: (value: string) => void;
+  setDefaultFlowShift: (value: string) => void;
   setNegativePrompt: (value: string) => void;
 }
 
@@ -23,6 +29,9 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
   defaultLightx2vLow: "1.0",
   defaultCfgHigh: "1",
   defaultCfgLow: "1",
+  defaultStepsTotal: "4",
+  defaultHighNoiseSteps: "2",
+  defaultFlowShift: "5",
   negativePrompt: "",
   loaded: false,
   fetchSettings: async () => {
@@ -33,6 +42,9 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
         defaultLightx2vLow: String(s.lightx2v_strength_low),
         defaultCfgHigh: String(s.cfg_high),
         defaultCfgLow: String(s.cfg_low),
+        defaultStepsTotal: String(s.steps_total),
+        defaultHighNoiseSteps: String(s.high_noise_steps),
+        defaultFlowShift: String(s.flow_shift),
         negativePrompt: s.negative_prompt,
         loaded: true,
       });
@@ -48,6 +60,9 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
       defaultLightx2vLow: String(s.lightx2v_strength_low),
       defaultCfgHigh: String(s.cfg_high),
       defaultCfgLow: String(s.cfg_low),
+      defaultStepsTotal: String(s.steps_total),
+      defaultHighNoiseSteps: String(s.high_noise_steps),
+      defaultFlowShift: String(s.flow_shift),
       negativePrompt: s.negative_prompt,
     });
   },
@@ -55,5 +70,8 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
   setDefaultLightx2vLow: (value) => set({ defaultLightx2vLow: value }),
   setDefaultCfgHigh: (value) => set({ defaultCfgHigh: value }),
   setDefaultCfgLow: (value) => set({ defaultCfgLow: value }),
+  setDefaultStepsTotal: (value) => set({ defaultStepsTotal: value }),
+  setDefaultHighNoiseSteps: (value) => set({ defaultHighNoiseSteps: value }),
+  setDefaultFlowShift: (value) => set({ defaultFlowShift: value }),
   setNegativePrompt: (value) => set({ negativePrompt: value }),
 }));


### PR DESCRIPTION
(a) 0.5x/0.75x speeds. (b) Steps/High-Noise/Flow-Shift defaults on the Settings page + fixes the LightX2V-default-not-honored bug (sync-on-open effect). (c) Preset dropdown: Lightning / Prompt-Aware / High Motion. Pairs with the api settings PR.