### PR TITLE
feat: video-settings presets UI (library + job/segment dropdowns)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import ImageRepo from "./pages/ImageRepo";
 import SuccessfulConfigs from "./pages/SuccessfulConfigs";
 import SettingsPage from "./pages/SettingsPage";
 import HologramPlayer from "./pages/HologramPlayer";
+import VideoPresetLibrary from "./pages/VideoPresetLibrary";
 
 export default function App() {
   return (
@@ -35,6 +36,7 @@ export default function App() {
             <Route path="/videos" element={<Videos />} />
             <Route path="/loras" element={<LoraLibrary />} />
             <Route path="/prompts" element={<PromptLibrary />} />
+            <Route path="/video-presets" element={<VideoPresetLibrary />} />
             <Route path="/images" element={<ImageRepo />} />
             <Route path="/settings" element={<SettingsPage />} />
           </Route>

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -18,6 +18,9 @@ import type {
   StatsResponse,
   WorkerSegmentResponse,
   PromptPreset,
+  VideoSettingsPreset,
+  VideoSettingsPresetCreate,
+  VideoSettingsPresetUpdate,
   PromptPresetCreate,
   PromptPresetUpdate,
   WildcardResponse,
@@ -331,6 +334,38 @@ export async function updatePromptPreset(
 
 export async function deletePromptPreset(id: string): Promise<void> {
   await api.delete(`/prompt-presets/${id}`);
+}
+
+export async function getVideoPresets(): Promise<VideoSettingsPreset[]> {
+  const { data } = await api.get<VideoSettingsPreset[]>("/video-presets");
+  return data;
+}
+
+export async function createVideoPreset(body: VideoSettingsPresetCreate): Promise<VideoSettingsPreset> {
+  const { data } = await api.post<VideoSettingsPreset>("/video-presets", body);
+  return data;
+}
+
+export async function updateVideoPreset(
+  id: string,
+  body: VideoSettingsPresetUpdate,
+): Promise<VideoSettingsPreset> {
+  const { data } = await api.patch<VideoSettingsPreset>(`/video-presets/${id}`, body);
+  return data;
+}
+
+export async function deleteVideoPreset(id: string): Promise<void> {
+  await api.delete(`/video-presets/${id}`);
+}
+
+export async function updateSegmentVideoPreset(
+  segmentId: string,
+  videoPresetId: string | null,
+): Promise<SegmentResponse> {
+  const { data } = await api.patch<SegmentResponse>(`/segments/${segmentId}/video-preset`, {
+    video_preset_id: videoPresetId,
+  });
+  return data;
 }
 
 // --- Wildcards ---

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -23,6 +23,7 @@ export interface SegmentCreate {
   negative_prompt?: string | null;
   auto_finalize?: boolean;
   transition?: string | null;
+  video_preset_id?: string | null;
 }
 
 export interface LoraConfig {
@@ -100,6 +101,7 @@ export interface JobCreate {
   steps_total?: number | null;
   high_noise_steps?: number | null;
   flow_shift?: number | null;
+  video_preset_id?: string | null;
   starting_image_uri?: string | null;
   starting_image_hash?: string | null;
   first_segment: SegmentCreate;
@@ -130,6 +132,7 @@ export interface JobResponse {
   steps_total: number | null;
   high_noise_steps: number | null;
   flow_shift: number | null;
+  video_preset_id?: string | null;
   priority: number;
   config_starred: boolean;
   status: JobStatus;
@@ -171,6 +174,7 @@ export interface SegmentResponse {
   reprocess_type: string | null;
   worker_id: string | null;
   worker_name: string | null;
+  video_preset_id: string | null;
   output_path: string | null;
   last_frame_path: string | null;
   hologram_video_path: string | null;
@@ -358,6 +362,33 @@ export interface PromptPresetUpdate {
   prompt?: string;
   loras?: PromptPresetLoraSlot[] | null;
 }
+
+export interface VideoSettingsPreset {
+  id: string;
+  name: string;
+  lightx2v_strength_high: number | null;
+  lightx2v_strength_low: number | null;
+  cfg_high: number | null;
+  cfg_low: number | null;
+  steps_total: number | null;
+  high_noise_steps: number | null;
+  flow_shift: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface VideoSettingsPresetCreate {
+  name: string;
+  lightx2v_strength_high?: number | null;
+  lightx2v_strength_low?: number | null;
+  cfg_high?: number | null;
+  cfg_low?: number | null;
+  steps_total?: number | null;
+  high_noise_steps?: number | null;
+  flow_shift?: number | null;
+}
+
+export type VideoSettingsPresetUpdate = Partial<VideoSettingsPresetCreate>;
 
 export interface WildcardResponse {
   id: string;

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -24,6 +24,7 @@ import { useLoraStore } from "../stores/loraStore";
 import { useSettingsStore } from "../stores/settingsStore";
 import { useTagStore } from "../stores/tagStore";
 import { usePromptPresetStore } from "../stores/promptPresetStore";
+import { useVideoPresetStore } from "../stores/videoPresetStore";
 import { createJob, getFileUrl, getFaceswapPresets, sha256Hex, checkStartingImageExists } from "../api/client";
 import type { JobCreate, LoraListItem, FaceswapPreset, PromptPreset } from "../api/types";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "./FaceswapConfig";
@@ -130,7 +131,7 @@ export default function CreateJobDialog({
   const [stepsTotal, setStepsTotal] = useState(defaultStepsTotal);
   const [highNoiseSteps, setHighNoiseSteps] = useState(defaultHighNoiseSteps);
   const [flowShift, setFlowShift] = useState(defaultFlowShift);
-  const [samplerPreset, setSamplerPreset] = useState("");
+  const [videoPresetId, setVideoPresetId] = useState("");
   const [startingImage, setStartingImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [startingImageUri, setStartingImageUri] = useState<string | null>(null);
@@ -189,6 +190,7 @@ export default function CreateJobDialog({
 
   // Preset state
   const { presets, fetchPresets } = usePromptPresetStore();
+  const { presets: videoPresets, fetchPresets: fetchVideoPresets } = useVideoPresetStore();
 
   // LoRA state
   const { loras: loraLibrary, fetchLoras } = useLoraStore();
@@ -200,6 +202,7 @@ export default function CreateJobDialog({
     if (open) {
       fetchLoras();
       fetchPresets();
+      fetchVideoPresets();
       fetchTags();
       fetchSettings();
       getFaceswapPresets().then((presets) => {
@@ -354,22 +357,19 @@ export default function CreateJobDialog({
     }
   }, [open, defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, defaultStepsTotal, defaultHighNoiseSteps, defaultFlowShift]);
 
-  const SAMPLER_PRESETS: Record<string, Record<string, string>> = {
-    Lightning: { lightx2vHigh: "1", lightx2vLow: "1", cfgHigh: "1", cfgLow: "1", stepsTotal: "4", highNoiseSteps: "2", flowShift: "5" },
-    "Prompt-Aware": { lightx2vHigh: "0", lightx2vLow: "1", cfgHigh: "2.75", cfgLow: "1", stepsTotal: "12", highNoiseSteps: "8", flowShift: "5" },
-    "High Motion": { lightx2vHigh: "0", lightx2vLow: "1", cfgHigh: "3.5", cfgLow: "1", stepsTotal: "12", highNoiseSteps: "8", flowShift: "5" },
-  };
-  const applySamplerPreset = (name: string) => {
-    setSamplerPreset(name);
-    const p = SAMPLER_PRESETS[name];
+  // Select a user-defined video-settings preset (live link). "" = Custom (raw fields below).
+  const applyVideoPreset = (id: string) => {
+    setVideoPresetId(id);
+    const p = videoPresets.find((v) => v.id === id);
     if (!p) return;
-    setLightx2vHigh(p.lightx2vHigh);
-    setLightx2vLow(p.lightx2vLow);
-    setCfgHigh(p.cfgHigh);
-    setCfgLow(p.cfgLow);
-    setStepsTotal(p.stepsTotal);
-    setHighNoiseSteps(p.highNoiseSteps);
-    setFlowShift(p.flowShift);
+    const s = (v: number | null) => (v == null ? "" : String(v));
+    setLightx2vHigh(s(p.lightx2v_strength_high));
+    setLightx2vLow(s(p.lightx2v_strength_low));
+    setCfgHigh(s(p.cfg_high));
+    setCfgLow(s(p.cfg_low));
+    setStepsTotal(s(p.steps_total));
+    setHighNoiseSteps(s(p.high_noise_steps));
+    setFlowShift(s(p.flow_shift));
   };
 
   const handleSubmit = async () => {
@@ -411,6 +411,7 @@ export default function CreateJobDialog({
         steps_total: stepsTotal ? parseInt(stepsTotal, 10) : null,
         high_noise_steps: highNoiseSteps ? parseInt(highNoiseSteps, 10) : null,
         flow_shift: flowShift ? parseFloat(flowShift) : null,
+        video_preset_id: videoPresetId || null,
         starting_image_uri: !startingImage && startingImageUri ? startingImageUri : null,
         starting_image_hash: reuseHash,
         tags: tags || null,
@@ -757,17 +758,17 @@ export default function CreateJobDialog({
             <Box sx={{ mt: 1.5 }}>
               <TextField
                 select
-                label="Preset"
+                label="Video Preset"
                 size="small"
-                value={samplerPreset}
-                onChange={(e) => applySamplerPreset(e.target.value)}
+                value={videoPresetId}
+                onChange={(e) => applyVideoPreset(e.target.value)}
                 sx={{ minWidth: 240 }}
-                helperText="Load a known-good sampler bundle"
+                helperText="Job default — manage in Video Presets. Custom = raw values below."
               >
                 <MenuItem value="">Custom</MenuItem>
-                <MenuItem value="Lightning">Lightning — fast, cfg 1</MenuItem>
-                <MenuItem value="Prompt-Aware">Prompt-Aware — cfg 2.75, motion</MenuItem>
-                <MenuItem value="High Motion">High Motion — cfg 3.5</MenuItem>
+                {videoPresets.map((p) => (
+                  <MenuItem key={p.id} value={p.id}>{p.name}</MenuItem>
+                ))}
               </TextField>
             </Box>
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   Image,
   Settings,
   Star,
+  Tune,
 } from "@mui/icons-material";
 import { useNavigate, useLocation } from "react-router";
 
@@ -31,6 +32,7 @@ const NAV_ITEMS = [
   { label: "Videos", icon: <VideoLibrary />, path: "/videos" },
   { label: "LoRA Library", icon: <AutoFixHigh />, path: "/loras" },
   { label: "Prompts", icon: <TextSnippet />, path: "/prompts" },
+  { label: "Video Presets", icon: <Tune />, path: "/video-presets" },
   { label: "Image Repo", icon: <Image />, path: "/images" },
   { label: "Settings", icon: <Settings />, path: "/settings" },
 ];

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -76,6 +76,7 @@ import {
 } from "../api/client";
 import { useLoraStore } from "../stores/loraStore";
 import { usePromptPresetStore } from "../stores/promptPresetStore";
+import { useVideoPresetStore } from "../stores/videoPresetStore";
 import { useSettingsStore } from "../stores/settingsStore";
 import type {
   JobDetailResponse,
@@ -2130,6 +2131,8 @@ function SegmentModal({
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const { loras: loraLibrary, fetchLoras } = useLoraStore();
   const { presets: promptPresets, fetchPresets } = usePromptPresetStore();
+  const { presets: segVideoPresets, fetchPresets: fetchSegVideoPresets } = useVideoPresetStore();
+  const [segVideoPresetId, setSegVideoPresetId] = useState("");
   const { negativePrompt: defaultNegativePrompt, fetchSettings } = useSettingsStore();
   const [prompt, setPrompt] = useState("");
   const [negativePrompt, setNegativePrompt] = useState("");
@@ -2208,6 +2211,7 @@ function SegmentModal({
     if (open) {
       fetchLoras();
       fetchPresets();
+      fetchSegVideoPresets();
       fetchSettings();
       getFaceswapPresets().then(setFaceswapPresets).catch(() => {});
     }
@@ -2323,6 +2327,7 @@ function SegmentModal({
               }))
             : null,
         negative_prompt: negativePrompt.trim() || null,
+        video_preset_id: segVideoPresetId || null,
       };
       await addSegment(jobId, body);
       onSubmitted();
@@ -2665,6 +2670,24 @@ function SegmentModal({
           >
             <ClearOutlined sx={{ fontSize: 14 }} />
           </IconButton>
+        </Box>
+
+        {/* ── Video Settings (per-segment override) ── */}
+        <Box sx={{ mt: 2 }}>
+          <TextField
+            select
+            fullWidth
+            label="Video Settings"
+            size="small"
+            value={segVideoPresetId}
+            onChange={(e) => setSegVideoPresetId(e.target.value)}
+            helperText="Inherit the job's settings, or override this segment with a preset."
+          >
+            <MenuItem value="">Inherit from job</MenuItem>
+            {segVideoPresets.map((p) => (
+              <MenuItem key={p.id} value={p.id}>{p.name}</MenuItem>
+            ))}
+          </TextField>
         </Box>
 
         {/* ── Negative Prompt (accordion) ── */}

--- a/src/pages/VideoPresetLibrary.tsx
+++ b/src/pages/VideoPresetLibrary.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Typography,
+  Button,
+  Card,
+  CardContent,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Alert,
+  CircularProgress,
+  Chip,
+  Stack,
+} from "@mui/material";
+import { Add, Edit, DeleteOutline } from "@mui/icons-material";
+import { useVideoPresetStore } from "../stores/videoPresetStore";
+import { createVideoPreset, updateVideoPreset, deleteVideoPreset } from "../api/client";
+import type { VideoSettingsPreset, VideoSettingsPresetCreate } from "../api/types";
+
+type ParamKey =
+  | "lightx2v_strength_high"
+  | "lightx2v_strength_low"
+  | "cfg_high"
+  | "cfg_low"
+  | "steps_total"
+  | "high_noise_steps"
+  | "flow_shift";
+
+const FIELDS: { key: ParamKey; label: string }[] = [
+  { key: "lightx2v_strength_high", label: "LightX2V High" },
+  { key: "lightx2v_strength_low", label: "LightX2V Low" },
+  { key: "cfg_high", label: "CFG High" },
+  { key: "cfg_low", label: "CFG Low" },
+  { key: "steps_total", label: "Steps Total" },
+  { key: "high_noise_steps", label: "High-Noise Steps" },
+  { key: "flow_shift", label: "Flow Shift" },
+];
+
+type FormState = Record<string, string>;
+
+function emptyForm(): FormState {
+  const f: FormState = { name: "" };
+  FIELDS.forEach((x) => (f[x.key] = ""));
+  return f;
+}
+
+function presetToForm(p: VideoSettingsPreset): FormState {
+  const f: FormState = { name: p.name };
+  FIELDS.forEach((x) => (f[x.key] = p[x.key] == null ? "" : String(p[x.key])));
+  return f;
+}
+
+export default function VideoPresetLibrary() {
+  const { presets, loading, error, fetchPresets } = useVideoPresetStore();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<VideoSettingsPreset | null>(null);
+  const [form, setForm] = useState<FormState>(emptyForm());
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<VideoSettingsPreset | null>(null);
+
+  useEffect(() => {
+    fetchPresets();
+  }, [fetchPresets]);
+
+  const openNew = () => {
+    setEditing(null);
+    setForm(emptyForm());
+    setFormError(null);
+    setDialogOpen(true);
+  };
+  const openEdit = (p: VideoSettingsPreset) => {
+    setEditing(p);
+    setForm(presetToForm(p));
+    setFormError(null);
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (!form.name.trim()) {
+      setFormError("Name is required");
+      return;
+    }
+    setSaving(true);
+    setFormError(null);
+    const body: VideoSettingsPresetCreate = { name: form.name.trim() };
+    FIELDS.forEach((x) => {
+      const v = form[x.key].trim();
+      body[x.key] = v === "" ? null : Number(v);
+    });
+    try {
+      if (editing) await updateVideoPreset(editing.id, body);
+      else await createVideoPreset(body);
+      setDialogOpen(false);
+      await fetchPresets();
+    } catch (e) {
+      const detail = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setFormError(detail || (e instanceof Error ? e.message : "Save failed"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteConfirm) return;
+    await deleteVideoPreset(deleteConfirm.id);
+    setDeleteConfirm(null);
+    await fetchPresets();
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1 }}>
+        <Typography variant="h5">Video Presets</Typography>
+        <Button variant="contained" startIcon={<Add />} onClick={openNew}>
+          New Preset
+        </Button>
+      </Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Named bundles of sampler settings. Choose one per-job (default) or per-segment (override) —
+        edits apply to future runs of anything using the preset.
+      </Typography>
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      {loading ? (
+        <CircularProgress />
+      ) : (
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+          {presets.map((p) => (
+            <Card key={p.id} sx={{ width: 340 }}>
+              <CardContent>
+                <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                  <Typography variant="subtitle1" fontWeight={600}>{p.name}</Typography>
+                  <Box>
+                    <IconButton size="small" onClick={() => openEdit(p)}>
+                      <Edit fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" onClick={() => setDeleteConfirm(p)}>
+                      <DeleteOutline fontSize="small" />
+                    </IconButton>
+                  </Box>
+                </Box>
+                <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: 1 }}>
+                  {FIELDS.map((x) => (
+                    <Chip key={x.key} size="small" label={`${x.label}: ${p[x.key] ?? "—"}`} />
+                  ))}
+                </Stack>
+              </CardContent>
+            </Card>
+          ))}
+          {presets.length === 0 && (
+            <Typography color="text.secondary" sx={{ p: 2 }}>No presets yet.</Typography>
+          )}
+        </Box>
+      )}
+
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>{editing ? "Edit Preset" : "New Preset"}</DialogTitle>
+        <DialogContent>
+          {formError && <Alert severity="error" sx={{ mb: 2 }}>{formError}</Alert>}
+          <TextField
+            label="Name"
+            fullWidth
+            size="small"
+            sx={{ mt: 1, mb: 2 }}
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+          />
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+            {FIELDS.map((x) => (
+              <TextField
+                key={x.key}
+                label={x.label}
+                type="number"
+                size="small"
+                sx={{ width: 150 }}
+                value={form[x.key]}
+                onChange={(e) => setForm({ ...form, [x.key]: e.target.value })}
+              />
+            ))}
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)} disabled={saving}>Cancel</Button>
+          <Button variant="contained" onClick={handleSave} disabled={saving}>
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={!!deleteConfirm} onClose={() => setDeleteConfirm(null)}>
+        <DialogTitle>Delete preset?</DialogTitle>
+        <DialogContent>
+          Delete “{deleteConfirm?.name}”? Jobs/segments using it fall back to their raw settings.
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteConfirm(null)}>Cancel</Button>
+          <Button color="error" variant="contained" onClick={handleDelete}>Delete</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/stores/videoPresetStore.ts
+++ b/src/stores/videoPresetStore.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import { getVideoPresets } from "../api/client";
+import type { VideoSettingsPreset } from "../api/types";
+
+interface VideoPresetState {
+  presets: VideoSettingsPreset[];
+  loading: boolean;
+  error: string | null;
+  fetchPresets: () => Promise<void>;
+}
+
+export const useVideoPresetStore = create<VideoPresetState>((set) => ({
+  presets: [],
+  loading: false,
+  error: null,
+
+  fetchPresets: async () => {
+    set({ loading: true, error: null });
+    try {
+      const presets = await getVideoPresets();
+      presets.sort((a, b) => a.name.localeCompare(b.name));
+      set({ presets, loading: false });
+    } catch (e) {
+      set({
+        loading: false,
+        error: e instanceof Error ? e.message : "Failed to fetch presets",
+      });
+    }
+  },
+}));


### PR DESCRIPTION
Pairs with wanly-api #115. Console for user-managed video-settings presets.

**Feature 1:** new **Video Presets** library page (create/name/edit/delete the 7-param bundles). `CreateJobDialog`'s dropdown now reads presets from the DB (live-links `video_preset_id`) instead of the hardcoded `SAMPLER_PRESETS`; "Custom" keeps raw fields.

**Feature 2:** the **Next Segment** dialog gets a "Video Settings" dropdown (inherit job / pick a preset) → per-segment `video_preset_id` override.

Store + client CRUD + `updateSegmentVideoPreset` + types. tsc + vite build + eslint clean.

**Deferred (follow-up):** an override selector for *already-created* segments — the API (`PATCH /segments/{id}/video-preset`) is built; just needs a UI hook (e.g. in the Segment Details dialog).