### PR TITLE
feat(CreateJobDialog): 480p resolution quick-buttons

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -689,6 +689,25 @@ export default function CreateJobDialog({
                 sx={{ flex: 1, minWidth: 100 }}
               />
             </Box>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 1.5 }}>
+              <Typography variant="caption" color="text.secondary">
+                480p:
+              </Typography>
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={() => { setWidth(480); setHeight(848); }}
+              >
+                480×848 ↕
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={() => { setWidth(848); setHeight(480); }}
+              >
+                848×480 ↔
+              </Button>
+            </Box>
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>
               <TextField
                 label="FPS"


### PR DESCRIPTION
Two one-tap buttons in the job modal's video resolution section: **480×848** (portrait) and **848×480** (landscape).

Why 848 and not 854: true 480p 16:9 is ~854×480, but 854 isn't divisible by 16 (854/8 = 106.75 → broken latent), so Wan can't use it directly. **848** is the nearest ÷16 value — same intent, a dimension the model actually accepts. tsc clean.