### PR TITLE
feat(dashboard): trim to five cards

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -412,9 +412,10 @@ export interface WildcardUpdate {
 export interface StatsResponse {
   jobs_by_status: Record<string, number>;
   segments_by_status: Record<string, number>;
-  avg_segment_run_time: number | null;
-  total_segments_completed: number;
-  total_video_time: number;
+  /** Rolling 24h window, not lifetime. */
+  avg_segment_run_time_24h: number | null;
+  /** Estimated seconds of work still queued across all active jobs. */
+  total_queue_time: number;
   worker_stats: WorkerStatsItem[];
 }
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -15,13 +15,10 @@ import {
 } from "@mui/material";
 import {
   Groups,
-  PlayArrow,
   HourglassEmpty,
   QuestionAnswer,
-  ErrorOutline,
   Timer,
-  Movie,
-  CheckCircle,
+  Schedule,
 } from "@mui/icons-material";
 import { getStats, getWorkers } from "../api/client";
 import type { StatsResponse, WorkerResponse } from "../api/types";
@@ -34,7 +31,8 @@ function formatRunTime(seconds: number): string {
   return `${m}m ${s}s`;
 }
 
-function formatVideoTime(seconds: number): string {
+/** Longer-form duration for totals that can run to hours. */
+function formatLongDuration(seconds: number): string {
   if (seconds < 60) return `${Math.round(seconds)}s`;
   const m = Math.floor(seconds / 60);
   const s = Math.round(seconds % 60);
@@ -129,14 +127,10 @@ export default function Dashboard() {
   }
 
   const onlineWorkers = workers.filter((w) => w.status !== "offline").length;
-  const runningSegments =
-    (stats?.segments_by_status.processing ?? 0) + (stats?.segments_by_status.claimed ?? 0);
   const pendingJobs = stats?.jobs_by_status.pending ?? 0;
   const awaitingJobs = stats?.jobs_by_status.awaiting ?? 0;
-  const failedSegments = stats?.segments_by_status.failed ?? 0;
-  const avgRunTime = stats?.avg_segment_run_time;
-  const totalVideoTime = stats?.total_video_time ?? 0;
-  const totalCompleted = stats?.total_segments_completed ?? 0;
+  const avgRunTime = stats?.avg_segment_run_time_24h;
+  const totalQueueTime = stats?.total_queue_time ?? 0;
 
   return (
     <Box>
@@ -151,14 +145,6 @@ export default function Dashboard() {
             value={onlineWorkers}
             color="#4caf50"
             icon={<Groups />}
-          />
-        </Grid>
-        <Grid size={{ xs: 6, sm: 4, md: 3 }}>
-          <StatCard
-            label="Running Segments"
-            value={runningSegments}
-            color="#2196f3"
-            icon={<PlayArrow />}
           />
         </Grid>
         <Grid size={{ xs: 6, sm: 4, md: 3 }}>
@@ -179,15 +165,7 @@ export default function Dashboard() {
         </Grid>
         <Grid size={{ xs: 6, sm: 4, md: 3 }}>
           <StatCard
-            label="Failed Segments"
-            value={failedSegments}
-            color="#f44336"
-            icon={<ErrorOutline />}
-          />
-        </Grid>
-        <Grid size={{ xs: 6, sm: 4, md: 3 }}>
-          <StatCard
-            label="Avg Run Time"
+            label="Avg Run Time (last 24 hrs)"
             value={avgRunTime != null ? formatRunTime(avgRunTime) : "-"}
             color="#ff9800"
             icon={<Timer />}
@@ -195,18 +173,10 @@ export default function Dashboard() {
         </Grid>
         <Grid size={{ xs: 6, sm: 4, md: 3 }}>
           <StatCard
-            label="Total Video Time"
-            value={formatVideoTime(totalVideoTime)}
+            label="Total Queue Time"
+            value={formatLongDuration(totalQueueTime)}
             color="#9c27b0"
-            icon={<Movie />}
-          />
-        </Grid>
-        <Grid size={{ xs: 6, sm: 4, md: 3 }}>
-          <StatCard
-            label="Total Completed"
-            value={totalCompleted}
-            color="#4caf50"
-            icon={<CheckCircle />}
+            icon={<Schedule />}
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
Pairs with wanly-api#135.

**Kept:** Workers Online, Pending Jobs, Awaiting Prompt
**Relabelled:** Avg Run Time → **Avg Run Time (last 24 hrs)**, matching the API's now-windowed value
**Added:** **Total Queue Time** — estimated work outstanding (production currently reads 3.11h)
**Removed:** Running Segments, Total Video Time, Total Completed, Failed Segments

### Why "Failed" showed 10
Queried production rather than guessing. All 10 failed segments belong to jobs that were **already resolved** — 3 finalized, 7 archived — and all date from July:

```
failed segments by parent job status
    ('archived', 7)
    ('finalized', 3)
failed whose job was later finalized/archived
    (10,)
```

`finalized` means the job completed anyway (the segment was retried); `archived` means it was deliberately set aside. So the card was a lifetime tally of already-handled failures that could only ever climb, and pointed at nothing actionable. Nothing is currently failing.

I'd initially planned to rescope it to unresolved failures only; removing it outright is simpler and the count would read 0 today either way.

### Notes
- `formatVideoTime` → `formatLongDuration`, now carrying Total Queue Time, which can run to hours.
- Grid sizing left at `md: 3`, so five cards fill a row of four and wrap one — no layout rework.

### Verification
`npm run build` (tsc + vite) and `eslint` clean. No test runner in this repo, so **no automated coverage** — verified by type-check, lint, and reading the diff.