### PR TITLE
fix(ImageRepo): reliably scroll to top on page change

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -141,14 +141,14 @@ export default function ImageRepo() {
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const btnSize = isMobile ? "small" : "medium";
 
-  // Scroll to top when page changes
+  // Scroll the main scroll container to the top when either page changes.
+  // Instant (not smooth) + rAF so the async image-grid re-render can't interrupt/stall it
+  // — smooth-scrolling from the bottom of a tall image page left it stuck at the bottom.
   useEffect(() => {
-    document.querySelector("main")?.scrollTo({ top: 0, behavior: "smooth" });
-  }, [folderPage]);
-
-  useEffect(() => {
-    document.querySelector("main")?.scrollTo({ top: 0, behavior: "smooth" });
-  }, [imagePage]);
+    requestAnimationFrame(() => {
+      document.querySelector("main")?.scrollTo({ top: 0 });
+    });
+  }, [folderPage, imagePage]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
When paging through images inside a folder, the view stayed stuck at the bottom instead of jumping to the top of the next page.

**Cause:** the scroll-to-top used `behavior: "smooth"`; on a tall image page (24 images) the animation from bottom→top got interrupted by the image grid re-rendering (new images mount, scroll height shifts), so it stalled at the bottom. Folder pages are short enough to never scroll, which is why only image dirs showed it.

**Fix:** instant scroll wrapped in `requestAnimationFrame` (runs after the DOM settles), and the two duplicate `folderPage`/`imagePage` effects consolidated into one. Container was already correct (`main`, MUI `TablePagination` unchanged).

tsc clean.