### PR TITLE
feat(ar): 2.5D depth flavor — selector + displaced WebXR mesh

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -177,6 +177,7 @@ export interface SegmentResponse {
   video_preset_id: string | null;
   output_path: string | null;
   last_frame_path: string | null;
+  hologram_flavor: string | null;
   hologram_video_path: string | null;
   hologram_manifest_path: string | null;
   hologram_poster_path: string | null;
@@ -191,6 +192,7 @@ export interface SegmentResponse {
 export interface HologramRequest {
   subject_height_m?: number;
   key_color?: string;
+  flavor?: string; // "2d_matte" (default) | "2.5d_depth"
 }
 
 export interface HologramUvRect {
@@ -202,6 +204,7 @@ export interface HologramUvRect {
 
 export interface HologramManifest {
   tier: number;
+  flavor?: string; // "2d_matte" | "2.5d_depth"
   layout: string;
   codec: string;
   fps: number;
@@ -209,6 +212,10 @@ export interface HologramManifest {
   video_height: number;
   region_color_uv: HologramUvRect;
   region_alpha_uv: HologramUvRect;
+  region_depth_uv?: HologramUvRect; // 2.5d_depth only
+  depth_encoding?: string;
+  depth_near_is?: string; // "bright"
+  depth_scale_m?: number; // relief in meters
   guard_px: number;
   crop_rect: { x: number; y: number; w: number; h: number };
   subject_px_height: number;

--- a/src/components/HologramConfig.tsx
+++ b/src/components/HologramConfig.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -7,6 +7,8 @@ import {
   Button,
   TextField,
   Slider,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from "@mui/material";
 import type { HologramRequest } from "../api/types";
@@ -16,14 +18,22 @@ export default function HologramConfig({
   onClose,
   onSubmit,
   busy,
+  initialFlavor = "2d_matte",
 }: {
   open: boolean;
   onClose: () => void;
   onSubmit: (body: HologramRequest) => void;
   busy?: boolean;
+  initialFlavor?: string;
 }) {
   const [height, setHeight] = useState(1.7);
   const [keyColor, setKeyColor] = useState("0x00b140");
+  const [flavor, setFlavor] = useState(initialFlavor);
+
+  // Reflect the current hologram's flavor each time the dialog opens (e.g. "Remake…").
+  useEffect(() => {
+    if (open) setFlavor(initialFlavor);
+  }, [open, initialFlavor]);
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
@@ -33,6 +43,23 @@ export default function HologramConfig({
           Matte this clip’s subject and pack it as a color+alpha hologram you can place life-size
           in your room on the Quest 3. Green-screen clips are chroma-keyed; any other background is
           matted automatically (RVM).
+        </Typography>
+        <Typography variant="subtitle2" gutterBottom>Flavor</Typography>
+        <ToggleButtonGroup
+          value={flavor}
+          exclusive
+          fullWidth
+          size="small"
+          onChange={(_, v) => v && setFlavor(v)}
+          sx={{ mb: 1 }}
+        >
+          <ToggleButton value="2d_matte">2D Matte (flat)</ToggleButton>
+          <ToggleButton value="2.5d_depth">2.5D Depth (parallax)</ToggleButton>
+        </ToggleButtonGroup>
+        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 2 }}>
+          {flavor === "2.5d_depth"
+            ? "Adds head-motion parallax + volume via a depth-displaced mesh (front-view only; 3090-only, slower to build)."
+            : "Flat photoreal standee — fastest, works from every angle but reads flat when you move."}
         </Typography>
         <Typography gutterBottom>Subject height: {height.toFixed(2)} m</Typography>
         <Slider
@@ -60,7 +87,7 @@ export default function HologramConfig({
         <Button
           variant="contained"
           disabled={busy}
-          onClick={() => onSubmit({ subject_height_m: height, key_color: keyColor })}
+          onClick={() => onSubmit({ subject_height_m: height, key_color: keyColor, flavor })}
         >
           {busy ? "Starting…" : "Make Hologram"}
         </Button>

--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -33,6 +33,40 @@ const FRAGMENT = /* glsl */ `
   }
 `;
 
+// 2.5d_depth: subdivided plane whose vertices are pushed toward the viewer by the packed depth
+// region (bright = near). GLSL3 so we can use textureLod (vertex-stage texture fetch needs an
+// explicit LOD). The 2d path above stays on the default GLSL1 shaders.
+const DEPTH_VERTEX = /* glsl */ `
+  uniform sampler2D map;
+  uniform vec4 depthRect;
+  uniform float depthScale;
+  out vec2 vUv;
+  void main() {
+    vUv = uv;
+    vec2 duv = vec2(depthRect.x + uv.x * depthRect.z, depthRect.y + (1.0 - uv.y) * depthRect.w);
+    float d = textureLod(map, duv, 0.0).r; // 0 = far/background, 1 = nearest
+    vec3 p = position + vec3(0.0, 0.0, d * depthScale);
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(p, 1.0);
+  }
+`;
+
+const DEPTH_FRAGMENT = /* glsl */ `
+  uniform sampler2D map;
+  uniform vec4 colorRect;
+  uniform vec4 alphaRect;
+  uniform float edgeMin;
+  uniform float edgeMax;
+  in vec2 vUv;
+  out vec4 fragColor;
+  void main() {
+    vec2 cuv = vec2(colorRect.x + vUv.x * colorRect.z, colorRect.y + (1.0 - vUv.y) * colorRect.w);
+    vec2 auv = vec2(alphaRect.x + vUv.x * alphaRect.z, alphaRect.y + (1.0 - vUv.y) * alphaRect.w);
+    vec3 color = texture(map, cuv).rgb;
+    float a = smoothstep(edgeMin, edgeMax, texture(map, auv).r);
+    fragColor = vec4(color * a, a); // premultiplied
+  }
+`;
+
 function radialShadowTexture(): THREE.Texture {
   const s = 128;
   const cv = document.createElement("canvas");
@@ -74,27 +108,40 @@ async function startArSession(
 
   const c = manifest.region_color_uv;
   const a = manifest.region_alpha_uv;
+  const depthRect = manifest.region_depth_uv;
+  const isDepth = manifest.flavor === "2.5d_depth" && !!depthRect;
+
+  const uniforms: Record<string, { value: unknown }> = {
+    map: { value: videoTex },
+    colorRect: { value: new THREE.Vector4(c.x, c.y, c.w, c.h) },
+    alphaRect: { value: new THREE.Vector4(a.x, a.y, a.w, a.h) },
+    edgeMin: { value: 0.05 },
+    edgeMax: { value: 0.95 },
+  };
+  if (isDepth && depthRect) {
+    uniforms.depthRect = { value: new THREE.Vector4(depthRect.x, depthRect.y, depthRect.w, depthRect.h) };
+    uniforms.depthScale = { value: manifest.depth_scale_m ?? 0.12 };
+  }
   const material = new THREE.ShaderMaterial({
-    uniforms: {
-      map: { value: videoTex },
-      colorRect: { value: new THREE.Vector4(c.x, c.y, c.w, c.h) },
-      alphaRect: { value: new THREE.Vector4(a.x, a.y, a.w, a.h) },
-      edgeMin: { value: 0.05 },
-      edgeMax: { value: 0.95 },
-    },
-    vertexShader: VERTEX,
-    fragmentShader: FRAGMENT,
+    uniforms,
+    vertexShader: isDepth ? DEPTH_VERTEX : VERTEX,
+    fragmentShader: isDepth ? DEPTH_FRAGMENT : FRAGMENT,
+    glslVersion: isDepth ? THREE.GLSL3 : undefined,
     transparent: true,
     premultipliedAlpha: true,
     side: THREE.DoubleSide,
     depthWrite: false,
   });
 
-  // Life-size quad: height = subject_height_m, width from crop aspect.
+  // Life-size mesh: height = subject_height_m, width from crop aspect. The depth flavor uses a
+  // subdivided plane so the vertex shader can displace it into relief; 2d stays a single quad.
   const height = manifest.subject_height_m || 1.7;
   const aspect = manifest.crop_rect.w / manifest.crop_rect.h;
   const width = height * aspect;
-  const quad = new THREE.Mesh(new THREE.PlaneGeometry(width, height), material);
+  const geometry = isDepth
+    ? new THREE.PlaneGeometry(width, height, 96, 160)
+    : new THREE.PlaneGeometry(width, height);
+  const quad = new THREE.Mesh(geometry, material);
   quad.position.y = height / 2; // base sits on the floor
 
   const shadow = new THREE.Mesh(
@@ -176,6 +223,7 @@ async function startArSession(
     video.pause();
     videoTex.dispose();
     material.dispose();
+    geometry.dispose();
     renderer.dispose();
     if (renderer.domElement.parentElement === container) container.removeChild(renderer.domElement);
     onEnd();

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -737,15 +737,18 @@ export default function JobDetail() {
             const holoSeg = job.segments?.find((s) => s.hologram_video_path);
             const holoUrl = holoSeg ? `${window.location.origin}/holo/${holoSeg.id}` : null;
             const building = !holoSeg && job.segments?.some((s) => s.reprocess_type === "ar_hologram");
+            const flavorLabel = holoSeg?.hologram_flavor === "2.5d_depth" ? "2.5D Depth" : "2D Matte";
             return (
               <Box sx={{ mt: 1.5, display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}>
                 {holoUrl ? (
                   <>
+                    <Chip size="small" label={flavorLabel} variant="outlined" />
                     <Button size="small" variant="contained" startIcon={<ViewInAr />} component="a" href={holoUrl} target="_blank">
                       Open in AR
                     </Button>
                     <QRCodeCanvas value={holoUrl} size={128} />
                     <Typography variant="caption" color="text.secondary">Scan on your Quest 3</Typography>
+                    <Button size="small" onClick={() => setHoloOpen(true)}>Remake…</Button>
                   </>
                 ) : building ? (
                   <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
@@ -769,6 +772,7 @@ export default function JobDetail() {
           onClose={() => setHoloOpen(false)}
           onSubmit={handleMakeHologram}
           busy={holoBusy}
+          initialFlavor={job.segments?.find((s) => s.hologram_video_path)?.hologram_flavor ?? "2d_matte"}
         />
       </Box>
 


### PR DESCRIPTION
Third of 3 PRs for **AR Tier-1 (2.5D depth)** (with api #119 + daemon #76). Completes the feature.

- **HologramConfig** — flavor toggle (2D Matte / 2.5D Depth) with a one-liner on the tradeoff; resets to the current flavor when reopened; sends `flavor`.
- **JobDetail** — shows the active flavor chip + a **Remake…** button (regenerate overwrites the single artifact → one flavor per video); seeds the dialog with the current flavor.
- **HologramPlayer** — branches on `manifest.flavor`. `2.5d_depth` builds a subdivided `PlaneGeometry(96×160)` + a **GLSL3 vertex shader** that samples the packed depth region via `textureLod` and pushes each vertex toward the viewer by `depth_scale_m` (bright = near). The flat 2D path + its GLSL1 shaders are untouched.
- types updated (manifest depth fields, request flavor, segment flavor).

tsc + vite build clean. The shader needs on-device (Quest 3) validation — can't compile WebXR here.