### PR TITLE
feat(vace): continuation toggle in the job dialog

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -102,6 +102,7 @@ export interface JobCreate {
   high_noise_steps?: number | null;
   flow_shift?: number | null;
   video_preset_id?: string | null;
+  continuation_mode?: string | null; // "vace" | "traditional"
   starting_image_uri?: string | null;
   starting_image_hash?: string | null;
   first_segment: SegmentCreate;
@@ -125,6 +126,8 @@ export interface JobResponse {
   fps: number;
   seed: number;
   starting_image: string | null;
+  continuation_mode?: string | null;
+  identity_reference_image?: string | null;
   lightx2v_strength_high: number | null;
   lightx2v_strength_low: number | null;
   cfg_high: number | null;

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -10,6 +10,8 @@ import {
   Button,
   Dialog,
   Divider,
+  FormControlLabel,
+  Switch,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -125,6 +127,7 @@ export default function CreateJobDialog({
   const [highNoiseSteps, setHighNoiseSteps] = useState(defaultHighNoiseSteps);
   const [flowShift, setFlowShift] = useState(defaultFlowShift);
   const [videoPresetId, setVideoPresetId] = useState("");
+  const [vaceContinuation, setVaceContinuation] = useState(false);
   const [startingImage, setStartingImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [startingImageUri, setStartingImageUri] = useState<string | null>(null);
@@ -283,6 +286,7 @@ export default function CreateJobDialog({
     setImagePreview(null);
     setStartingImageUri(null);
     setFaceswap(defaultFaceswapState({ sourceType: DEFAULT_FACESWAP_SOURCE_TYPE }));
+    setVaceContinuation(false);
     setLoras([]);
     setSelectedTag1("");
     setSelectedTag2("");
@@ -383,6 +387,7 @@ export default function CreateJobDialog({
         high_noise_steps: highNoiseSteps ? parseInt(highNoiseSteps, 10) : null,
         flow_shift: flowShift ? parseFloat(flowShift) : null,
         video_preset_id: videoPresetId || null,
+        continuation_mode: vaceContinuation ? "vace" : null,
         starting_image_uri: !startingImage && startingImageUri ? startingImageUri : null,
         starting_image_hash: reuseHash,
         tags: tags || null,
@@ -703,6 +708,22 @@ export default function CreateJobDialog({
                   </Typography>
                 );
               })()}
+            </Box>
+            <Box sx={{ mt: 1 }}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={vaceContinuation}
+                    onChange={(e) => setVaceContinuation(e.target.checked)}
+                    size="small"
+                  />
+                }
+                label="VACE continuation (identity-anchored)"
+              />
+              <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: -0.5 }}>
+                Multi-segment: continue motion from the last frame but anchor the face to a canonical
+                crop from seg0 (holds identity across cuts). ≤480–512p, 3090-only.
+              </Typography>
             </Box>
           </AccordionDetails>
         </Accordion>


### PR DESCRIPTION
Third of 3 PRs (with api #120 + daemon #77). Completes **identity-anchored VACE continuation**.

- A **"VACE continuation (identity-anchored)"** switch in the Video Settings section → sets `job.continuation_mode = "vace"`.
- When on, multi-segment jobs run the VACE path: motion continues from the last frame, but the face is anchored to the canonical **seg0 face crop** (daemon), so identity holds across cuts.
- Types updated (`continuation_mode`, `identity_reference_image`).

Build clean. After the daemon restart, flip this on for one multi-segment job and compare identity across cuts vs the traditional path.