### PR TITLE
feat(CreateJobDialog): 480p + 720p buttons, auto-orient

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -691,21 +691,21 @@ export default function CreateJobDialog({
             </Box>
             <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 1.5 }}>
               <Typography variant="caption" color="text.secondary">
-                480p:
+                Resolution:
               </Typography>
               <Button
                 size="small"
                 variant="outlined"
-                onClick={() => { setWidth(480); setHeight(832); }}
+                onClick={() => { const p = height >= width; setWidth(p ? 480 : 832); setHeight(p ? 832 : 480); }}
               >
-                480×832 ↕
+                480p
               </Button>
               <Button
                 size="small"
                 variant="outlined"
-                onClick={() => { setWidth(832); setHeight(480); }}
+                onClick={() => { const p = height >= width; setWidth(p ? 720 : 1280); setHeight(p ? 1280 : 720); }}
               >
-                832×480 ↔
+                720p
               </Button>
             </Box>
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>


### PR DESCRIPTION
Simplifies the resolution shortcuts to **two buttons — 480p and 720p** — each auto-detecting orientation from the current dims (height≥width → portrait) and setting Wan-native ÷16 resolutions:
- 480p → 480×832 (portrait) / 832×480 (landscape)
- 720p → 720×1280 (portrait) / 1280×720 (landscape)

No orientation buttons needed; it follows the starting image. Supersedes #214/#215. tsc clean.