### PR TITLE
fix(CreateJobDialog): 480p buttons use Wan-native 832x480

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -696,16 +696,16 @@ export default function CreateJobDialog({
               <Button
                 size="small"
                 variant="outlined"
-                onClick={() => { setWidth(480); setHeight(848); }}
+                onClick={() => { setWidth(480); setHeight(832); }}
               >
-                480×848 ↕
+                480×832 ↕
               </Button>
               <Button
                 size="small"
                 variant="outlined"
-                onClick={() => { setWidth(848); setHeight(480); }}
+                onClick={() => { setWidth(832); setHeight(480); }}
               >
-                848×480 ↔
+                832×480 ↔
               </Button>
             </Box>
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>


### PR DESCRIPTION
Follow-up to #214. Switch the 480p quick-buttons to **480×832 / 832×480** — Wan's native, ÷16, model-trained 480p (what jobs already use). The point of the buttons is exactly this: a one-tap shortcut so you never have to remember 832. tsc clean.