### PR TITLE
fix(ImageRepo): scroll to top on search pagination too

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -141,14 +141,15 @@ export default function ImageRepo() {
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const btnSize = isMobile ? "small" : "medium";
 
-  // Scroll the main scroll container to the top when either page changes.
-  // Instant (not smooth) + rAF so the async image-grid re-render can't interrupt/stall it
-  // — smooth-scrolling from the bottom of a tall image page left it stuck at the bottom.
+  // Scroll the main scroll container to the top on any pagination change
+  // (folders, in-folder images, AND search results).
+  // Instant (not smooth) + rAF so the async grid re-render can't interrupt/stall it
+  // — smooth-scrolling from the bottom of a tall page left it stuck at the bottom.
   useEffect(() => {
     requestAnimationFrame(() => {
       document.querySelector("main")?.scrollTo({ top: 0 });
     });
-  }, [folderPage, imagePage]);
+  }, [folderPage, imagePage, searchPage]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
Follow-up to #209. That fix covered folder + in-folder image pagination, but **search results paginate on a third state (`searchPage`)** that wasn't in the scroll-to-top effect's deps — so paging across search results didn't snap to top.

Added `searchPage` to the effect deps. Now all three pagination paths (folders, in-folder images, search results) scroll to top on page change.

tsc clean.