### PR TITLE
feat: require a video preset (retire Custom/raw path)

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -25,7 +25,7 @@ import { useLoraStore } from "../stores/loraStore";
 import { useSettingsStore } from "../stores/settingsStore";
 import { useTagStore } from "../stores/tagStore";
 import { useVideoPresetStore } from "../stores/videoPresetStore";
-import SettingsSignatureInputs from "./SettingsSignatureInputs";
+import SettingsSignature from "./SettingsSignature";
 import { createJob, getFileUrl, getFaceswapPresets, sha256Hex, checkStartingImageExists } from "../api/client";
 import type { JobCreate, LoraListItem, FaceswapPreset } from "../api/types";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "./FaceswapConfig";
@@ -342,6 +342,10 @@ export default function CreateJobDialog({
   const handleSubmit = async () => {
     if (!name.trim() || !prompt.trim()) {
       setError("Name and prompt are required");
+      return;
+    }
+    if (!videoPresetId) {
+      setError("Select a video preset");
       return;
     }
     if (!startingImage && !startingImageUri) {
@@ -679,38 +683,26 @@ export default function CreateJobDialog({
                 value={videoPresetId}
                 onChange={(e) => applyVideoPreset(e.target.value)}
                 sx={{ minWidth: 240 }}
-                helperText="Job default — manage in Video Presets. Custom = raw values below."
+                error={!videoPresetId}
+                helperText="Required — the recipe this job runs. Edit values in Video Presets."
               >
-                <MenuItem value="">Custom</MenuItem>
+                <MenuItem value="" disabled>Select a preset…</MenuItem>
                 {videoPresets.map((p) => (
                   <MenuItem key={p.id} value={p.id}>{p.name}</MenuItem>
                 ))}
               </TextField>
             </Box>
             <Box sx={{ mt: 1.5 }}>
-              <SettingsSignatureInputs
-                values={{
-                  lightx2v_strength_high: lightx2vHigh,
-                  lightx2v_strength_low: lightx2vLow,
-                  cfg_high: cfgHigh,
-                  cfg_low: cfgLow,
-                  steps_total: stepsTotal,
-                  high_noise_steps: highNoiseSteps,
-                  flow_shift: flowShift,
-                }}
-                onChange={(k, v) => {
-                  const setters: Record<string, (val: string) => void> = {
-                    lightx2v_strength_high: setLightx2vHigh,
-                    lightx2v_strength_low: setLightx2vLow,
-                    cfg_high: setCfgHigh,
-                    cfg_low: setCfgLow,
-                    steps_total: setStepsTotal,
-                    high_noise_steps: setHighNoiseSteps,
-                    flow_shift: setFlowShift,
-                  };
-                  setters[k]?.(v);
-                }}
-              />
+              {(() => {
+                const p = videoPresets.find((v) => v.id === videoPresetId);
+                return p ? (
+                  <SettingsSignature values={p} />
+                ) : (
+                  <Typography variant="caption" color="text.secondary">
+                    Select a preset to see its settings.
+                  </Typography>
+                );
+              })()}
             </Box>
           </AccordionDetails>
         </Accordion>

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -1904,6 +1904,10 @@ function SegmentModal({
   useEffect(() => {
     if (open && lastSegment) {
       setPrompt(lastSegment.prompt_template ?? lastSegment.prompt);
+      // Carry the recipe forward: pre-select the previous segment's (or job's) preset so every
+      // segment explicitly names a recipe. Set directly (no applySegVideoPreset) to keep the
+      // continuation prompt from being overwritten by the preset's default prompt.
+      setSegVideoPresetId(lastSegment.video_preset_id ?? job?.video_preset_id ?? "");
       setDuration(lastSegment.duration_seconds);
       setSpeed(lastSegment.speed);
       const srcType = lastSegment.faceswap_source_type === "preset"


### PR DESCRIPTION
Per the decision that a segment must **always** show a preset name.

- **CreateJobDialog**: Video Preset is now **required** — disabled "Select a preset…" placeholder, no "Custom" option, submit blocked without one. The editable raw sampler table becomes a **read-only** signature of the selected preset; to try a variant you edit/save a preset.
- **Add-Segment**: pre-selects the previous segment's (or job's) preset so each segment explicitly carries a recipe — set directly so it doesn't overwrite the carried-forward continuation prompt.

Because the row resolves `seg.video_preset_id ?? job.video_preset_id`, requiring it at job creation guarantees every segment (own or inherited) shows a name. Old Custom jobs still read "Custom" (historical). Build clean.