### PR TITLE
feat: 0.1 step on preset sampler + LoRA weight inputs

### DIFF
--- a/src/components/SettingsSignature.tsx
+++ b/src/components/SettingsSignature.tsx
@@ -11,14 +11,16 @@ export type SignatureValues = {
 };
 
 // Canonical order + abbreviated headers for the 7 sampler params.
-export const SIG_COLS: { key: keyof SignatureValues; label: string; full: string }[] = [
-  { key: "lightx2v_strength_high", label: "LX-H", full: "LightX2V High" },
-  { key: "lightx2v_strength_low", label: "LX-L", full: "LightX2V Low" },
-  { key: "cfg_high", label: "CFG-H", full: "CFG High" },
-  { key: "cfg_low", label: "CFG-L", full: "CFG Low" },
-  { key: "steps_total", label: "Steps", full: "Steps Total" },
-  { key: "high_noise_steps", label: "St-H", full: "High-Noise Steps (high/low split)" },
-  { key: "flow_shift", label: "Flow", full: "Flow Shift" },
+// step: 0.1 for the continuous knobs (weights/cfg/flow); 1 for the integer step-count fields
+// (steps_total / high_noise_steps must stay whole — the API rejects fractional ints).
+export const SIG_COLS: { key: keyof SignatureValues; label: string; full: string; step: number }[] = [
+  { key: "lightx2v_strength_high", label: "LX-H", full: "LightX2V High", step: 0.1 },
+  { key: "lightx2v_strength_low", label: "LX-L", full: "LightX2V Low", step: 0.1 },
+  { key: "cfg_high", label: "CFG-H", full: "CFG High", step: 0.1 },
+  { key: "cfg_low", label: "CFG-L", full: "CFG Low", step: 0.1 },
+  { key: "steps_total", label: "Steps", full: "Steps Total", step: 1 },
+  { key: "high_noise_steps", label: "St-H", full: "High-Noise Steps (high/low split)", step: 1 },
+  { key: "flow_shift", label: "Flow", full: "Flow Shift", step: 0.1 },
 ];
 
 // Parse "1,1,3,1,8,4,5" or grouped "1,1 · 3,1 · 8/4 · 5" into the 7 keyed values.

--- a/src/components/SettingsSignatureInputs.tsx
+++ b/src/components/SettingsSignatureInputs.tsx
@@ -32,7 +32,7 @@ export default function SettingsSignatureInputs({
           size="small"
           value={values[c.key] ?? ""}
           onChange={(e) => onChange(c.key, e.target.value)}
-          slotProps={{ htmlInput: { style: { textAlign: "center", padding: "6px 4px" } } }}
+          slotProps={{ htmlInput: { step: c.step, style: { textAlign: "center", padding: "6px 4px" } } }}
         />
       ))}
     </Box>

--- a/src/pages/VideoPresetLibrary.tsx
+++ b/src/pages/VideoPresetLibrary.tsx
@@ -342,6 +342,7 @@ export default function VideoPresetLibrary() {
                   sx={{ width: 150 }}
                   value={lora.high_weight}
                   onChange={(e) => updateWeight(idx, "high_weight", Number(e.target.value))}
+                  slotProps={{ htmlInput: { step: 0.1 } }}
                 />
                 <TextField
                   label="Low (identity)"
@@ -350,6 +351,7 @@ export default function VideoPresetLibrary() {
                   sx={{ width: 150 }}
                   value={lora.low_weight}
                   onChange={(e) => updateWeight(idx, "low_weight", Number(e.target.value))}
+                  slotProps={{ htmlInput: { step: 0.1 } }}
                 />
               </Box>
             </Card>


### PR DESCRIPTION
Number inputs for LX-H/L, CFG-H/L, Flow, and LoRA high/low weights now step by **0.1** (were jumping by 1). Steps Total / St-H keep integer step-1 (the API rejects fractional ints). Applies everywhere `SettingsSignatureInputs` renders. Build clean.