### PR TITLE
feat: Successful Configs page + star toggle on job detail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Videos from "./pages/Videos";
 import LoraLibrary from "./pages/LoraLibrary";
 import PromptLibrary from "./pages/PromptLibrary";
 import ImageRepo from "./pages/ImageRepo";
+import SuccessfulConfigs from "./pages/SuccessfulConfigs";
 import SettingsPage from "./pages/SettingsPage";
 
 export default function App() {
@@ -25,6 +26,7 @@ export default function App() {
             <Route path="/" element={<Dashboard />} />
             <Route path="/jobs" element={<JobQueue />} />
             <Route path="/jobs/:id" element={<JobDetail />} />
+            <Route path="/configs" element={<SuccessfulConfigs />} />
             <Route path="/workers" element={<Workers />} />
             <Route path="/workers/:id" element={<WorkerDetail />} />
             <Route path="/videos" element={<Videos />} />

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -80,6 +80,7 @@ export async function getJobs(params?: {
   sort?: string;
   name?: string;
   q?: string;
+  starred?: boolean;
 }): Promise<JobListResponse> {
   const { data } = await api.get<JobListResponse>("/jobs", { params });
   return data;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -122,6 +122,7 @@ export interface JobResponse {
   high_noise_steps: number | null;
   flow_shift: number | null;
   priority: number;
+  config_starred: boolean;
   status: JobStatus;
   segment_count: number;
   completed_segment_count: number;
@@ -214,6 +215,7 @@ export interface JobUpdate {
   name?: string;
   status?: string;
   tags?: string | null;
+  config_starred?: boolean;
 }
 
 export type JobStatus =

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   TextSnippet,
   Image,
   Settings,
+  Star,
 } from "@mui/icons-material";
 import { useNavigate, useLocation } from "react-router";
 
@@ -25,6 +26,7 @@ export const DRAWER_WIDTH = 220;
 const NAV_ITEMS = [
   { label: "Dashboard", icon: <DashboardIcon />, path: "/" },
   { label: "Job Queue", icon: <QueueMusic />, path: "/jobs" },
+  { label: "Successful Configs", icon: <Star />, path: "/configs" },
   { label: "Workers", icon: <Dns />, path: "/workers" },
   { label: "Videos", icon: <VideoLibrary />, path: "/videos" },
   { label: "LoRA Library", icon: <AutoFixHigh />, path: "/loras" },

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -49,6 +49,8 @@ import {
   ChevronLeft,
   ChevronRight,
   Face,
+  Star,
+  StarBorder,
 } from "@mui/icons-material";
 import { useParams, useNavigate, Link as RouterLink } from "react-router";
 import {
@@ -345,6 +347,18 @@ export default function JobDetail() {
     }
   };
 
+  const handleToggleStar = async () => {
+    if (!id || !job) return;
+    const next = !job.config_starred;
+    setJob((prev) => (prev ? { ...prev, config_starred: next } : prev)); // optimistic
+    try {
+      await updateJob(id, { config_starred: next });
+    } catch {
+      setJob((prev) => (prev ? { ...prev, config_starred: !next } : prev)); // revert
+      setError("Failed to update config flag");
+    }
+  };
+
   const handleRetry = async (seg: SegmentResponse) => {
     setActionLoading(seg.id);
     try {
@@ -589,7 +603,16 @@ export default function JobDetail() {
       {/* Job metadata + finalized video */}
       <Box sx={{ display: "flex", gap: 3, mb: 3, flexWrap: { xs: "wrap", md: "nowrap" } }}>
         <Card sx={{ flex: 1, minWidth: 0 }}>
-          <CardContent>
+          <CardContent sx={{ position: "relative" }}>
+            <Tooltip title={job.config_starred ? "Flagged as a successful config" : "Flag this config as successful"}>
+              <IconButton
+                onClick={handleToggleStar}
+                size="small"
+                sx={{ position: "absolute", top: 8, right: 8, color: job.config_starred ? "warning.main" : "action.active" }}
+              >
+                {job.config_starred ? <Star fontSize="small" /> : <StarBorder fontSize="small" />}
+              </IconButton>
+            </Tooltip>
             <Box
               sx={{
                 display: "grid",

--- a/src/pages/SuccessfulConfigs.tsx
+++ b/src/pages/SuccessfulConfigs.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import { Link as RouterLink } from "react-router";
+import {
+  Box,
+  Card,
+  CardActionArea,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { Star } from "@mui/icons-material";
+import { getJobs, getFileUrl } from "../api/client";
+import StatusChip from "../components/StatusChip";
+import type { JobResponse } from "../api/types";
+
+function ConfigChip({ label, value }: { label: string; value: string | number }) {
+  return (
+    <Chip
+      size="small"
+      variant="outlined"
+      label={
+        <span>
+          <Box component="span" sx={{ color: "text.secondary" }}>
+            {label}
+          </Box>{" "}
+          {value}
+        </span>
+      }
+    />
+  );
+}
+
+export default function SuccessfulConfigs() {
+  const [jobs, setJobs] = useState<JobResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    getJobs({ starred: true, limit: 200 })
+      .then((res) => {
+        if (active) setJobs(res.items);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 3 }}>
+        <Star color="warning" />
+        <Typography variant="h5">Successful Configs</Typography>
+      </Stack>
+
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : jobs.length === 0 ? (
+        <Typography color="text.secondary">
+          No configs flagged yet. Open a job whose result you liked and tap the star in its top card.
+        </Typography>
+      ) : (
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr", lg: "1fr 1fr 1fr" },
+            gap: 2,
+          }}
+        >
+          {jobs.map((job) => (
+            <Card key={job.id}>
+              <CardActionArea component={RouterLink} to={`/jobs/${job.id}`}>
+                <Box sx={{ display: "flex" }}>
+                  {job.starting_image && (
+                    <Box
+                      component="img"
+                      src={getFileUrl(job.starting_image)}
+                      alt={job.name}
+                      sx={{
+                        width: 96,
+                        height: 96,
+                        objectFit: "cover",
+                        flexShrink: 0,
+                        bgcolor: "action.hover",
+                      }}
+                    />
+                  )}
+                  <CardContent sx={{ py: 1.5, flex: 1, minWidth: 0 }}>
+                    <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+                      <Typography
+                        variant="subtitle2"
+                        noWrap
+                        sx={{ flex: 1, minWidth: 0 }}
+                        title={job.name}
+                      >
+                        {job.name}
+                      </Typography>
+                      <StatusChip status={job.status} />
+                    </Stack>
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                      <ConfigChip label="CFG" value={`${job.cfg_high ?? 1}/${job.cfg_low ?? 1}`} />
+                      <ConfigChip
+                        label="LX2V"
+                        value={`${job.lightx2v_strength_high ?? 2.0}/${job.lightx2v_strength_low ?? 1.0}`}
+                      />
+                      {job.steps_total != null && (
+                        <ConfigChip label="Steps" value={`${job.steps_total} (${job.high_noise_steps ?? "?"}h)`} />
+                      )}
+                      {job.flow_shift != null && <ConfigChip label="Shift" value={job.flow_shift} />}
+                      <ConfigChip label="" value={`${job.width}x${job.height}`} />
+                    </Box>
+                  </CardContent>
+                </Box>
+              </CardActionArea>
+            </Card>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
Flag a job whose runtime config produced a good result, and find those configs later.

- **Star toggle** in the JobDetail top card (optimistic, reverts on error) → `PATCH /jobs/{id} { config_starred }`
- **'Successful Configs'** sidebar page at `/configs` — a starred-only job list (thumbnail + config summary: CFG, LightX2V, Steps, Flow Shift, dims + status + link)
- `config_starred` on Job types; `starred` param on `getJobs`

Pairs with wanly-api #104 (needs that deployed + migrated). tsc clean.