### PR TITLE
feat(JobDetail): expose Steps, High-Noise Steps, Flow Shift in top card

### DIFF
--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -617,6 +617,18 @@ export default function JobDetail() {
                 value={`${job.cfg_low ?? 1}`}
               />
               <MetaItem
+                label="Steps"
+                value={job.steps_total != null ? `${job.steps_total}` : "—"}
+              />
+              <MetaItem
+                label="High-Noise Steps"
+                value={job.high_noise_steps != null ? `${job.high_noise_steps}` : "—"}
+              />
+              <MetaItem
+                label="Flow Shift"
+                value={job.flow_shift != null ? `${job.flow_shift}` : "—"}
+              />
+              <MetaItem
                 label="Segments"
                 value={`${job.completed_segment_count}`}
               />


### PR DESCRIPTION
The top card showed dimensions/fps/seed/LightX2V/CFG but not the newer sampler knobs (`steps_total`, `high_noise_steps`, `flow_shift`) — they were on `JobResponse` but never rendered. Added the three MetaItems so the full job-level runtime config is visible. (Speed/LoRAs are per-segment and remain in the segment rows.)

tsc clean.