### PR TITLE
fix: keep list pagination in the URL so it survives navigation

### DIFF
--- a/src/hooks/useQueryState.ts
+++ b/src/hooks/useQueryState.ts
@@ -1,0 +1,79 @@
+import { useCallback } from "react";
+import { useSearchParams } from "react-router";
+
+export type QueryUpdates = Record<string, string | number | null | undefined>;
+
+/**
+ * Small helper around `useSearchParams` for keeping list state (pagination,
+ * search, filters) in the URL instead of component state.
+ *
+ * Why the URL: pages like Videos / Image Repo unmount when you click through to
+ * /jobs/:id, so anything held in `useState` is lost and the list snaps back to
+ * page 1 on return. The query string survives unmount/remount, browser
+ * back/forward, refresh, and is shareable.
+ *
+ * `setQuery` always uses `replace: true` so paging through a list does not
+ * stack up one history entry per click (back would otherwise have to be pressed
+ * once per page change). Replacing still records the params on the *current*
+ * history entry, so a later push (e.g. navigating to /jobs/:id) followed by a
+ * browser back restores the list exactly as it was left.
+ *
+ * Pass `null`/`undefined`/`""` to drop a param, so defaults never litter the URL.
+ * Batch every key you want to change into a single `setQuery` call — two calls
+ * in the same tick would both start from the same (pre-update) params.
+ */
+export function useQueryState() {
+  const [params, setSearchParams] = useSearchParams();
+
+  const setQuery = useCallback(
+    (updates: QueryUpdates) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          for (const [key, value] of Object.entries(updates)) {
+            if (value === null || value === undefined || value === "") {
+              next.delete(key);
+            } else {
+              next.set(key, String(value));
+            }
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return { params, setQuery };
+}
+
+/**
+ * Read a 1-based page param as the 0-based index MUI's TablePagination wants.
+ * Missing/garbage/out-of-range values fall back to the first page.
+ */
+export function getPage(params: URLSearchParams, key: string): number {
+  const parsed = Number.parseInt(params.get(key) ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 1 ? parsed - 1 : 0;
+}
+
+/** 0-based page index -> URL value (1-based). The first page is omitted. */
+export function pageValue(page: number): number | null {
+  return page > 0 ? page + 1 : null;
+}
+
+/** Read a rows-per-page param, ignoring anything that is not an offered option. */
+export function getPerPage(
+  params: URLSearchParams,
+  key: string,
+  allowed: readonly number[],
+  fallback: number,
+): number {
+  const parsed = Number.parseInt(params.get(key) ?? "", 10);
+  return allowed.includes(parsed) ? parsed : fallback;
+}
+
+/** Rows-per-page -> URL value. The default is omitted. */
+export function perPageValue(value: number, fallback: number): number | null {
+  return value === fallback ? null : value;
+}

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -64,6 +64,12 @@ import CreateJobDialog from "../components/CreateJobDialog";
 import CropResizeDialog from "../components/CropResizeDialog";
 import FavoriteHeart from "../components/FavoriteHeart";
 import { useTagStore } from "../stores/tagStore";
+import { useQueryState, getPage, pageValue, getPerPage, perPageValue } from "../hooks/useQueryState";
+
+const FOLDER_ROWS_OPTIONS = [12, 24, 48];
+const DEFAULT_FOLDER_ROWS = 12;
+const IMAGE_ROWS_OPTIONS = [24, 48, 96];
+const DEFAULT_IMAGE_ROWS = 24;
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -83,7 +89,6 @@ function shuffleArray<T>(arr: T[]): T[] {
 export default function ImageRepo() {
   const [folders, setFolders] = useState<ImageFolder[]>([]);
   const [images, setImages] = useState<ImageFile[]>([]);
-  const [currentFolder, setCurrentFolder] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [lightboxImage, setLightboxImage] = useState<ImageFile | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<ImageFile | null>(null);
@@ -91,10 +96,6 @@ export default function ImageRepo() {
   const [jobDialogImageUri, setJobDialogImageUri] = useState<string | null>(null);
   const [jobDialogImageTags, setJobDialogImageTags] = useState<string | null>(null);
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
-  const [folderPage, setFolderPage] = useState(0);
-  const [foldersPerPage, setFoldersPerPage] = useState(12);
-  const [imagePage, setImagePage] = useState(0);
-  const [imagesPerPage, setImagesPerPage] = useState(24);
   const [newFolderOpen, setNewFolderOpen] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
   const [creatingFolder, setCreatingFolder] = useState(false);
@@ -115,7 +116,6 @@ export default function ImageRepo() {
   const [loadingJobs, setLoadingJobs] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [favoritesSet, setFavoritesSet] = useState<Set<string>>(new Set());
-  const [favoritesOnly, setFavoritesOnly] = useState(false);
   const [favoritesView, setFavoritesView] = useState(false);
   const [favImages, setFavImages] = useState<ImageFile[]>([]);
   const [loadingFavImages, setLoadingFavImages] = useState(false);
@@ -124,13 +124,9 @@ export default function ImageRepo() {
   const [loadingUntagged, setLoadingUntagged] = useState(false);
   const [lightboxTags, setLightboxTags] = useState("");
   const tagSaveTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [searchResults, setSearchResults] = useState<ImageFile[]>([]);
   const [searchTotal, setSearchTotal] = useState(0);
   const [searchLoading, setSearchLoading] = useState(false);
-  const [searchPage, setSearchPage] = useState(0);
-  const [searchRowsPerPage, setSearchRowsPerPage] = useState(24);
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const [screensaverOpen, setScreensaverOpen] = useState(false);
   const [screensaverIndex, setScreensaverIndex] = useState(0);
@@ -140,6 +136,26 @@ export default function ImageRepo() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const btnSize = isMobile ? "small" : "medium";
+
+  // Browsing state lives in the URL (?folder=…&fpage=2&ipage=3&spage=1&q=…&fav=1)
+  // so it survives the unmount caused by clicking through to /jobs/:id, plus
+  // browser back/forward and refresh. Page params are 1-based and omitted when
+  // on the first page; MUI's TablePagination is 0-based, converted here.
+  const { params, setQuery } = useQueryState();
+  // `|| null` so an empty ?folder= is treated as "no folder open".
+  const currentFolder = params.get("folder") || null;
+  const folderPage = getPage(params, "fpage");
+  const foldersPerPage = getPerPage(params, "fper", FOLDER_ROWS_OPTIONS, DEFAULT_FOLDER_ROWS);
+  const imagePage = getPage(params, "ipage");
+  const imagesPerPage = getPerPage(params, "iper", IMAGE_ROWS_OPTIONS, DEFAULT_IMAGE_ROWS);
+  const searchPage = getPage(params, "spage");
+  const searchRowsPerPage = getPerPage(params, "sper", IMAGE_ROWS_OPTIONS, DEFAULT_IMAGE_ROWS);
+  const favoritesOnly = params.get("fav") === "1";
+  // The committed (debounced) search term *is* the URL param; the text field
+  // keeps local state so typing stays instant and does not rewrite the URL on
+  // every keystroke.
+  const debouncedSearch = params.get("q") ?? "";
+  const [searchQuery, setSearchQuery] = useState(debouncedSearch);
 
   // Scroll the main scroll container to the top on any pagination change
   // (folders, in-folder images, AND search results).
@@ -165,16 +181,19 @@ export default function ImageRepo() {
     setLightboxTags(lightboxImage?.tags ?? "");
   }, [lightboxImage]);
 
+  // Commit the search box to the URL after a pause. The equality guard means a
+  // remount (restored ?q=…) does not re-commit the same term — which would wipe
+  // the restored page params along with it.
   useEffect(() => {
+    if (searchQuery === debouncedSearch) return;
     if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
     searchDebounceRef.current = setTimeout(() => {
-      setDebouncedSearch(searchQuery);
-      setSearchPage(0);
+      setQuery({ q: searchQuery || null, spage: null });
     }, 300);
     return () => {
       if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
     };
-  }, [searchQuery]);
+  }, [searchQuery, debouncedSearch, setQuery]);
 
   useEffect(() => {
     fetchTags();
@@ -195,6 +214,14 @@ export default function ImageRepo() {
     }, 5000);
     return () => clearInterval(timer);
   }, [screensaverOpen]);
+
+  // Same "clamp back into range" guard as the folder list, for search results
+  // (whose pagination control only renders when the page has results).
+  useEffect(() => {
+    if (!debouncedSearch || searchTotal === 0) return;
+    const maxPage = Math.max(0, Math.ceil(searchTotal / searchRowsPerPage) - 1);
+    if (searchPage > maxPage) setQuery({ spage: pageValue(maxPage) });
+  }, [debouncedSearch, searchTotal, searchRowsPerPage, searchPage, setQuery]);
 
   const fetchSearchResults = useCallback(async () => {
     if (!debouncedSearch) {
@@ -267,18 +294,32 @@ export default function ImageRepo() {
 
   // Keep folderPage in range if the list shrinks (e.g. after a delete), but never
   // reset it on navigation — resetting was what snapped "page 2 -> folder -> back" to page 1.
+  // The guards matter: `folders` is empty before the first fetch resolves and
+  // while a folder is open, and clamping against an empty list would throw away
+  // a page restored from the URL.
   useEffect(() => {
+    if (currentFolder !== null || folders.length === 0) return;
     const maxPage = Math.max(0, Math.ceil(folders.length / foldersPerPage) - 1);
-    if (folderPage > maxPage) setFolderPage(maxPage);
-  }, [folders.length, foldersPerPage, folderPage]);
+    if (folderPage > maxPage) setQuery({ fpage: pageValue(maxPage) });
+  }, [currentFolder, folders.length, foldersPerPage, folderPage, setQuery]);
+
+  // Same idea for the in-folder image page. `images` is empty while loading and
+  // while the folder list is showing, so both are guarded out.
+  useEffect(() => {
+    if (currentFolder === null || images.length === 0) return;
+    const count = favoritesOnly
+      ? images.filter((img) => favoritesSet.has(img.path)).length
+      : images.length;
+    const maxPage = Math.max(0, Math.ceil(count / imagesPerPage) - 1);
+    if (imagePage > maxPage) setQuery({ ipage: pageValue(maxPage) });
+  }, [currentFolder, images, favoritesOnly, favoritesSet, imagesPerPage, imagePage, setQuery]);
 
   const handleFolderClick = (name: string) => {
-    setCurrentFolder(name);
-    setImagePage(0);
+    setQuery({ folder: name, ipage: null });
   };
 
   const handleBack = () => {
-    setCurrentFolder(null);
+    setQuery({ folder: null, ipage: null });
     setImages([]);
   };
 
@@ -1023,10 +1064,7 @@ export default function ImageRepo() {
             size="small"
             placeholder="Search images by tag…"
             value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value);
-              setSearchPage(0);
-            }}
+            onChange={(e) => setSearchQuery(e.target.value)}
             slotProps={{
               input: {
                 startAdornment: (
@@ -1108,13 +1146,15 @@ export default function ImageRepo() {
                   component="div"
                   count={searchTotal}
                   page={searchPage}
-                  onPageChange={(_, p) => setSearchPage(p)}
+                  onPageChange={(_, p) => setQuery({ spage: pageValue(p) })}
                   rowsPerPage={searchRowsPerPage}
                   onRowsPerPageChange={(e) => {
-                    setSearchRowsPerPage(parseInt(e.target.value, 10));
-                    setSearchPage(0);
+                    setQuery({
+                      sper: perPageValue(parseInt(e.target.value, 10), DEFAULT_IMAGE_ROWS),
+                      spage: null,
+                    });
                   }}
-                  rowsPerPageOptions={[24, 48, 96]}
+                  rowsPerPageOptions={IMAGE_ROWS_OPTIONS}
                   showFirstButton
                   showLastButton
                   sx={{
@@ -1300,13 +1340,15 @@ export default function ImageRepo() {
             component="div"
             count={folders.length}
             page={folderPage}
-            onPageChange={(_, p) => setFolderPage(p)}
+            onPageChange={(_, p) => setQuery({ fpage: pageValue(p) })}
             rowsPerPage={foldersPerPage}
             onRowsPerPageChange={(e) => {
-              setFoldersPerPage(parseInt(e.target.value, 10));
-              setFolderPage(0);
+              setQuery({
+                fper: perPageValue(parseInt(e.target.value, 10), DEFAULT_FOLDER_ROWS),
+                fpage: null,
+              });
             }}
-            rowsPerPageOptions={[12, 24, 48]}
+            rowsPerPageOptions={FOLDER_ROWS_OPTIONS}
             showFirstButton
             showLastButton
             sx={{
@@ -1406,10 +1448,7 @@ export default function ImageRepo() {
           size="small"
           placeholder="Search images by tag…"
           value={searchQuery}
-          onChange={(e) => {
-            setSearchQuery(e.target.value);
-            setSearchPage(0);
-          }}
+          onChange={(e) => setSearchQuery(e.target.value)}
           slotProps={{
             input: {
               startAdornment: (
@@ -1454,7 +1493,7 @@ export default function ImageRepo() {
           size={isMobile ? "small" : "medium"}
           onClick={() => {
             setSortDesc((prev) => !prev);
-            setImagePage(0);
+            setQuery({ ipage: null });
           }}
           title={sortDesc ? "Newest first" : "Oldest first"}
         >
@@ -1466,8 +1505,7 @@ export default function ImageRepo() {
           startIcon={isMobile ? undefined : <Favorite />}
           size={isMobile ? "small" : "medium"}
           onClick={() => {
-            setFavoritesOnly((v) => !v);
-            setImagePage(0);
+            setQuery({ fav: favoritesOnly ? null : "1", ipage: null });
           }}
         >
           {isMobile ? (favoritesOnly ? "Fav" : "Fav") : "Favorites"}
@@ -1677,13 +1715,15 @@ export default function ImageRepo() {
                 component="div"
                 count={searchTotal}
                 page={searchPage}
-                onPageChange={(_, p) => setSearchPage(p)}
+                onPageChange={(_, p) => setQuery({ spage: pageValue(p) })}
                 rowsPerPage={searchRowsPerPage}
                 onRowsPerPageChange={(e) => {
-                  setSearchRowsPerPage(parseInt(e.target.value, 10));
-                  setSearchPage(0);
+                  setQuery({
+                    sper: perPageValue(parseInt(e.target.value, 10), DEFAULT_IMAGE_ROWS),
+                    spage: null,
+                  });
                 }}
-                rowsPerPageOptions={[24, 48, 96]}
+                rowsPerPageOptions={IMAGE_ROWS_OPTIONS}
                 showFirstButton
                 showLastButton
                 sx={{
@@ -1839,13 +1879,15 @@ export default function ImageRepo() {
           component="div"
           count={favoritesOnly ? images.filter((img) => favoritesSet.has(img.path)).length : images.length}
           page={imagePage}
-          onPageChange={(_, p) => setImagePage(p)}
+          onPageChange={(_, p) => setQuery({ ipage: pageValue(p) })}
           rowsPerPage={imagesPerPage}
           onRowsPerPageChange={(e) => {
-            setImagesPerPage(parseInt(e.target.value, 10));
-            setImagePage(0);
+            setQuery({
+              iper: perPageValue(parseInt(e.target.value, 10), DEFAULT_IMAGE_ROWS),
+              ipage: null,
+            });
           }}
-          rowsPerPageOptions={[24, 48, 96]}
+          rowsPerPageOptions={IMAGE_ROWS_OPTIONS}
           showFirstButton
           showLastButton
           sx={{

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -24,6 +24,10 @@ import { getJobs, getJob, getFileUrl, getFavorites, toggleFavorite } from "../ap
 import type { JobDetailResponse, JobResponse } from "../api/types";
 import { DEFAULT_JOB_FETCH_LIMIT, POLL_INTERVAL_FAST } from "../constants";
 import FavoriteHeart from "../components/FavoriteHeart";
+import { useQueryState, getPage, pageValue, getPerPage, perPageValue } from "../hooks/useQueryState";
+
+const ROWS_PER_PAGE_OPTIONS = [12, 24, 48];
+const DEFAULT_ROWS_PER_PAGE = 12;
 
 function formatDuration(seconds: number) {
   const m = Math.floor(seconds / 60);
@@ -48,34 +52,53 @@ export default function Videos() {
   const [loading, setLoading] = useState(true);
   const [videoModal, setVideoModal] = useState<{ jobId: string } | null>(null);
   const [jobDetails, setJobDetails] = useState<Record<string, JobDetailResponse>>({});
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(12);
   const [playlist, setPlaylist] = useState<{ jobId: string; videoPath: string; jobName: string }[]>([]);
   const [playlistIndex, setPlaylistIndex] = useState(0);
   const [loadingRandom, setLoadingRandom] = useState(false);
   const [loopVideo, setLoopVideo] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [debouncedQuery, setDebouncedQuery] = useState("");
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const [favoritesSet, setFavoritesSet] = useState<Set<string>>(new Set());
-  const [favoritesOnly, setFavoritesOnly] = useState(false);
+
+  // List state lives in the URL (?page=3&per=24&q=…&fav=1) so it survives the
+  // unmount caused by clicking through to /jobs/:id — and browser back/forward.
+  const { params, setQuery } = useQueryState();
+  const page = getPage(params, "page");
+  const rowsPerPage = getPerPage(params, "per", ROWS_PER_PAGE_OPTIONS, DEFAULT_ROWS_PER_PAGE);
+  const favoritesOnly = params.get("fav") === "1";
+  // The committed (debounced) search term *is* the URL param.
+  const debouncedQuery = params.get("q") ?? "";
+  // The text field keeps its own state so typing stays instant and does not
+  // rewrite the URL on every keystroke; it is seeded from the URL on mount.
+  const [searchQuery, setSearchQuery] = useState(debouncedQuery);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   // Scroll to top when page changes
   useEffect(() => {
     document.querySelector("main")?.scrollTo({ top: 0, behavior: "smooth" });
   }, [page]);
 
-  // Debounce search input to avoid hammering the API on every keystroke
+  // Debounce search input to avoid hammering the API on every keystroke.
+  // The equality guard means a remount (restored ?q=…) does not re-commit the
+  // same term — which would wipe the restored ?page= along with it.
   useEffect(() => {
+    if (searchQuery === debouncedQuery) return;
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      setDebouncedQuery(searchQuery);
-      setPage(0);
+      setQuery({ q: searchQuery || null, page: null });
     }, 300);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [searchQuery]);
+  }, [searchQuery, debouncedQuery, setQuery]);
+
+  // A restored/bookmarked page can end up past the end of the list (e.g. jobs
+  // were removed while away). The pagination control is only rendered when the
+  // page has results, so clamp back into range instead of stranding the user on
+  // an empty screen. Guarded on `total` so it never fires before the first fetch.
+  useEffect(() => {
+    if (total === 0) return;
+    const maxPage = Math.max(0, Math.ceil(total / rowsPerPage) - 1);
+    if (page > maxPage) setQuery({ page: pageValue(maxPage) });
+  }, [total, rowsPerPage, page, setQuery]);
 
   const fetchVideos = useCallback(async () => {
     try {
@@ -225,7 +248,7 @@ export default function Videos() {
           color={favoritesOnly ? "error" : "inherit"}
           startIcon={<Favorite />}
           size="small"
-          onClick={() => setFavoritesOnly((v) => !v)}
+          onClick={() => setQuery({ fav: favoritesOnly ? null : "1" })}
           sx={{ textTransform: "none" }}
         >
           Favorites
@@ -235,10 +258,7 @@ export default function Videos() {
           size="small"
           placeholder="Search videos…"
           value={searchQuery}
-          onChange={(e) => {
-            setSearchQuery(e.target.value);
-            setPage(0);
-          }}
+          onChange={(e) => setSearchQuery(e.target.value)}
           slotProps={{
             input: {
               startAdornment: (
@@ -419,13 +439,15 @@ export default function Videos() {
             component="div"
             count={total}
             page={page}
-            onPageChange={(_, p) => setPage(p)}
+            onPageChange={(_, p) => setQuery({ page: pageValue(p) })}
             rowsPerPage={rowsPerPage}
             onRowsPerPageChange={(e) => {
-              setRowsPerPage(parseInt(e.target.value, 10));
-              setPage(0);
+              setQuery({
+                per: perPageValue(parseInt(e.target.value, 10), DEFAULT_ROWS_PER_PAGE),
+                page: null,
+              });
             }}
-            rowsPerPageOptions={[12, 24, 48]}
+            rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
           />
         )}
         </>


### PR DESCRIPTION
Paging to page 3 on Videos or Image Repo, clicking into an item, then coming back always dropped the user on page 1. Two independent causes, both fixed here:

(a) Pagination lived in component-local useState. The router has no state
    preservation, so navigating to /jobs/:id unmounts the page and every
    useState value is destroyed; returning remounts it with page 0.

(b) Even with the page restored, the search-debounce effects fired ~300ms
    after *mount* and unconditionally called setPage(0) / setSearchPage(0),
    silently wiping the restored page. This is why the bug kept coming
    back after previous partial fixes.

Fix: the URL query string is now the single source of truth, via useSearchParams. Page numbers are 1-based and human-readable, params are omitted at their defaults (?page=3&per=24, and fpage/ipage/spage for the Image Repo's three independent paginations, plus folder/q/fav). All writes use replace:true so paging does not push one history entry per click, while still recording state on the current entry — so a push to /jobs/:id followed by browser back restores the list exactly as it was left. Back/forward and bookmarking now work as a side effect.

The debounce is guarded (if input === committed value, do nothing), so a remount can no longer re-commit the same term and clear the restored page. Added out-of-range clamps, guarded on "data not loaded yet", so a restored page past a shrunken list cannot strand the user on an empty screen.

Extracted the shared helpers into src/hooks/useQueryState.ts.

---

## User-visible behaviour change

**Typing in the search box no longer snaps to page 1 instantly** — it snaps when the query commits, 300ms after you stop typing. This is deliberate: resetting the page on every keystroke is exactly the mechanism behind root cause (b), so the guarded, commit-time reset is what makes the remount fix hold.

## Why the crux flow works now

Paging 1→2→3 *replaces*, so the single history entry for `/videos` becomes `/videos?page=3`. Clicking **View Job** calls `navigate('/jobs/:id')`, a **push** — stack is `[…, /videos?page=3, /jobs/:id]`. Browser Back pops to `/videos?page=3`; the page remounts, reads index 2, fetches `offset = 2 × 12`. The debounce early-returns and the clamp no-ops while `total === 0`, so nothing resets it. Same for Image Repo's lightbox → job link (`folder` + `ipage` both restore).

## Deliberately not changed

- `favoritesView`, `untaggedView`, `sortDesc`, `selectMode`/`selectedKeys` and modal state stay local. The two view toggles fetch their data inside the click handler, so URL-persisting them needs new fetch effects — scope creep, unrelated to this bug.
- The search box is not URL-controlled per keystroke on purpose: react-router 7 wraps navigation state in `startTransition`, and controlled inputs driven through a transition can drop characters. Since every write uses `replace`, there is no history entry where the input could diverge from the URL anyway.
- Toggling Favorites on Videos still doesn't reset the page (matches previous behaviour; it's a client-side filter over the current page).

## Verification

- `npm run build` (`tsc -b && vite build`) passes on this branch, built off `origin/main` in isolation from the unrelated `feat/lynx-ui` work.
- `npm run lint` output is identical to the pre-change baseline (4 errors, 7 warnings, all pre-existing). Note this repo enables `react-hooks/set-state-in-effect` as an **error**, which is why the design avoids any URL→state sync effect.
- **There is no test runner configured in this repo** (no test script, no vitest/jest), so verification was build + lint + a line-by-line trace of the user flow rather than automated tests.
