### PR TITLE
feat: AR hologram console — WebXR /holo player + Make Hologram + QR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,12 @@
         "@mui/icons-material": "^7.3.7",
         "@mui/material": "^7.3.7",
         "axios": "^1.9.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-easy-crop": "^5.5.7",
         "react-router": "^7.13.0",
+        "three": "^0.171.0",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -25,6 +27,7 @@
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
+        "@types/three": "^0.171.0",
         "@vitejs/plugin-react": "^5.1.1",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -1847,6 +1850,13 @@
         "win32"
       ]
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1955,6 +1965,35 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.171.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.171.0.tgz",
+      "integrity": "sha512-oLuT1SAsT+CUg/wxUTFHo0K3NtJLnx9sJhZWQJp/0uXqFpzSk1hRHmvWvpaAWSfvx2db0lVKZ5/wV0I0isD2mQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.55.0",
@@ -2245,6 +2284,13 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -2981,6 +3027,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3506,6 +3559,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3800,6 +3860,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -4070,6 +4139,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/three": {
+      "version": "0.171.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
+      "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "@mui/icons-material": "^7.3.7",
     "@mui/material": "^7.3.7",
     "axios": "^1.9.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-easy-crop": "^5.5.7",
     "react-router": "^7.13.0",
+    "three": "^0.171.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {
@@ -27,6 +29,7 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.171.0",
     "@vitejs/plugin-react": "^5.1.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import PromptLibrary from "./pages/PromptLibrary";
 import ImageRepo from "./pages/ImageRepo";
 import SuccessfulConfigs from "./pages/SuccessfulConfigs";
 import SettingsPage from "./pages/SettingsPage";
+import HologramPlayer from "./pages/HologramPlayer";
 
 export default function App() {
   return (
@@ -22,6 +23,8 @@ export default function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/login" element={<Login />} />
+          {/* Full-screen WebXR player — outside MainLayout (no nav chrome) */}
+          <Route path="/holo/:id" element={<HologramPlayer />} />
           <Route element={<MainLayout />}>
             <Route path="/" element={<Dashboard />} />
             <Route path="/jobs" element={<JobQueue />} />

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -7,6 +7,7 @@ import type {
   JobUpdate,
   SegmentCreate,
   SegmentResponse,
+  HologramRequest,
   SegmentReprocessRequest,
   FramePreviewResponse,
   WorkerResponse,
@@ -225,6 +226,21 @@ export async function reprocessSegment(
 
 export async function deleteSegment(segmentId: string): Promise<void> {
   await api.delete(`/segments/${segmentId}`);
+}
+
+export async function makeHologram(
+  jobId: string,
+  body: HologramRequest,
+): Promise<SegmentResponse> {
+  const { data } = await api.post<SegmentResponse>(`/jobs/${jobId}/hologram`, body);
+  return data;
+}
+
+export async function getHologram(
+  segmentId: string,
+): Promise<{ video_path: string; manifest_path: string; poster_path: string }> {
+  const { data } = await api.get(`/segments/${segmentId}/hologram`);
+  return data;
 }
 
 export async function getWorkerSegments(workerId: string): Promise<WorkerSegmentResponse[]> {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -172,12 +172,44 @@ export interface SegmentResponse {
   worker_name: string | null;
   output_path: string | null;
   last_frame_path: string | null;
+  hologram_video_path: string | null;
+  hologram_manifest_path: string | null;
+  hologram_poster_path: string | null;
   created_at: string;
   claimed_at: string | null;
   completed_at: string | null;
   error_message: string | null;
   progress_log: string | null;
   estimated_run_time: number | null;
+}
+
+export interface HologramRequest {
+  subject_height_m?: number;
+  key_color?: string;
+}
+
+export interface HologramUvRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface HologramManifest {
+  tier: number;
+  layout: string;
+  codec: string;
+  fps: number;
+  video_width: number;
+  video_height: number;
+  region_color_uv: HologramUvRect;
+  region_alpha_uv: HologramUvRect;
+  guard_px: number;
+  crop_rect: { x: number; y: number; w: number; h: number };
+  subject_px_height: number;
+  subject_height_m: number;
+  premultiplied: boolean;
+  alpha_encoding: string;
 }
 
 export interface WorkerSegmentResponse {

--- a/src/components/HologramConfig.tsx
+++ b/src/components/HologramConfig.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Slider,
+  Typography,
+} from "@mui/material";
+import type { HologramRequest } from "../api/types";
+
+export default function HologramConfig({
+  open,
+  onClose,
+  onSubmit,
+  busy,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (body: HologramRequest) => void;
+  busy?: boolean;
+}) {
+  const [height, setHeight] = useState(1.7);
+  const [keyColor, setKeyColor] = useState("0x00b140");
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Make Hologram</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Matte this clip’s subject off its (green) background and pack it as a color+alpha
+          hologram you can place life-size in your room on the Quest 3.
+        </Typography>
+        <Typography gutterBottom>Subject height: {height.toFixed(2)} m</Typography>
+        <Slider
+          value={height}
+          min={0.3}
+          max={2.5}
+          step={0.05}
+          onChange={(_, v) => setHeight(v as number)}
+          valueLabelDisplay="auto"
+        />
+        <TextField
+          label="Key color"
+          value={keyColor}
+          onChange={(e) => setKeyColor(e.target.value)}
+          fullWidth
+          size="small"
+          sx={{ mt: 2 }}
+          helperText="Hex like 0x00b140 — the background the clip was generated on."
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={busy}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          disabled={busy}
+          onClick={() => onSubmit({ subject_height_m: height, key_color: keyColor })}
+        >
+          {busy ? "Starting…" : "Make Hologram"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useRef, useState } from "react";
+import { useParams } from "react-router";
+import * as THREE from "three";
+import { getHologram, getFileUrl } from "../api/client";
+import type { HologramManifest } from "../api/types";
+
+// Full-screen WebXR immersive-ar player: places a finalized clip's matted subject
+// (packed color+alpha) life-size on the real floor via Quest 3 passthrough. Tier-0 flat/mono.
+
+const VERTEX = /* glsl */ `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+// Recombine: sample color + alpha from the packed frame via manifest UV rects. The video
+// texture uses flipY=false (top-left origin) to match the manifest, so flip vUv.y here.
+const FRAGMENT = /* glsl */ `
+  uniform sampler2D map;
+  uniform vec4 colorRect;   // x, y, w, h in texture UV
+  uniform vec4 alphaRect;
+  uniform float edgeMin;
+  uniform float edgeMax;
+  varying vec2 vUv;
+  void main() {
+    vec2 cuv = vec2(colorRect.x + vUv.x * colorRect.z, colorRect.y + (1.0 - vUv.y) * colorRect.w);
+    vec2 auv = vec2(alphaRect.x + vUv.x * alphaRect.z, alphaRect.y + (1.0 - vUv.y) * alphaRect.w);
+    vec3 color = texture2D(map, cuv).rgb;
+    float a = smoothstep(edgeMin, edgeMax, texture2D(map, auv).r);
+    gl_FragColor = vec4(color * a, a); // premultiplied
+  }
+`;
+
+function radialShadowTexture(): THREE.Texture {
+  const s = 128;
+  const cv = document.createElement("canvas");
+  cv.width = cv.height = s;
+  const ctx = cv.getContext("2d")!;
+  const g = ctx.createRadialGradient(s / 2, s / 2, 0, s / 2, s / 2, s / 2);
+  g.addColorStop(0, "rgba(0,0,0,0.55)");
+  g.addColorStop(0.7, "rgba(0,0,0,0.25)");
+  g.addColorStop(1, "rgba(0,0,0,0)");
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, s, s);
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+async function startArSession(
+  container: HTMLDivElement,
+  overlay: HTMLElement,
+  manifest: HologramManifest,
+  videoUrl: string,
+  onEnd: () => void,
+): Promise<void> {
+  const xr = (navigator as unknown as { xr: XRSystem }).xr;
+
+  // Video → texture (packed color+alpha). crossOrigin so the texture is CORS-clean.
+  const video = document.createElement("video");
+  video.src = videoUrl;
+  video.crossOrigin = "anonymous";
+  video.loop = true;
+  video.muted = true;
+  video.playsInline = true;
+  const videoTex = new THREE.VideoTexture(video);
+  videoTex.flipY = false;
+  videoTex.colorSpace = THREE.SRGBColorSpace;
+  videoTex.minFilter = THREE.LinearFilter;
+  videoTex.magFilter = THREE.LinearFilter;
+
+  const c = manifest.region_color_uv;
+  const a = manifest.region_alpha_uv;
+  const material = new THREE.ShaderMaterial({
+    uniforms: {
+      map: { value: videoTex },
+      colorRect: { value: new THREE.Vector4(c.x, c.y, c.w, c.h) },
+      alphaRect: { value: new THREE.Vector4(a.x, a.y, a.w, a.h) },
+      edgeMin: { value: 0.05 },
+      edgeMax: { value: 0.95 },
+    },
+    vertexShader: VERTEX,
+    fragmentShader: FRAGMENT,
+    transparent: true,
+    premultipliedAlpha: true,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+  });
+
+  // Life-size quad: height = subject_height_m, width from crop aspect.
+  const height = manifest.subject_height_m || 1.7;
+  const aspect = manifest.crop_rect.w / manifest.crop_rect.h;
+  const width = height * aspect;
+  const quad = new THREE.Mesh(new THREE.PlaneGeometry(width, height), material);
+  quad.position.y = height / 2; // base sits on the floor
+
+  const shadow = new THREE.Mesh(
+    new THREE.CircleGeometry(width * 0.55, 48),
+    new THREE.MeshBasicMaterial({ map: radialShadowTexture(), transparent: true, depthWrite: false }),
+  );
+  shadow.rotation.x = -Math.PI / 2;
+  shadow.position.y = 0.005;
+
+  const group = new THREE.Group();
+  group.add(quad);
+  group.add(shadow);
+  group.visible = false;
+
+  const reticle = new THREE.Mesh(
+    new THREE.RingGeometry(0.07, 0.09, 32).rotateX(-Math.PI / 2),
+    new THREE.MeshBasicMaterial({ color: 0x00e5ff }),
+  );
+  reticle.matrixAutoUpdate = false;
+  reticle.visible = false;
+
+  const scene = new THREE.Scene();
+  scene.add(reticle);
+  scene.add(group);
+
+  const camera = new THREE.PerspectiveCamera();
+  const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+  renderer.setPixelRatio(window.devicePixelRatio);
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.xr.enabled = true;
+  renderer.xr.setReferenceSpaceType("local-floor");
+  container.appendChild(renderer.domElement);
+
+  const session = await xr.requestSession("immersive-ar", {
+    requiredFeatures: ["local-floor", "hit-test"],
+    optionalFeatures: ["dom-overlay"],
+    domOverlay: { root: overlay },
+  } as XRSessionInit);
+  await renderer.xr.setSession(session);
+  video.play().catch(() => undefined);
+
+  const viewerSpace = await session.requestReferenceSpace("viewer");
+  const hitSource = await (
+    session as unknown as {
+      requestHitTestSource: (o: { space: XRReferenceSpace }) => Promise<XRHitTestSource>;
+    }
+  ).requestHitTestSource({ space: viewerSpace });
+
+  const place = () => {
+    if (!reticle.visible) return;
+    group.position.setFromMatrixPosition(reticle.matrix);
+    // Face the user (yaw only) at placement, then stay put.
+    const camPos = new THREE.Vector3().setFromMatrixPosition(camera.matrixWorld);
+    group.rotation.y = Math.atan2(camPos.x - group.position.x, camPos.z - group.position.z);
+    group.visible = true;
+  };
+  session.addEventListener("select", place);
+
+  renderer.setAnimationLoop((_t, frame?: XRFrame) => {
+    if (frame && !group.visible) {
+      const refSpace = renderer.xr.getReferenceSpace();
+      const results = frame.getHitTestResults(hitSource);
+      if (refSpace && results.length) {
+        const pose = results[0].getPose(refSpace);
+        if (pose) {
+          reticle.visible = true;
+          reticle.matrix.fromArray(pose.transform.matrix);
+        }
+      } else {
+        reticle.visible = false;
+      }
+    }
+    renderer.render(scene, camera);
+  });
+
+  session.addEventListener("end", () => {
+    renderer.setAnimationLoop(null);
+    video.pause();
+    videoTex.dispose();
+    material.dispose();
+    renderer.dispose();
+    if (renderer.domElement.parentElement === container) container.removeChild(renderer.domElement);
+    onEnd();
+  });
+}
+
+export default function HologramPlayer() {
+  const { id } = useParams<{ id: string }>();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const [manifest, setManifest] = useState<HologramManifest | null>(null);
+  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [posterUrl, setPosterUrl] = useState<string | null>(null);
+  const [arSupported, setArSupported] = useState<boolean | null>(null);
+  const [inAr, setInAr] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        if (!id) return;
+        const paths = await getHologram(id);
+        const res = await fetch(getFileUrl(paths.manifest_path));
+        if (!res.ok) throw new Error(`manifest ${res.status}`);
+        const m: HologramManifest = await res.json();
+        if (cancelled) return;
+        setManifest(m);
+        setVideoUrl(getFileUrl(paths.video_path));
+        setPosterUrl(getFileUrl(paths.poster_path));
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load hologram");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  useEffect(() => {
+    const xr = (navigator as unknown as { xr?: XRSystem }).xr;
+    if (!window.isSecureContext || !xr) {
+      setArSupported(false);
+      return;
+    }
+    xr.isSessionSupported("immersive-ar")
+      .then((ok) => setArSupported(ok))
+      .catch(() => setArSupported(false));
+  }, []);
+
+  const enterAR = async () => {
+    if (!manifest || !videoUrl || !containerRef.current || !overlayRef.current) return;
+    try {
+      setInAr(true);
+      await startArSession(containerRef.current, overlayRef.current, manifest, videoUrl, () =>
+        setInAr(false),
+      );
+    } catch (e) {
+      setInAr(false);
+      setError(e instanceof Error ? e.message : "Could not start AR session");
+    }
+  };
+
+  const wrap: React.CSSProperties = {
+    position: "fixed",
+    inset: 0,
+    background: "#0b0b0f",
+    color: "#eee",
+    fontFamily: "system-ui, sans-serif",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 16,
+    textAlign: "center",
+    padding: 24,
+  };
+
+  return (
+    <div ref={containerRef} style={{ position: "fixed", inset: 0 }}>
+      {/* dom-overlay content (transport UI could live here during AR) */}
+      <div ref={overlayRef} style={{ position: "fixed", inset: 0, pointerEvents: "none" }}>
+        {inAr && (
+          <div style={{ position: "absolute", bottom: 24, width: "100%", textAlign: "center", color: "#fff" }}>
+            Point at your floor and tap to place • pinch/exit to leave
+          </div>
+        )}
+      </div>
+
+      {!inAr && (
+        <div style={wrap}>
+          {error && <div style={{ color: "#ff6b6b" }}>⚠ {error}</div>}
+          {posterUrl && (
+            <img
+              src={posterUrl}
+              alt="hologram poster"
+              style={{ maxHeight: "45vh", maxWidth: "80vw", objectFit: "contain" }}
+            />
+          )}
+          {arSupported === true && manifest && (
+            <button
+              onClick={enterAR}
+              style={{
+                fontSize: 20,
+                padding: "14px 28px",
+                borderRadius: 10,
+                border: "none",
+                background: "#00e5ff",
+                color: "#00121a",
+                fontWeight: 700,
+                cursor: "pointer",
+              }}
+            >
+              Enter AR
+            </button>
+          )}
+          {arSupported === false && (
+            <div style={{ maxWidth: 420, lineHeight: 1.5 }}>
+              <p style={{ fontWeight: 600 }}>Open this on a Quest 3 (or WebXR headset) to place it in your room.</p>
+              <p style={{ opacity: 0.7, fontSize: 14 }}>
+                Immersive AR isn’t available in this browser. Preview below.
+              </p>
+              {videoUrl && (
+                <video
+                  src={videoUrl}
+                  controls
+                  loop
+                  muted
+                  playsInline
+                  style={{ maxWidth: "80vw", maxHeight: "40vh", marginTop: 12, borderRadius: 8 }}
+                />
+              )}
+            </div>
+          )}
+          {arSupported === null && !error && <div style={{ opacity: 0.6 }}>Checking AR support…</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -51,6 +51,7 @@ import {
   Face,
   Star,
   StarBorder,
+  ViewInAr,
 } from "@mui/icons-material";
 import { useParams, useNavigate, Link as RouterLink } from "react-router";
 import {
@@ -61,6 +62,7 @@ import {
   retrySegment,
   cancelSegment,
   reprocessSegment,
+  makeHologram,
   deleteSegment,
   deleteJob,
   reopenJob,
@@ -90,6 +92,8 @@ import type {
 } from "../api/types";
 import StatusChip from "../components/StatusChip";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
+import HologramConfig from "../components/HologramConfig";
+import { QRCodeCanvas } from "qrcode.react";
 import {
   DEFAULT_DURATION,
   DEFAULT_SPEED,
@@ -256,6 +260,8 @@ export default function JobDetail() {
   const [reopening, setReopening] = useState(false);
   const [reopenConfirm, setReopenConfirm] = useState(false);
   const [reprocessSeg, setReprocessSeg] = useState<SegmentResponse | null>(null);
+  const [holoOpen, setHoloOpen] = useState(false);
+  const [holoBusy, setHoloBusy] = useState(false);
   const [archiving, setArchiving] = useState(false);
   const [trimValues, setTrimValues] = useState<Record<string, { start: number; end: number }>>({});
   const trimTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
@@ -286,6 +292,23 @@ export default function JobDetail() {
       setLoading(false);
     }
   }, [id]);
+
+  const handleMakeHologram = useCallback(
+    async (body: { subject_height_m?: number; key_color?: string }) => {
+      if (!id) return;
+      setHoloBusy(true);
+      try {
+        await makeHologram(id, body);
+        setHoloOpen(false);
+        await fetchJob();
+      } catch {
+        setError("Failed to start hologram");
+      } finally {
+        setHoloBusy(false);
+      }
+    },
+    [id, fetchJob],
+  );
 
   useEffect(() => {
     fetchJob();
@@ -706,10 +729,37 @@ export default function JobDetail() {
               </IconButton>
             </Box>
           </Box>
+          {(() => {
+            const holoSeg = job.segments?.find((s) => s.hologram_video_path);
+            const holoUrl = holoSeg ? `${window.location.origin}/holo/${holoSeg.id}` : null;
+            return (
+              <Box sx={{ mt: 1.5, display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}>
+                {holoUrl ? (
+                  <>
+                    <Button size="small" variant="contained" startIcon={<ViewInAr />} component="a" href={holoUrl} target="_blank">
+                      Open in AR
+                    </Button>
+                    <QRCodeCanvas value={holoUrl} size={128} />
+                    <Typography variant="caption" color="text.secondary">Scan on your Quest 3</Typography>
+                  </>
+                ) : (
+                  <Button size="small" variant="outlined" fullWidth startIcon={<ViewInAr />} onClick={() => setHoloOpen(true)}>
+                    Make Hologram
+                  </Button>
+                )}
+              </Box>
+            );
+          })()}
               </CardContent>
             </Card>
           );
         })()}
+        <HologramConfig
+          open={holoOpen}
+          onClose={() => setHoloOpen(false)}
+          onSubmit={handleMakeHologram}
+          busy={holoBusy}
+        />
       </Box>
 
       {/* Tags editor — always visible */}


### PR DESCRIPTION
Final slice of the personal AR-hologram feature (pairs with wanly-api #109 + wanly-gpu-daemon #70).

- **`/holo/:id`** (new, full-screen, outside MainLayout): three.js `immersive-ar` player — fetches the segment's manifest + packed mp4, **recombine shader** (color+alpha via manifest UV rects, edge smoothstep, premultiplied), **hit-test floor placement**, **life-size** quad from `subject_height_m`+crop aspect, **contact-shadow disc**, faces you at placement. Graceful fallback (flat `<video>` + banner) when immersive-ar / secure context is unavailable.
- **JobDetail**: "Make Hologram" button on the finalized-video card → `HologramConfig` dialog (subject height + key color) → `makeHologram`; once produced, "Open in AR" + a **QR** of the `/holo` URL to scan in-headset.
- Adds `three` + `qrcode.react`; `makeHologram`/`getHologram` client fns; hologram fields + `HologramManifest` type. **tsc + vite build + eslint clean.**

**Known deploy check:** the WebGL VideoTexture uses `crossOrigin="anonymous"`, so the jobs S3 bucket needs CORS allowing the console origin (one-time). Else the texture taints and we'd add a byte-proxy endpoint (deferred).