### PR TITLE
feat: 'Extra' accordion (Negative Prompt + Faceswap + Tags)

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -9,6 +9,7 @@ import {
   Card,
   Button,
   Dialog,
+  Divider,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -549,43 +550,6 @@ export default function CreateJobDialog({
           </IconButton>
         </Box>
 
-        {/* ── Negative Prompt (accordion) ── */}
-        <Accordion defaultExpanded={false} disableGutters sx={accordionSx}>
-          <AccordionSummary expandIcon={<ExpandMore />}>
-            <Typography variant="subtitle2">
-              Negative Prompt
-              {negativePrompt && (
-                <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
-                  {negativePrompt.length > 60 ? negativePrompt.slice(0, 60) + '…' : negativePrompt}
-                </Typography>
-              )}
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails sx={{ pt: 0 }}>
-            <TextField
-              label="Negative Prompt"
-              fullWidth
-              multiline
-              rows={3}
-              value={negativePrompt}
-              onChange={(e) => setNegativePrompt(e.target.value)}
-              helperText="Passed as negative conditioning to ComfyUI"
-            />
-            <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: -0.5 }}>
-              <IconButton
-                size="small"
-                onClick={() => setNegativePrompt("")}
-                disabled={!negativePrompt}
-                sx={{ color: "text.disabled", p: 0.25 }}
-                title="Clear negative prompt"
-                aria-label="Clear negative prompt"
-              >
-                <ClearOutlined sx={{ fontSize: 14 }} />
-              </IconButton>
-            </Box>
-          </AccordionDetails>
-        </Accordion>
-
         {/* ── Video Settings (accordion) ── */}
         <Accordion defaultExpanded={false} disableGutters sx={accordionSx}>
           <AccordionSummary expandIcon={<ExpandMore />}>
@@ -920,12 +884,49 @@ export default function CreateJobDialog({
           </AccordionDetails>
         </Accordion>
 
-        {/* ── Tags (accordion, collapsed by default) ── */}
-        <Accordion defaultExpanded={false} sx={accordionSx}>
+        {/* ── Extra (accordion): Negative Prompt · Faceswap · Tags ── */}
+        <Accordion defaultExpanded={false} disableGutters sx={accordionSx}>
           <AccordionSummary expandIcon={<ExpandMore />}>
-            <Typography variant="subtitle2">Tags</Typography>
+            <Typography variant="subtitle2">Extra</Typography>
           </AccordionSummary>
-          <AccordionDetails>
+          <AccordionDetails sx={{ pt: 0 }}>
+            {/* Negative Prompt */}
+            <TextField
+              label="Negative Prompt"
+              fullWidth
+              multiline
+              rows={3}
+              value={negativePrompt}
+              onChange={(e) => setNegativePrompt(e.target.value)}
+              helperText="Passed as negative conditioning to ComfyUI"
+            />
+            <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: -0.5 }}>
+              <IconButton
+                size="small"
+                onClick={() => setNegativePrompt("")}
+                disabled={!negativePrompt}
+                sx={{ color: "text.disabled", p: 0.25 }}
+                title="Clear negative prompt"
+                aria-label="Clear negative prompt"
+              >
+                <ClearOutlined sx={{ fontSize: 14 }} />
+              </IconButton>
+            </Box>
+
+            <Divider sx={{ my: 2 }} />
+
+            {/* Faceswap */}
+            <FaceswapConfig
+              state={faceswap}
+              onChange={setFaceswap}
+              presets={faceswapPresets}
+              disableStartFrame={!startingImage && !startingImageUri}
+              inline
+            />
+
+            <Divider sx={{ my: 2 }} />
+
+            {/* Tags */}
             <TextField
               label="Tags"
               fullWidth
@@ -937,15 +938,6 @@ export default function CreateJobDialog({
             />
           </AccordionDetails>
         </Accordion>
-
-        {/* ── Faceswap (accordion) ── */}
-        <FaceswapConfig
-          state={faceswap}
-          onChange={setFaceswap}
-          presets={faceswapPresets}
-          accordionSx={accordionSx}
-          disableStartFrame={!startingImage && !startingImageUri}
-        />
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>

--- a/src/components/FaceswapConfig.tsx
+++ b/src/components/FaceswapConfig.tsx
@@ -52,6 +52,8 @@ interface FaceswapConfigProps {
   defaultExpanded?: boolean;
   disableStartFrame?: boolean;
   existingImageName?: string | null;
+  /** Render the controls inline (a labelled section) instead of wrapped in an Accordion. */
+  inline?: boolean;
 }
 
 export default function FaceswapConfig({
@@ -62,21 +64,13 @@ export default function FaceswapConfig({
   defaultExpanded = false,
   disableStartFrame = false,
   existingImageName,
+  inline = false,
 }: FaceswapConfigProps) {
   const update = (patch: Partial<FaceswapConfigState>) =>
     onChange({ ...state, ...patch });
 
-  return (
-    <Accordion defaultExpanded={defaultExpanded} disableGutters sx={accordionSx}>
-      <AccordionSummary expandIcon={<ExpandMore />}>
-        <Typography variant="subtitle2">
-          Faceswap
-          <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
-            {state.enabled ? `ON — ${state.method}` : "OFF"}
-          </Typography>
-        </Typography>
-      </AccordionSummary>
-      <AccordionDetails sx={{ pt: 0 }}>
+  const body = (
+    <>
         <FormControlLabel
           control={
             <Switch
@@ -201,7 +195,31 @@ export default function FaceswapConfig({
             )}
           </Box>
         )}
-      </AccordionDetails>
+    </>
+  );
+
+  const header = (
+    <Typography variant="subtitle2">
+      Faceswap
+      <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+        {state.enabled ? `ON — ${state.method}` : "OFF"}
+      </Typography>
+    </Typography>
+  );
+
+  if (inline) {
+    return (
+      <Box>
+        <Box sx={{ mb: 1 }}>{header}</Box>
+        {body}
+      </Box>
+    );
+  }
+
+  return (
+    <Accordion defaultExpanded={defaultExpanded} disableGutters sx={accordionSx}>
+      <AccordionSummary expandIcon={<ExpandMore />}>{header}</AccordionSummary>
+      <AccordionDetails sx={{ pt: 0 }}>{body}</AccordionDetails>
     </Accordion>
   );
 }


### PR DESCRIPTION
New-job modal cleanup: Negative Prompt, Faceswap, and Tags no longer each have their own accordion. They're consolidated into a single **Extra** accordion at the bottom of the modal, with a divider between each section. `FaceswapConfig` gains an `inline` prop so it renders as a labelled section rather than its own accordion. Build clean.