### PR TITLE
feat: editable signature table everywhere + fix invalid sampler name

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -25,6 +25,7 @@ import { useSettingsStore } from "../stores/settingsStore";
 import { useTagStore } from "../stores/tagStore";
 import { usePromptPresetStore } from "../stores/promptPresetStore";
 import { useVideoPresetStore } from "../stores/videoPresetStore";
+import SettingsSignatureInputs from "./SettingsSignatureInputs";
 import { createJob, getFileUrl, getFaceswapPresets, sha256Hex, checkStartingImageExists } from "../api/client";
 import type { JobCreate, LoraListItem, FaceswapPreset, PromptPreset } from "../api/types";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "./FaceswapConfig";
@@ -787,80 +788,29 @@ export default function CreateJobDialog({
                 ))}
               </TextField>
             </Box>
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>
-              <TextField
-                label="LightX2V High"
-                type="number"
-                size="small"
-                value={lightx2vHigh}
-                onChange={(e) => setLightx2vHigh(e.target.value)}
-                sx={{ flex: 1, minWidth: 100 }}
-                slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
-                helperText="1.0–5.6"
-              />
-              <TextField
-                label="LightX2V Low"
-                type="number"
-                size="small"
-                value={lightx2vLow}
-                onChange={(e) => setLightx2vLow(e.target.value)}
-                sx={{ flex: 1, minWidth: 100 }}
-                slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
-                helperText="1.0–2.0"
-              />
-            </Box>
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>
-              <TextField
-                label="CFG High"
-                type="number"
-                size="small"
-                value={cfgHigh}
-                onChange={(e) => setCfgHigh(e.target.value)}
-                sx={{ flex: 1, minWidth: 100 }}
-                slotProps={{ htmlInput: { step: 0.5, min: 0 } }}
-                helperText="High noise"
-              />
-              <TextField
-                label="CFG Low"
-                type="number"
-                size="small"
-                value={cfgLow}
-                onChange={(e) => setCfgLow(e.target.value)}
-                sx={{ flex: 1, minWidth: 100 }}
-                slotProps={{ htmlInput: { step: 0.5, min: 0 } }}
-                helperText="Low noise"
-              />
-            </Box>
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>
-              <TextField
-                label="Steps Total"
-                type="number"
-                size="small"
-                value={stepsTotal}
-                onChange={(e) => setStepsTotal(e.target.value)}
-                sx={{ flex: 1, minWidth: 100 }}
-                slotProps={{ htmlInput: { step: 1, min: 1 } }}
-                helperText="Total steps (4=distilled; raise + drop Lightning for CFG)"
-              />
-              <TextField
-                label="High-Noise Steps"
-                type="number"
-                size="small"
-                value={highNoiseSteps}
-                onChange={(e) => setHighNoiseSteps(e.target.value)}
-                sx={{ flex: 1, minWidth: 100 }}
-                slotProps={{ htmlInput: { step: 1, min: 0 } }}
-                helperText="High/low split boundary"
-              />
-              <TextField
-                label="Flow Shift"
-                type="number"
-                size="small"
-                value={flowShift}
-                onChange={(e) => setFlowShift(e.target.value)}
-                sx={{ flex: 1, minWidth: 100 }}
-                slotProps={{ htmlInput: { step: 0.5, min: 1 } }}
-                helperText="Motion: 5=default, raise ~8-10 for more"
+            <Box sx={{ mt: 1.5 }}>
+              <SettingsSignatureInputs
+                values={{
+                  lightx2v_strength_high: lightx2vHigh,
+                  lightx2v_strength_low: lightx2vLow,
+                  cfg_high: cfgHigh,
+                  cfg_low: cfgLow,
+                  steps_total: stepsTotal,
+                  high_noise_steps: highNoiseSteps,
+                  flow_shift: flowShift,
+                }}
+                onChange={(k, v) => {
+                  const setters: Record<string, (val: string) => void> = {
+                    lightx2v_strength_high: setLightx2vHigh,
+                    lightx2v_strength_low: setLightx2vLow,
+                    cfg_high: setCfgHigh,
+                    cfg_low: setCfgLow,
+                    steps_total: setStepsTotal,
+                    high_noise_steps: setHighNoiseSteps,
+                    flow_shift: setFlowShift,
+                  };
+                  setters[k]?.(v);
+                }}
               />
             </Box>
           </AccordionDetails>

--- a/src/components/SettingsSignatureInputs.tsx
+++ b/src/components/SettingsSignatureInputs.tsx
@@ -1,0 +1,40 @@
+import { Box, Tooltip, TextField } from "@mui/material";
+import { SIG_COLS } from "./SettingsSignature";
+
+// Editable version of the signature table: abbreviated headers over a row of number inputs.
+export default function SettingsSignatureInputs({
+  values,
+  onChange,
+}: {
+  values: Record<string, string>;
+  onChange: (key: string, value: string) => void;
+}) {
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${SIG_COLS.length}, minmax(52px, 1fr))`,
+        gap: 0.75,
+        alignItems: "end",
+      }}
+    >
+      {SIG_COLS.map((c) => (
+        <Tooltip key={`h-${c.key}`} title={c.full} arrow>
+          <Box sx={{ fontSize: 11, fontWeight: 700, color: "text.secondary", textAlign: "center", cursor: "default" }}>
+            {c.label}
+          </Box>
+        </Tooltip>
+      ))}
+      {SIG_COLS.map((c) => (
+        <TextField
+          key={`v-${c.key}`}
+          type="number"
+          size="small"
+          value={values[c.key] ?? ""}
+          onChange={(e) => onChange(c.key, e.target.value)}
+          slotProps={{ htmlInput: { style: { textAlign: "center", padding: "6px 4px" } } }}
+        />
+      ))}
+    </Box>
+  );
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { useTagStore } from "../stores/tagStore";
+import SettingsSignatureInputs from "../components/SettingsSignatureInputs";
 import { useSettingsStore } from "../stores/settingsStore";
 
 export default function SettingsPage() {
@@ -204,80 +205,29 @@ export default function SettingsPage() {
             </Box>
           ) : (
             <>
-              <Box sx={{ display: "flex", gap: 2, maxWidth: 500, flexWrap: "wrap" }}>
-                <TextField
-                  label="LightX2V High"
-                  type="number"
-                  size="small"
-                  value={defaultLightx2vHigh}
-                  onChange={(e) => setDefaultLightx2vHigh(e.target.value)}
-                  slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
-                  helperText="Range: 1.0–5.6"
-                  sx={{ flex: 1, minWidth: 110 }}
-                />
-                <TextField
-                  label="LightX2V Low"
-                  type="number"
-                  size="small"
-                  value={defaultLightx2vLow}
-                  onChange={(e) => setDefaultLightx2vLow(e.target.value)}
-                  slotProps={{ htmlInput: { step: 0.1, min: 0 } }}
-                  helperText="Range: 1.0–2.0"
-                  sx={{ flex: 1, minWidth: 110 }}
-                />
-              </Box>
-              <Box sx={{ display: "flex", gap: 2, maxWidth: 500, mt: 2, flexWrap: "wrap" }}>
-                <TextField
-                  label="CFG High"
-                  type="number"
-                  size="small"
-                  value={defaultCfgHigh}
-                  onChange={(e) => setDefaultCfgHigh(e.target.value)}
-                  slotProps={{ htmlInput: { step: 0.5, min: 0 } }}
-                  helperText="High noise sampler"
-                  sx={{ flex: 1, minWidth: 110 }}
-                />
-                <TextField
-                  label="CFG Low"
-                  type="number"
-                  size="small"
-                  value={defaultCfgLow}
-                  onChange={(e) => setDefaultCfgLow(e.target.value)}
-                  slotProps={{ htmlInput: { step: 0.5, min: 0 } }}
-                  helperText="Low noise sampler"
-                  sx={{ flex: 1, minWidth: 110 }}
-                />
-              </Box>
-              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 2 }}>
-                <TextField
-                  label="Steps Total"
-                  type="number"
-                  size="small"
-                  value={defaultStepsTotal}
-                  onChange={(e) => setDefaultStepsTotal(e.target.value)}
-                  slotProps={{ htmlInput: { step: 1, min: 1 } }}
-                  helperText="Total sampler steps"
-                  sx={{ flex: 1, minWidth: 110 }}
-                />
-                <TextField
-                  label="High-Noise Steps"
-                  type="number"
-                  size="small"
-                  value={defaultHighNoiseSteps}
-                  onChange={(e) => setDefaultHighNoiseSteps(e.target.value)}
-                  slotProps={{ htmlInput: { step: 1, min: 0 } }}
-                  helperText="High/low split boundary"
-                  sx={{ flex: 1, minWidth: 110 }}
-                />
-                <TextField
-                  label="Flow Shift"
-                  type="number"
-                  size="small"
-                  value={defaultFlowShift}
-                  onChange={(e) => setDefaultFlowShift(e.target.value)}
-                  slotProps={{ htmlInput: { step: 0.5, min: 1 } }}
-                  helperText="Motion schedule shift"
-                  sx={{ flex: 1, minWidth: 110 }}
+              <Box sx={{ maxWidth: 560 }}>
+                <SettingsSignatureInputs
+                  values={{
+                    lightx2v_strength_high: defaultLightx2vHigh,
+                    lightx2v_strength_low: defaultLightx2vLow,
+                    cfg_high: defaultCfgHigh,
+                    cfg_low: defaultCfgLow,
+                    steps_total: defaultStepsTotal,
+                    high_noise_steps: defaultHighNoiseSteps,
+                    flow_shift: defaultFlowShift,
+                  }}
+                  onChange={(k, v) => {
+                    const setters: Record<string, (val: string) => void> = {
+                      lightx2v_strength_high: setDefaultLightx2vHigh,
+                      lightx2v_strength_low: setDefaultLightx2vLow,
+                      cfg_high: setDefaultCfgHigh,
+                      cfg_low: setDefaultCfgLow,
+                      steps_total: setDefaultStepsTotal,
+                      high_noise_steps: setDefaultHighNoiseSteps,
+                      flow_shift: setDefaultFlowShift,
+                    };
+                    setters[k]?.(v);
+                  }}
                 />
               </Box>
               <TextField

--- a/src/pages/VideoPresetLibrary.tsx
+++ b/src/pages/VideoPresetLibrary.tsx
@@ -23,6 +23,7 @@ import { createVideoPreset, updateVideoPreset, deleteVideoPreset, getFileUrl } f
 import type { VideoSettingsPreset, VideoSettingsPresetCreate, LoraListItem } from "../api/types";
 import { MAX_LORAS } from "../constants";
 import SettingsSignature, { parseSignature } from "../components/SettingsSignature";
+import SettingsSignatureInputs from "../components/SettingsSignatureInputs";
 
 type LoraSlot = { lora_id: string; name: string; high_weight: number; low_weight: number; preview_image: string | null };
 
@@ -47,7 +48,7 @@ const FIELDS: { key: ParamKey; label: string }[] = [
 
 type FormState = Record<string, string>;
 
-const SAMPLERS = ["euler", "dpmpp_2m", "dpmpp_sde", "dpmpp_2m_sde", "unipc", "res_multistep"];
+const SAMPLERS = ["euler", "dpmpp_2m", "dpmpp_sde", "dpmpp_2m_sde", "uni_pc", "res_multistep"];
 const SCHEDULERS = ["simple", "normal", "karras", "beta", "sgm_uniform"];
 
 function emptyForm(): FormState {
@@ -248,19 +249,10 @@ export default function VideoPresetLibrary() {
               }
             }}
           />
-          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-            {FIELDS.map((x) => (
-              <TextField
-                key={x.key}
-                label={x.label}
-                type="number"
-                size="small"
-                sx={{ width: 150 }}
-                value={form[x.key]}
-                onChange={(e) => setForm({ ...form, [x.key]: e.target.value })}
-              />
-            ))}
-          </Box>
+          <SettingsSignatureInputs
+            values={form}
+            onChange={(k, v) => setForm((f) => ({ ...f, [k]: v }))}
+          />
 
           <Box sx={{ display: "flex", gap: 2, mt: 2 }}>
             <TextField


### PR DESCRIPTION
Converts the three remaining spots that still used individual inputs to the **editable signature table** (headers over an input row): Settings → Job Defaults, Edit Preset dialog, and CreateJobDialog's Video Settings. New reusable `SettingsSignatureInputs`. Also fixes the sampler dropdown offering `unipc` (invalid KSampler name; should be `uni_pc`). tsc + build clean.