### PR TITLE
feat(SuccessfulConfigs): show each config's LoRAs + weights

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -106,6 +106,15 @@ export interface JobCreate {
   tags?: string | null;
 }
 
+export interface JobLoraSummary {
+  lora_id?: string | null;
+  name?: string | null;
+  high_file?: string | null;
+  low_file?: string | null;
+  high_weight?: number | null;
+  low_weight?: number | null;
+}
+
 export interface JobResponse {
   id: string;
   name: string;
@@ -128,6 +137,7 @@ export interface JobResponse {
   completed_segment_count: number;
   estimated_run_time: number | null;
   faceswap_enabled: boolean;
+  loras: JobLoraSummary[];
   tags: string | null;
   created_at: string;
   updated_at: string;

--- a/src/pages/SuccessfulConfigs.tsx
+++ b/src/pages/SuccessfulConfigs.tsx
@@ -13,7 +13,12 @@ import {
 import { Star } from "@mui/icons-material";
 import { getJobs, getFileUrl } from "../api/client";
 import StatusChip from "../components/StatusChip";
-import type { JobResponse } from "../api/types";
+import type { JobResponse, JobLoraSummary } from "../api/types";
+
+function loraLabel(l: JobLoraSummary): string {
+  const raw = l.name || l.high_file || l.low_file || l.lora_id || "lora";
+  return raw.replace(/\.safetensors$/i, "");
+}
 
 function ConfigChip({ label, value }: { label: string; value: string | number }) {
   return (
@@ -116,6 +121,26 @@ export default function SuccessfulConfigs() {
                       {job.flow_shift != null && <ConfigChip label="Shift" value={job.flow_shift} />}
                       <ConfigChip label="" value={`${job.width}x${job.height}`} />
                     </Box>
+                    {job.loras.length > 0 && (
+                      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mt: 0.75 }}>
+                        {job.loras.map((l, i) => (
+                          <Chip
+                            key={i}
+                            size="small"
+                            color="secondary"
+                            variant="outlined"
+                            label={
+                              <span>
+                                {loraLabel(l)}{" "}
+                                <Box component="span" sx={{ color: "text.secondary" }}>
+                                  hi {l.high_weight ?? 0} · lo {l.low_weight ?? 0}
+                                </Box>
+                              </span>
+                            }
+                          />
+                        ))}
+                      </Box>
+                    )}
                   </CardContent>
                 </Box>
               </CardActionArea>


### PR DESCRIPTION
Follow-up to #212. A flagged config now captures its **LoRAs and weights**, not just cfg/steps/etc.

- `JobLoraSummary` type + `loras` on `JobResponse`
- Each Successful Configs card renders its LoRAs as chips: name (or filename) + `hi <high_weight> · lo <low_weight>`

Needs wanly-api #105 deployed. tsc clean.