### PR TITLE
feat(lynx): Lynx engine in the create-job form

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -107,7 +107,72 @@ export interface JobCreate {
   starting_image_hash?: string | null;
   first_segment: SegmentCreate;
   tags?: string | null;
+  // Lynx identity-preserving engine. generation_engine="lynx" routes the job to the
+  // Lynx graph builder; every lynx_* value is optional and null means "use the
+  // daemon's settings default".
+  generation_engine?: string | null;
+  lynx_subject_image?: string | null;
+  lynx_ip_scale?: number | null;
+  lynx_ref_scale?: number | null;
+  lynx_cfg_scale?: number | null;
+  lynx_start_percent?: number | null;
+  lynx_end_percent?: number | null;
+  lynx_ref_blocks_to_use?: string | null;
+  lynx_ip_layers?: string | null;
+  lynx_resampler?: string | null;
+  lynx_steps?: number | null;
+  lynx_cfg?: number | null;
+  lynx_shift?: number | null;
+  lynx_scheduler?: string | null;
+  lynx_distill_strength?: number | null;
 }
+
+/** The Lynx knobs the create-job form collects. Mirrors the JobCreate lynx_* fields. */
+export interface LynxSettings {
+  ip_scale: number;
+  ref_scale: number;
+  arm: "lite" | "full";
+  steps: number;
+  cfg: number;
+  shift: number;
+  start_percent: number;
+  end_percent: number;
+  ref_blocks_to_use: string;
+}
+
+/** Matched ip-layer/resampler pairs. Mixing arms loads without error and produces
+ *  garbage identity, so the two files are always chosen together. */
+export const LYNX_ARMS: Record<"lite" | "full", { ip_layers: string; resampler: string; label: string }> = {
+  lite: {
+    ip_layers: "Wan2_1-T2V-14B-Lynx_lite_ip_layers_fp16.safetensors",
+    resampler: "lynx_lite_resampler_fp32.safetensors",
+    label: "Lite ip (default)",
+  },
+  full: {
+    ip_layers: "Wan2_1-T2V-14B-Lynx_full_ip_layers_fp16.safetensors",
+    resampler: "lynx_full_resampler_fp32.safetensors",
+    label: "Full ip (A/B arm)",
+  },
+};
+
+/** Wan native buckets Lynx is validated at — the daemon rejects anything else. */
+export const LYNX_RESOLUTIONS = [
+  { width: 832, height: 480, label: "832 × 480" },
+  { width: 1280, height: 720, label: "1280 × 720" },
+];
+
+/** Kijai's reference-workflow values, which are the daemon's settings defaults. */
+export const LYNX_DEFAULTS: LynxSettings = {
+  ip_scale: 0.7,
+  ref_scale: 0.6,
+  arm: "lite",
+  steps: 6,
+  cfg: 1.0,
+  shift: 8.0,
+  start_percent: 0.0,
+  end_percent: 1.0,
+  ref_blocks_to_use: "",
+};
 
 export interface JobLoraSummary {
   lora_id?: string | null;

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -16,6 +16,8 @@ import {
   TextField,
   MenuItem,
   Slider,
+  ToggleButton,
+  ToggleButtonGroup,
   Alert,
   IconButton,
 } from "@mui/material";
@@ -27,7 +29,9 @@ import { useTagStore } from "../stores/tagStore";
 import { useVideoPresetStore } from "../stores/videoPresetStore";
 import SettingsSignature from "./SettingsSignature";
 import { createJob, getFileUrl, getFaceswapPresets, sha256Hex, checkStartingImageExists } from "../api/client";
-import type { JobCreate, LoraListItem, FaceswapPreset } from "../api/types";
+import type { JobCreate, LoraListItem, FaceswapPreset, LynxSettings } from "../api/types";
+import { LYNX_ARMS, LYNX_DEFAULTS, LYNX_RESOLUTIONS } from "../api/types";
+import LynxConfig from "./LynxConfig";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "./FaceswapConfig";
 import {
   DEFAULT_WIDTH,
@@ -139,6 +143,11 @@ export default function CreateJobDialog({
   const [selectedTag2, setSelectedTag2] = useState("");
   const [tags, setTags] = useState("");
   const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
+  // Engine selection. "wan22" = the default i2v path; "lynx" = identity-preserving
+  // Wan2.1 T2V, which uses a different set of controls entirely.
+  const [engine, setEngine] = useState<"wan22" | "lynx">("wan22");
+  const [lynx, setLynx] = useState<LynxSettings>(LYNX_DEFAULTS);
+  const isLynx = engine === "lynx";
 
   // Auto-generate name from tags + fps
   useEffect(() => {
@@ -379,12 +388,18 @@ export default function CreateJobDialog({
       setError("Name and prompt are required");
       return;
     }
-    if (!videoPresetId) {
+    // Lynx carries its own sampler settings, so it does not need a video preset.
+    if (!isLynx && !videoPresetId) {
       setError("Select a video preset");
       return;
     }
     if (!startingImage && !startingImageUri) {
-      setError("Starting image is required");
+      setError(isLynx ? "Subject image is required" : "Starting image is required");
+      return;
+    }
+    if (isLynx && !LYNX_RESOLUTIONS.some((r) => r.width === width && r.height === height)) {
+      // The daemon rejects off-bucket resolutions rather than snapping them, so catch it here.
+      setError(`Lynx supports only ${LYNX_RESOLUTIONS.map((r) => r.label).join(" or ")}`);
       return;
     }
 
@@ -417,8 +432,21 @@ export default function CreateJobDialog({
         steps_total: stepsTotal ? parseInt(stepsTotal, 10) : null,
         high_noise_steps: highNoiseSteps ? parseInt(highNoiseSteps, 10) : null,
         flow_shift: flowShift ? parseFloat(flowShift) : null,
-        video_preset_id: videoPresetId || null,
+        video_preset_id: isLynx ? null : videoPresetId || null,
         continuation_mode: "traditional",
+        // Lynx: the API maps the uploaded starting image to lynx_subject_image, so the
+        // same upload path is reused. ip layers and resampler always travel as a pair.
+        generation_engine: isLynx ? "lynx" : null,
+        lynx_ip_scale: isLynx ? lynx.ip_scale : null,
+        lynx_ref_scale: isLynx ? lynx.ref_scale : null,
+        lynx_start_percent: isLynx ? lynx.start_percent : null,
+        lynx_end_percent: isLynx ? lynx.end_percent : null,
+        lynx_ref_blocks_to_use: isLynx && lynx.ref_blocks_to_use ? lynx.ref_blocks_to_use : null,
+        lynx_ip_layers: isLynx ? LYNX_ARMS[lynx.arm].ip_layers : null,
+        lynx_resampler: isLynx ? LYNX_ARMS[lynx.arm].resampler : null,
+        lynx_steps: isLynx ? lynx.steps : null,
+        lynx_cfg: isLynx ? lynx.cfg : null,
+        lynx_shift: isLynx ? lynx.shift : null,
         starting_image_uri: !startingImage && startingImageUri ? startingImageUri : null,
         starting_image_hash: reuseHash,
         tags: tags || null,
@@ -541,11 +569,41 @@ export default function CreateJobDialog({
           autoFocus
         />
 
-        {/* ── Starting Image (moved up — needed for auto-generate) ── */}
+        {/* ── Engine ── */}
+        <Box sx={{ mt: 2, mb: 1 }}>
+          <Typography variant="subtitle2" gutterBottom>Engine</Typography>
+          <ToggleButtonGroup
+            value={engine}
+            exclusive
+            fullWidth
+            size="small"
+            onChange={(_, v) => {
+              if (!v) return;
+              setEngine(v);
+              // Lynx only runs at the Wan native buckets, so snap to the nearest valid one
+              // when switching in (the daemon rejects anything else outright).
+              if (v === "lynx" && !LYNX_RESOLUTIONS.some((r) => r.width === width && r.height === height)) {
+                setWidth(LYNX_RESOLUTIONS[0].width);
+                setHeight(LYNX_RESOLUTIONS[0].height);
+              }
+            }}
+          >
+            <ToggleButton value="wan22">Wan 2.2 i2v</ToggleButton>
+            <ToggleButton value="lynx">Lynx (identity)</ToggleButton>
+          </ToggleButtonGroup>
+          {isLynx && (
+            <Typography variant="caption" color="warning.main" sx={{ display: "block", mt: 1 }}>
+              Lynx runs on RunPod only — the local 3090's WanVideoWrapper predates it. The image
+              below conditions identity and is <strong>not</strong> used as the first frame.
+            </Typography>
+          )}
+        </Box>
+
+        {/* ── Starting / Subject Image (moved up — needed for auto-generate) ── */}
         <Box sx={{ mt: 1, mb: 1 }}>
           <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap", "& > .MuiButton-root": { minWidth: { xs: "100%", sm: 0 } } }}>
             <Button variant="outlined" component="label" size="small">
-              {startingImage ? startingImage.name : startingImageUri ? "Image from repo" : "Choose Image *"}
+              {startingImage ? startingImage.name : startingImageUri ? "Image from repo" : isLynx ? "Choose Subject Image *" : "Choose Image *"}
               <input
                 type="file"
                 hidden
@@ -567,6 +625,12 @@ export default function CreateJobDialog({
             )}
           </Box>
         </Box>
+
+        {isLynx && (
+          <Box sx={{ mt: 1, mb: 2 }}>
+            <LynxConfig value={lynx} onChange={setLynx} />
+          </Box>
+        )}
 
         {/* ── Prompt ── */}
         <TextField

--- a/src/components/LynxConfig.tsx
+++ b/src/components/LynxConfig.tsx
@@ -1,0 +1,153 @@
+import {
+  Box,
+  Slider,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
+import { LYNX_ARMS, LYNX_DEFAULTS } from "../api/types";
+import type { LynxSettings } from "../api/types";
+
+/**
+ * Lynx identity-preserving engine settings.
+ *
+ * Lynx runs Wan 2.1 T2V-14B with two adapters that re-assert identity at every
+ * denoising step (unlike a character LoRA, which bakes it into the weights once):
+ * an ID-adapter driven by an ArcFace embedding, and a Ref-adapter driven by dense
+ * VAE features of the reference face.
+ *
+ * Note this is a text-to-video model conditioned on a subject image — NOT first-frame
+ * i2v. The subject never appears as frame 0, which is why the image field is labelled
+ * "subject image" rather than "starting image" when this engine is selected.
+ */
+export default function LynxConfig({
+  value,
+  onChange,
+}: {
+  value: LynxSettings;
+  onChange: (next: LynxSettings) => void;
+}) {
+  const set = <K extends keyof LynxSettings>(key: K, v: LynxSettings[K]) =>
+    onChange({ ...value, [key]: v });
+
+  return (
+    <Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Identity is re-applied at every denoising step from the subject image, rather than
+        baked in like a character LoRA. Defaults are Kijai's reference values — treat them
+        as a calibration starting point, not settled.
+      </Typography>
+
+      <Typography variant="subtitle2" gutterBottom>
+        ID adapter strength (ip_scale): {value.ip_scale.toFixed(2)}
+      </Typography>
+      <Slider
+        value={value.ip_scale}
+        min={0}
+        max={2}
+        step={0.05}
+        marks={[{ value: LYNX_DEFAULTS.ip_scale, label: "0.7" }]}
+        onChange={(_, v) => set("ip_scale", v as number)}
+        valueLabelDisplay="auto"
+      />
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 2 }}>
+        Controls <em>who the face is</em>. Pushing this high tends to freeze expression.
+      </Typography>
+
+      <Typography variant="subtitle2" gutterBottom>
+        Reference adapter strength (ref_scale): {value.ref_scale.toFixed(2)}
+      </Typography>
+      <Slider
+        value={value.ref_scale}
+        min={0}
+        max={2}
+        step={0.05}
+        marks={[{ value: LYNX_DEFAULTS.ref_scale, label: "0.6" }]}
+        onChange={(_, v) => set("ref_scale", v as number)}
+        valueLabelDisplay="auto"
+      />
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 2 }}>
+        Controls fine appearance — skin, hair, lighting. Too high drags the reference's own
+        pose and lighting into the video.
+      </Typography>
+
+      <Typography variant="subtitle2" gutterBottom>
+        Adapter arm
+      </Typography>
+      <ToggleButtonGroup
+        value={value.arm}
+        exclusive
+        fullWidth
+        size="small"
+        onChange={(_, v) => v && set("arm", v as "lite" | "full")}
+        sx={{ mb: 1 }}
+      >
+        <ToggleButton value="lite">{LYNX_ARMS.lite.label}</ToggleButton>
+        <ToggleButton value="full">{LYNX_ARMS.full.label}</ToggleButton>
+      </ToggleButtonGroup>
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 2 }}>
+        {value.arm === "full"
+          ? "Kijai's own note reports the full ip adapter as “very weak”. Kept as the A/B arm so it can be settled by measurement."
+          : "Kijai's shipped combination (lite ip + full ref). The ip layers and resampler always switch together."}
+      </Typography>
+
+      <Typography variant="subtitle2" gutterBottom>
+        Reference window: {value.start_percent.toFixed(2)} – {value.end_percent.toFixed(2)}
+      </Typography>
+      <Slider
+        value={[value.start_percent, value.end_percent]}
+        min={0}
+        max={1}
+        step={0.05}
+        onChange={(_, v) => {
+          const [start, end] = v as number[];
+          onChange({ ...value, start_percent: start, end_percent: end });
+        }}
+        valueLabelDisplay="auto"
+      />
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 2 }}>
+        Fraction of the denoise over which the reference adapter applies. Narrowing the end
+        (e.g. 0.60) frees the late steps from the reference — worth trying if identity holds
+        but motion looks stiff.
+      </Typography>
+
+      <Box sx={{ display: "flex", gap: 1, mb: 2 }}>
+        <TextField
+          label="Steps"
+          type="number"
+          size="small"
+          value={value.steps}
+          onChange={(e) => set("steps", parseInt(e.target.value, 10) || LYNX_DEFAULTS.steps)}
+          fullWidth
+        />
+        <TextField
+          label="CFG"
+          type="number"
+          size="small"
+          value={value.cfg}
+          onChange={(e) => set("cfg", parseFloat(e.target.value) || LYNX_DEFAULTS.cfg)}
+          fullWidth
+        />
+        <TextField
+          label="Shift"
+          type="number"
+          size="small"
+          value={value.shift}
+          onChange={(e) => set("shift", parseFloat(e.target.value) || LYNX_DEFAULTS.shift)}
+          fullWidth
+        />
+      </Box>
+
+      <TextField
+        label="Reference blocks"
+        size="small"
+        fullWidth
+        value={value.ref_blocks_to_use}
+        onChange={(e) => set("ref_blocks_to_use", e.target.value)}
+        placeholder="e.g. 0-20, 25, 35-39"
+        helperText="Which DiT blocks receive the reference feature. Leave empty for all blocks."
+      />
+    </Box>
+  );
+}


### PR DESCRIPTION
Adds an engine selector (Wan 2.2 i2v / Lynx) and a `LynxConfig` panel so Lynx jobs can be launched from the UI.

Follows the existing `HologramConfig` + MUI form patterns rather than introducing a new paradigm.

## Controls

- **ip_scale / ref_scale** sliders (0–2, marked at Kijai's 0.7 / 0.6), with copy explaining what each actually does — ip = *who the face is* (too high freezes expression), ref = *fine appearance* (too high drags the reference's pose and lighting in).
- **Adapter arm** toggle. The ip layers and resampler are a **matched pair**, so the toggle swaps both together — a mixed pair loads without error and yields garbage identity.
- **Reference window** (start/end percent) as a range slider, plus steps / cfg / shift and `ref_blocks_to_use`.

## Guards

- Resolution is checked against the two Wan native buckets **before submit**, because the daemon rejects rather than snaps. Switching to Lynx snaps to 832×480 if the current size is invalid.
- Lynx carries its own sampler settings, so the video-preset requirement is relaxed for it.
- The image field is relabelled **Subject Image** with an explicit note that it conditions identity and is **not** the first frame — Lynx is a T2V base and the subject never appears as frame 0.

Paired with a small API change: `create_job` mirrors the resolved starting-image URI into `lynx_subject_image` for Lynx jobs, so the console reuses the existing upload path (crop, hash-dedup) instead of needing a second upload route.

## Not done

**No unit tests.** This repo has no test runner at all — no vitest, no jest, no `test` script. Per David's call the UI ships now and the framework is a follow-up, so the 100% coverage convention is knowingly unmet here rather than silently skipped.

`tsc -b` and `vite build` are clean. The 4 remaining eslint errors are pre-existing in files this PR doesn't touch — the Lynx constants live in `api/types.ts` specifically to avoid the `react-refresh/only-export-components` error the other config components trip.