### PR TITLE
fix: always label segment video-settings (preset name or Custom)

### DIFF
--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -997,11 +997,18 @@ export default function JobDetail() {
                         const vs = segVideoSettings(seg);
                         return (
                           <>
-                            {vs.presetName && (
-                              <Typography variant="caption" sx={{ fontWeight: 600, display: "block", mb: 0.5 }}>
-                                {vs.presetName}
-                              </Typography>
-                            )}
+                            <Typography
+                              variant="caption"
+                              sx={{
+                                display: "block",
+                                mb: 0.5,
+                                fontWeight: vs.presetName ? 600 : 400,
+                                fontStyle: vs.presetName ? "normal" : "italic",
+                                color: vs.presetName ? "text.primary" : "text.secondary",
+                              }}
+                            >
+                              {vs.presetName ?? "Custom"}
+                            </Typography>
                             <SettingsSignature values={vs.values} />
                             {vs.loras.length > 0 && (
                               <Box sx={{ mt: 0.5 }}>
@@ -1421,11 +1428,18 @@ export default function JobDetail() {
                       const vs = segVideoSettings(seg);
                       return (
                         <Box sx={{ mb: 0.5 }}>
-                          {vs.presetName && (
-                            <Typography variant="caption" sx={{ fontWeight: 600, display: "block", mb: 0.5 }}>
-                              {vs.presetName}
-                            </Typography>
-                          )}
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              display: "block",
+                              mb: 0.5,
+                              fontWeight: vs.presetName ? 600 : 400,
+                              fontStyle: vs.presetName ? "normal" : "italic",
+                              color: vs.presetName ? "text.primary" : "text.secondary",
+                            }}
+                          >
+                            {vs.presetName ?? "Custom"}
+                          </Typography>
                           <SettingsSignature values={vs.values} />
                           {vs.loras.length > 0 && (
                             <Box sx={{ mt: 0.5 }}>


### PR DESCRIPTION
The recipe name above the segment settings table only showed when a preset was attached; raw/Custom runs (and next-segments that didn't inherit the job's preset) showed a bare table, which read as 'the name disappeared.' Now every table gets a header line — the **preset name** when one resolves (`seg.video_preset_id ?? job.video_preset_id`), else an italic **Custom**. Build clean.