### PR TITLE
fix: preset dropdown inside the Video Settings accordion

### DIFF
--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -63,6 +63,7 @@ import {
   cancelSegment,
   reprocessSegment,
   makeHologram,
+  updateSegmentVideoPreset,
   deleteSegment,
   deleteJob,
   reopenJob,
@@ -1886,8 +1887,18 @@ function SegmentDetailModal({
   onClose: () => void;
 }) {
   const { loras: loraLibrary } = useLoraStore();
+  const { presets: videoPresets, fetchPresets: fetchVideoPresets } = useVideoPresetStore();
+  const [presetId, setPresetId] = useState<string>("");
+  const [savingPreset, setSavingPreset] = useState(false);
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+
+  useEffect(() => {
+    if (seg) {
+      fetchVideoPresets();
+      setPresetId(seg.video_preset_id ?? "");
+    }
+  }, [seg, fetchVideoPresets]);
 
   if (!seg) return null;
 
@@ -1944,6 +1955,36 @@ function SegmentDetailModal({
               <Typography variant="body2">{seg.worker_name}</Typography>
             </Box>
           )}
+        </Box>
+
+        {/* Video settings (per-segment override, in place) */}
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+            Video Settings
+          </Typography>
+          <TextField
+            select
+            fullWidth
+            size="small"
+            value={presetId}
+            disabled={savingPreset}
+            onChange={async (e) => {
+              const val = e.target.value;
+              setPresetId(val);
+              setSavingPreset(true);
+              try {
+                await updateSegmentVideoPreset(seg.id, val || null);
+              } finally {
+                setSavingPreset(false);
+              }
+            }}
+            helperText="Applies on the next run — retry this segment to test it."
+          >
+            <MenuItem value="">Inherit from job</MenuItem>
+            {videoPresets.map((p) => (
+              <MenuItem key={p.id} value={p.id}>{p.name}</MenuItem>
+            ))}
+          </TextField>
         </Box>
 
         {/* Thumbnails */}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -2713,24 +2713,6 @@ function SegmentModal({
           </IconButton>
         </Box>
 
-        {/* ── Video Settings (per-segment override) ── */}
-        <Box sx={{ mt: 2 }}>
-          <TextField
-            select
-            fullWidth
-            label="Video Settings"
-            size="small"
-            value={segVideoPresetId}
-            onChange={(e) => setSegVideoPresetId(e.target.value)}
-            helperText="Inherit the job's settings, or override this segment with a preset."
-          >
-            <MenuItem value="">Inherit from job</MenuItem>
-            {segVideoPresets.map((p) => (
-              <MenuItem key={p.id} value={p.id}>{p.name}</MenuItem>
-            ))}
-          </TextField>
-        </Box>
-
         {/* ── Negative Prompt (accordion) ── */}
         <Accordion defaultExpanded={false} disableGutters sx={accordionSx}>
           <AccordionSummary expandIcon={<ExpandMore />}>
@@ -2779,6 +2761,21 @@ function SegmentModal({
             </Typography>
           </AccordionSummary>
           <AccordionDetails sx={{ pt: 0 }}>
+            <TextField
+              select
+              fullWidth
+              label="Preset"
+              size="small"
+              value={segVideoPresetId}
+              onChange={(e) => setSegVideoPresetId(e.target.value)}
+              helperText="Inherit the job's default, or override this segment with a preset."
+              sx={{ mb: 2 }}
+            >
+              <MenuItem value="">Inherit from job</MenuItem>
+              {segVideoPresets.map((p) => (
+                <MenuItem key={p.id} value={p.id}>{p.name}</MenuItem>
+              ))}
+            </TextField>
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
               <TextField
                 label="Duration"


### PR DESCRIPTION
The per-segment preset dropdown was a separate box above the accordion, with a duplicate 'Video Settings' label. Moved it inside the Video Settings accordion (with Duration/Speed), relabeled 'Preset'.