### PR TITLE
Bring back the Wildcards UI + segment start-image lightbox

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import SuccessfulConfigs from "./pages/SuccessfulConfigs";
 import SettingsPage from "./pages/SettingsPage";
 import HologramPlayer from "./pages/HologramPlayer";
 import VideoPresetLibrary from "./pages/VideoPresetLibrary";
+import Wildcards from "./pages/Wildcards";
 
 export default function App() {
   return (
@@ -37,6 +38,7 @@ export default function App() {
             <Route path="/smashcut" element={<SmashcutBuilder />} />
             <Route path="/loras" element={<LoraLibrary />} />
             <Route path="/video-presets" element={<VideoPresetLibrary />} />
+            <Route path="/wildcards" element={<Wildcards />} />
             <Route path="/images" element={<ImageRepo />} />
             <Route path="/settings" element={<SettingsPage />} />
           </Route>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Star,
   Tune,
   Movie,
+  Casino,
 } from "@mui/icons-material";
 import { useNavigate, useLocation } from "react-router";
 
@@ -33,6 +34,7 @@ const NAV_ITEMS = [
   { label: "Smashcut", icon: <Movie />, path: "/smashcut" },
   { label: "LoRA Library", icon: <AutoFixHigh />, path: "/loras" },
   { label: "Video Presets", icon: <Tune />, path: "/video-presets" },
+  { label: "Wildcards", icon: <Casino />, path: "/wildcards" },
   { label: "Image Repo", icon: <Image />, path: "/images" },
   { label: "Settings", icon: <Settings />, path: "/settings" },
 ];

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -251,6 +251,7 @@ export default function JobDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [videoModal, setVideoModal] = useState<{ path: string; v?: string; segIndex?: number } | null>(null);
+  const [imageModal, setImageModal] = useState<{ path: string; segIndex: number } | null>(null);
   const [loopVideo, setLoopVideo] = useState(false);
   const [finalizing, setFinalizing] = useState(false);
   const [segmentModalOpen, setSegmentModalOpen] = useState(false);
@@ -1018,6 +1019,7 @@ export default function JobDetail() {
                             component="img"
                             src={getFileUrl(img)}
                             alt="Start"
+                            onClick={() => setImageModal({ path: img, segIndex: seg.index })}
                             sx={{
                               width: 80,
                               height: 80,
@@ -1025,6 +1027,8 @@ export default function JobDetail() {
                               borderRadius: 1,
                               bgcolor: "#f5f5f5",
                               display: "block",
+                              cursor: "pointer",
+                              "&:hover": { opacity: 0.85 },
                             }}
                           />
                         ) : (
@@ -1393,12 +1397,15 @@ export default function JobDetail() {
                           component="img"
                           src={getFileUrl(startImg)}
                           alt="Start"
+                          onClick={() => setImageModal({ path: startImg, segIndex: seg.index })}
                           sx={{
                             width: 64,
                             height: 64,
                             objectFit: "cover",
                             borderRadius: 1,
                             bgcolor: "#f5f5f5",
+                            cursor: "pointer",
+                            "&:hover": { opacity: 0.85 },
                           }}
                         />
                       ) : (
@@ -1782,6 +1789,51 @@ export default function JobDetail() {
             >
               <Repeat fontSize="small" />
             </IconButton>
+          </Box>
+        </DialogContent>
+      </Dialog>
+
+      {/* Start image modal */}
+      <Dialog
+        open={!!imageModal}
+        onClose={() => setImageModal(null)}
+        maxWidth="md"
+        fullWidth
+        fullScreen={isMobile}
+      >
+        <DialogContent sx={{ p: 0, position: "relative", bgcolor: "#000" }}>
+          <IconButton
+            onClick={() => {
+              if (!imageModal || !job) return;
+              const a = document.createElement("a");
+              a.href = getFileUrl(imageModal.path);
+              a.download = `${job.name}_segment${imageModal.segIndex}_start${
+                imageModal.path.match(/\.[a-z0-9]+$/i)?.[0] ?? ".png"
+              }`;
+              a.click();
+            }}
+            sx={{ position: "absolute", top: 8, right: 48, color: "white", zIndex: 1 }}
+          >
+            <Download />
+          </IconButton>
+          <IconButton
+            onClick={() => setImageModal(null)}
+            sx={{ position: "absolute", top: 8, right: 8, color: "white", zIndex: 1 }}
+          >
+            <Close />
+          </IconButton>
+          {imageModal && (
+            <Box
+              component="img"
+              src={getFileUrl(imageModal.path)}
+              alt={`Segment ${imageModal.segIndex} start image`}
+              sx={{ width: "100%", maxHeight: "80vh", objectFit: "contain", display: "block" }}
+            />
+          )}
+          <Box sx={{ px: 1.5, py: 1, bgcolor: "rgba(0,0,0,0.8)" }}>
+            <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.7)", wordBreak: "break-all" }}>
+              {imageModal ? `#${imageModal.segIndex} — ${imageModal.path.split("/").pop()}` : ""}
+            </Typography>
           </Box>
         </DialogContent>
       </Dialog>

--- a/src/pages/Wildcards.tsx
+++ b/src/pages/Wildcards.tsx
@@ -1,0 +1,267 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Box,
+  Typography,
+  Button,
+  Card,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Alert,
+  Chip,
+  CircularProgress,
+  Tooltip,
+} from "@mui/material";
+import { Add, Edit, DeleteOutline, ContentCopy } from "@mui/icons-material";
+import { getWildcards, createWildcard, updateWildcard, deleteWildcard } from "../api/client";
+import type { WildcardResponse } from "../api/types";
+
+// The API resolver matches <([^<>]+)> — so a name containing angle brackets can never be hit.
+const NAME_RE = /^[^<>]+$/;
+
+// Options are edited one-per-line: dolphin returns long sentences, which chips/autocomplete
+// would make unreadable.
+const optionsToText = (options: string[]) => options.join("\n");
+const textToOptions = (text: string) =>
+  text
+    .split("\n")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+export default function Wildcards() {
+  const [wildcards, setWildcards] = useState<WildcardResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<WildcardResponse | null>(null);
+  const [name, setName] = useState("");
+  const [optionsText, setOptionsText] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<WildcardResponse | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    try {
+      setWildcards(await getWildcards());
+      setError(null);
+    } catch {
+      setError("Failed to load wildcards");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const openNew = () => {
+    setEditing(null);
+    setName("");
+    setOptionsText("");
+    setFormError(null);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (wc: WildcardResponse) => {
+    setEditing(wc);
+    setName(wc.name);
+    setOptionsText(optionsToText(wc.options));
+    setFormError(null);
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    const trimmed = name.trim();
+    const options = textToOptions(optionsText);
+    if (!trimmed) {
+      setFormError("Name is required");
+      return;
+    }
+    if (!NAME_RE.test(trimmed)) {
+      setFormError("Name cannot contain < or >");
+      return;
+    }
+    if (options.length === 0) {
+      setFormError("Add at least one option — a wildcard with no options is left unresolved in the prompt");
+      return;
+    }
+    setSaving(true);
+    try {
+      if (editing) {
+        await updateWildcard(editing.id, { name: trimmed, options });
+      } else {
+        await createWildcard({ name: trimmed, options });
+      }
+      setDialogOpen(false);
+      await fetchAll();
+    } catch (e) {
+      const detail = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setFormError(detail ?? "Failed to save wildcard");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteConfirm) return;
+    try {
+      await deleteWildcard(deleteConfirm.id);
+      setDeleteConfirm(null);
+      await fetchAll();
+    } catch {
+      setError("Failed to delete wildcard");
+      setDeleteConfirm(null);
+    }
+  };
+
+  const copyToken = (wcName: string) => {
+    navigator.clipboard.writeText(`<${wcName}>`);
+    setCopied(wcName);
+    setTimeout(() => setCopied(null), 1500);
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
+        <Typography variant="h5" sx={{ fontWeight: 600 }}>
+          Wildcards
+        </Typography>
+        <Button variant="contained" startIcon={<Add />} onClick={openNew} sx={{ ml: "auto" }}>
+          New Wildcard
+        </Button>
+      </Box>
+
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Drop <code>&lt;name&gt;</code> into any segment prompt. At submission the API swaps it for a
+        random option and stores the unresolved template alongside the resolved prompt. A name used
+        twice in one prompt resolves to the <strong>same</strong> option both times — and an unknown
+        name is passed through to the model verbatim, brackets and all.
+      </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box sx={{ textAlign: "center", py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : wildcards.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No wildcards yet. Create one to start varying prompts across a batch.
+        </Typography>
+      ) : (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+          {wildcards.map((wc) => (
+            <Card key={wc.id} variant="outlined" sx={{ p: 2 }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+                <Typography
+                  sx={{ fontFamily: "monospace", fontWeight: 600, fontSize: "0.95rem" }}
+                >
+                  &lt;{wc.name}&gt;
+                </Typography>
+                <Tooltip title={copied === wc.name ? "Copied!" : "Copy token"}>
+                  <IconButton size="small" onClick={() => copyToken(wc.name)}>
+                    <ContentCopy fontSize="inherit" />
+                  </IconButton>
+                </Tooltip>
+                <Chip label={`${wc.options.length} options`} size="small" variant="outlined" />
+                <Box sx={{ ml: "auto", display: "flex", gap: 0.5 }}>
+                  <IconButton size="small" onClick={() => openEdit(wc)}>
+                    <Edit fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" color="error" onClick={() => setDeleteConfirm(wc)}>
+                    <DeleteOutline fontSize="small" />
+                  </IconButton>
+                </Box>
+              </Box>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+                {wc.options.slice(0, 3).map((opt, i) => (
+                  <Typography
+                    key={i}
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    • {opt}
+                  </Typography>
+                ))}
+                {wc.options.length > 3 && (
+                  <Typography variant="caption" color="text.secondary">
+                    …and {wc.options.length - 3} more
+                  </Typography>
+                )}
+              </Box>
+            </Card>
+          ))}
+        </Box>
+      )}
+
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>{editing ? "Edit Wildcard" : "New Wildcard"}</DialogTitle>
+        <DialogContent>
+          {formError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {formError}
+            </Alert>
+          )}
+          <TextField
+            label="Name"
+            size="small"
+            fullWidth
+            autoFocus
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            helperText={`Referenced in prompts as <${name.trim() || "name"}>`}
+            sx={{ mt: 1, mb: 2 }}
+          />
+          <TextField
+            label="Options"
+            multiline
+            minRows={6}
+            maxRows={18}
+            fullWidth
+            value={optionsText}
+            onChange={(e) => setOptionsText(e.target.value)}
+            helperText="One option per line. Blank lines are ignored."
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button variant="contained" onClick={handleSave} disabled={saving}>
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={!!deleteConfirm} onClose={() => setDeleteConfirm(null)}>
+        <DialogTitle>Delete wildcard?</DialogTitle>
+        <DialogContent>
+          Delete &lt;{deleteConfirm?.name}&gt;? Prompts still referencing it will pass the literal
+          text through to the model.
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteConfirm(null)}>Cancel</Button>
+          <Button color="error" variant="contained" onClick={handleDelete}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Wildcards UI

The backend never went away — `/wildcards` CRUD, the `Wildcard` model, migration 005, and `_resolve_wildcards()` wired into **both** submission paths (`jobs.py:187`, `segments.py:177`). What was missing was the console: `client.ts` had `getWildcards/createWildcard/updateWildcard/deleteWildcard` and `types.ts` had the interfaces, but nothing in `src/` called them. Managing wildcards meant hitting the API by hand.

Adds `pages/Wildcards.tsx` on `/wildcards` with a sidebar entry, wired to the existing client functions. Options are edited one-per-line instead of as chips — generated prompt fragments are full sentences and chips make them unreadable.

The page surfaces two resolver behaviours that are otherwise invisible from the UI:
- a name used twice in one prompt resolves to the **same** option both times (one `random.choice` per unique name, then replace-all)
- an unknown name, or one with an empty options list, is passed through to the model verbatim — brackets and all, no error

Client-side validation rejects names containing `<`/`>` (the resolver regex `<([^<>]+)>` could never match them) and empty option lists.

## Segment start-image lightbox

Start-image thumbnails in the segments table and mobile cards were static crops. They're now clickable, opening a modal that mirrors the existing video modal — contained image up to 80vh, download + close, caption strip with segment index and filename. Applies to every segment, not just index 0.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on all touched files
- `npm run build` succeeds
- `pytest tests/test_resolve_wildcards.py` — 5 passed (submission-time resolution confirmed working)

Note: no backend changes in this PR — resolution at submission time was already functional and is covered by the existing tests.