### PR TITLE
feat: settings signature table + quick-set paste

### DIFF
--- a/src/components/SettingsSignature.tsx
+++ b/src/components/SettingsSignature.tsx
@@ -1,0 +1,76 @@
+import { Box, Tooltip } from "@mui/material";
+
+export type SignatureValues = {
+  lightx2v_strength_high?: number | null;
+  lightx2v_strength_low?: number | null;
+  cfg_high?: number | null;
+  cfg_low?: number | null;
+  steps_total?: number | null;
+  high_noise_steps?: number | null;
+  flow_shift?: number | null;
+};
+
+// Canonical order + abbreviated headers for the 7 sampler params.
+export const SIG_COLS: { key: keyof SignatureValues; label: string; full: string }[] = [
+  { key: "lightx2v_strength_high", label: "LX-H", full: "LightX2V High" },
+  { key: "lightx2v_strength_low", label: "LX-L", full: "LightX2V Low" },
+  { key: "cfg_high", label: "CFG-H", full: "CFG High" },
+  { key: "cfg_low", label: "CFG-L", full: "CFG Low" },
+  { key: "steps_total", label: "Steps", full: "Steps Total" },
+  { key: "high_noise_steps", label: "St-H", full: "High-Noise Steps (high/low split)" },
+  { key: "flow_shift", label: "Flow", full: "Flow Shift" },
+];
+
+// Parse "1,1,3,1,8,4,5" or grouped "1,1 · 3,1 · 8/4 · 5" into the 7 keyed values.
+export function parseSignature(s: string): SignatureValues | null {
+  const nums = s
+    .split(/[^0-9.]+/)
+    .filter((x) => x !== "")
+    .map(Number);
+  if (nums.length !== SIG_COLS.length || nums.some((n) => Number.isNaN(n))) return null;
+  const out: SignatureValues = {};
+  SIG_COLS.forEach((c, i) => (out[c.key] = nums[i]));
+  return out;
+}
+
+export default function SettingsSignature({ values }: { values: SignatureValues }) {
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${SIG_COLS.length}, 1fr)`,
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 1,
+        overflow: "hidden",
+        fontSize: 11,
+        lineHeight: 1.5,
+      }}
+    >
+      {SIG_COLS.map((c) => (
+        <Tooltip key={`h-${c.key}`} title={c.full} arrow>
+          <Box
+            sx={{
+              px: 0.25,
+              py: 0.25,
+              bgcolor: "action.hover",
+              borderBottom: "1px solid",
+              borderColor: "divider",
+              textAlign: "center",
+              fontWeight: 700,
+              color: "text.secondary",
+              cursor: "default",
+            }}
+          >
+            {c.label}
+          </Box>
+        </Tooltip>
+      ))}
+      {SIG_COLS.map((c) => (
+        <Box key={`v-${c.key}`} sx={{ px: 0.25, py: 0.25, textAlign: "center", fontVariantNumeric: "tabular-nums" }}>
+          {values[c.key] ?? "—"}
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -78,6 +78,7 @@ import {
 import { useLoraStore } from "../stores/loraStore";
 import { usePromptPresetStore } from "../stores/promptPresetStore";
 import { useVideoPresetStore } from "../stores/videoPresetStore";
+import SettingsSignature from "../components/SettingsSignature";
 import { useSettingsStore } from "../stores/settingsStore";
 import type {
   JobDetailResponse,
@@ -1985,6 +1986,14 @@ function SegmentDetailModal({
               <MenuItem key={p.id} value={p.id}>{p.name}</MenuItem>
             ))}
           </TextField>
+          {(() => {
+            const p = videoPresets.find((v) => v.id === presetId);
+            return p ? (
+              <Box sx={{ mt: 1 }}>
+                <SettingsSignature values={p} />
+              </Box>
+            ) : null;
+          })()}
         </Box>
 
         {/* Thumbnails */}
@@ -2776,6 +2785,14 @@ function SegmentModal({
                 <MenuItem key={p.id} value={p.id}>{p.name}</MenuItem>
               ))}
             </TextField>
+            {(() => {
+              const p = segVideoPresets.find((v) => v.id === segVideoPresetId);
+              return p ? (
+                <Box sx={{ mb: 2 }}>
+                  <SettingsSignature values={p} />
+                </Box>
+              ) : null;
+            })()}
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
               <TextField
                 label="Duration"

--- a/src/pages/VideoPresetLibrary.tsx
+++ b/src/pages/VideoPresetLibrary.tsx
@@ -13,8 +13,6 @@ import {
   TextField,
   Alert,
   CircularProgress,
-  Chip,
-  Stack,
   Autocomplete,
   MenuItem,
 } from "@mui/material";
@@ -24,6 +22,7 @@ import { useLoraStore } from "../stores/loraStore";
 import { createVideoPreset, updateVideoPreset, deleteVideoPreset, getFileUrl } from "../api/client";
 import type { VideoSettingsPreset, VideoSettingsPresetCreate, LoraListItem } from "../api/types";
 import { MAX_LORAS } from "../constants";
+import SettingsSignature, { parseSignature } from "../components/SettingsSignature";
 
 type LoraSlot = { lora_id: string; name: string; high_weight: number; low_weight: number; preview_image: string | null };
 
@@ -70,6 +69,7 @@ export default function VideoPresetLibrary() {
   const [editing, setEditing] = useState<VideoSettingsPreset | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm());
   const [loraSlots, setLoraSlots] = useState<LoraSlot[]>([]);
+  const [sigInput, setSigInput] = useState("");
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<VideoSettingsPreset | null>(null);
@@ -114,6 +114,7 @@ export default function VideoPresetLibrary() {
     setEditing(null);
     setForm(emptyForm());
     loadLoraSlots(null);
+    setSigInput("");
     setFormError(null);
     setDialogOpen(true);
   };
@@ -121,6 +122,7 @@ export default function VideoPresetLibrary() {
     setEditing(p);
     setForm(presetToForm(p));
     loadLoraSlots(p);
+    setSigInput("");
     setFormError(null);
     setDialogOpen(true);
   };
@@ -195,11 +197,16 @@ export default function VideoPresetLibrary() {
                     </IconButton>
                   </Box>
                 </Box>
-                <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: 1 }}>
-                  {FIELDS.map((x) => (
-                    <Chip key={x.key} size="small" label={`${x.label}: ${p[x.key] ?? "—"}`} />
-                  ))}
-                </Stack>
+                <Box sx={{ mt: 1 }}>
+                  <SettingsSignature values={p} />
+                </Box>
+                {(p.loras?.length || p.sampler_name || p.scheduler) && (
+                  <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: "block" }}>
+                    {p.loras?.length ? `${p.loras.length} LoRA${p.loras.length > 1 ? "s" : ""}` : ""}
+                    {p.sampler_name ? ` · ${p.sampler_name}` : ""}
+                    {p.scheduler ? `/${p.scheduler}` : ""}
+                  </Typography>
+                )}
               </CardContent>
             </Card>
           ))}
@@ -220,6 +227,26 @@ export default function VideoPresetLibrary() {
             sx={{ mt: 1, mb: 2 }}
             value={form.name}
             onChange={(e) => setForm({ ...form, name: e.target.value })}
+          />
+          <TextField
+            label="Quick set — paste a signature"
+            fullWidth
+            size="small"
+            sx={{ mb: 2 }}
+            value={sigInput}
+            placeholder="1,1,3,1,8,4,5"
+            helperText="Order: LX-H, LX-L, CFG-H, CFG-L, Steps, St-H, Flow  (commas, ·, or / all work)"
+            onChange={(e) => {
+              setSigInput(e.target.value);
+              const parsed = parseSignature(e.target.value);
+              if (parsed) {
+                setForm((f) => {
+                  const nf = { ...f };
+                  Object.entries(parsed).forEach(([k, v]) => (nf[k] = String(v)));
+                  return nf;
+                });
+              }
+            }}
           />
           <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
             {FIELDS.map((x) => (


### PR DESCRIPTION
Turns the 7 sampler params into one glanceable, sayable thing:
- **Signature table** (2-row, abbreviated headers over values: LX-H, LX-L, CFG-H, CFG-L, Steps, St-H, Flow) on preset cards and under each per-segment preset dropdown.
- **Quick-set**: paste `1,1,3,1,8,4,5` (commas / · / / all parse) in the preset dialog → fills all 7 fields.
Reusable `SettingsSignature` + `parseSignature`. Console-only, tsc + build clean.