### PR TITLE
Add Seed re-anchor toggle to Settings

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -482,6 +482,7 @@ export interface AppSettingsResponse {
   high_noise_steps: number;
   flow_shift: number;
   negative_prompt: string;
+  seed_faceswap: boolean;
 }
 
 export interface FavoriteToggleRequest {
@@ -507,6 +508,7 @@ export interface AppSettingsUpdate {
   high_noise_steps?: number;
   flow_shift?: number;
   negative_prompt?: string;
+  seed_faceswap?: boolean;
 }
 
 export interface SegmentReprocessRequest {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -7,6 +7,8 @@ import {
   CardContent,
   Chip,
   CircularProgress,
+  FormControlLabel,
+  Switch,
   TextField,
   Typography,
   useMediaQuery,
@@ -32,9 +34,11 @@ export default function SettingsPage() {
     defaultHighNoiseSteps,
     defaultFlowShift,
     negativePrompt,
+    seedFaceswap,
     loaded,
     fetchSettings,
     saveSettings,
+    setSeedFaceswap,
     setDefaultLightx2vHigh,
     setDefaultLightx2vLow,
     setDefaultCfgHigh,
@@ -77,6 +81,7 @@ export default function SettingsPage() {
         high_noise_steps: parseInt(defaultHighNoiseSteps, 10) || 2,
         flow_shift: parseFloat(defaultFlowShift) || 5,
         negative_prompt: negativePrompt,
+        seed_faceswap: seedFaceswap,
       });
       setSaved(true);
     } catch (err) {
@@ -241,6 +246,22 @@ export default function SettingsPage() {
                 helperText="Sent as negative conditioning to ComfyUI"
                 sx={{ mt: 2, width: "100%", maxWidth: 500 }}
               />
+              <Box sx={{ mt: 2 }}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={seedFaceswap}
+                      onChange={(e) => setSeedFaceswap(e.target.checked)}
+                    />
+                  }
+                  label="Seed re-anchor (faceswap continuation seed)"
+                />
+                <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: -0.5 }}>
+                  Multi-segment: faceswap each segment's last frame to the canonical identity before it
+                  seeds the next segment. Falls back to the raw frame when no face is detected. Only fires
+                  when a later segment exists.
+                </Typography>
+              </Box>
               <Box sx={{ mt: 2 }}>
                 <Button
                   variant="contained"

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -11,6 +11,7 @@ interface SettingsState {
   defaultHighNoiseSteps: string;
   defaultFlowShift: string;
   negativePrompt: string;
+  seedFaceswap: boolean;
   loaded: boolean;
   fetchSettings: () => Promise<void>;
   saveSettings: (updates: AppSettingsUpdate) => Promise<void>;
@@ -22,6 +23,7 @@ interface SettingsState {
   setDefaultHighNoiseSteps: (value: string) => void;
   setDefaultFlowShift: (value: string) => void;
   setNegativePrompt: (value: string) => void;
+  setSeedFaceswap: (value: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()((set) => ({
@@ -33,6 +35,7 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
   defaultHighNoiseSteps: "2",
   defaultFlowShift: "5",
   negativePrompt: "",
+  seedFaceswap: false,
   loaded: false,
   fetchSettings: async () => {
     try {
@@ -46,6 +49,7 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
         defaultHighNoiseSteps: String(s.high_noise_steps),
         defaultFlowShift: String(s.flow_shift),
         negativePrompt: s.negative_prompt,
+        seedFaceswap: s.seed_faceswap,
         loaded: true,
       });
     } catch {
@@ -64,6 +68,7 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
       defaultHighNoiseSteps: String(s.high_noise_steps),
       defaultFlowShift: String(s.flow_shift),
       negativePrompt: s.negative_prompt,
+      seedFaceswap: s.seed_faceswap,
     });
   },
   setDefaultLightx2vHigh: (value) => set({ defaultLightx2vHigh: value }),
@@ -74,4 +79,5 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
   setDefaultHighNoiseSteps: (value) => set({ defaultHighNoiseSteps: value }),
   setDefaultFlowShift: (value) => set({ defaultFlowShift: value }),
   setNegativePrompt: (value) => set({ negativePrompt: value }),
+  setSeedFaceswap: (value) => set({ seedFaceswap: value }),
 }));


### PR DESCRIPTION
Adds a Switch on the Settings page bound to the `seed_faceswap` AppSetting (api #126). Faceswaps each continuation segment's last frame to the canonical identity before it seeds the next segment; off by default. Wires types + store + page. Build passes.