### PR TITLE
feat: 'Building hologram…' state on the finalized card

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -168,6 +168,7 @@ export interface SegmentResponse {
   reference_frames: string[] | null;
   negative_prompt: string | null;
   status: SegmentStatus;
+  reprocess_type: string | null;
   worker_id: string | null;
   worker_name: string | null;
   output_path: string | null;

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -732,6 +732,7 @@ export default function JobDetail() {
           {(() => {
             const holoSeg = job.segments?.find((s) => s.hologram_video_path);
             const holoUrl = holoSeg ? `${window.location.origin}/holo/${holoSeg.id}` : null;
+            const building = !holoSeg && job.segments?.some((s) => s.reprocess_type === "ar_hologram");
             return (
               <Box sx={{ mt: 1.5, display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}>
                 {holoUrl ? (
@@ -742,6 +743,11 @@ export default function JobDetail() {
                     <QRCodeCanvas value={holoUrl} size={128} />
                     <Typography variant="caption" color="text.secondary">Scan on your Quest 3</Typography>
                   </>
+                ) : building ? (
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    <CircularProgress size={18} />
+                    <Typography variant="body2" color="text.secondary">Building hologram…</Typography>
+                  </Box>
                 ) : (
                   <Button size="small" variant="outlined" fullWidth startIcon={<ViewInAr />} onClick={() => setHoloOpen(true)}>
                     Make Hologram


### PR DESCRIPTION
Closes the confusion where clicking Make Hologram left the card looking idle (and the finalized job flashing back to 'processing' with no explanation). The card now shows a **Building hologram…** spinner while an `ar_hologram` carrier segment is in flight (derived from the server's `reprocess_type`, so it's reload-safe), then swaps to Open in AR + QR when done. tsc + build clean.