### PR TITLE
feat(seed-faceswap): move the seed re-anchor into the segment faceswap UI

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -20,6 +20,7 @@ export interface SegmentCreate {
   faceswap_image?: string | null;
   faceswap_faces_order?: string | null;
   faceswap_faces_index?: string | null;
+  seed_faceswap?: boolean;
   negative_prompt?: string | null;
   auto_finalize?: boolean;
   transition?: string | null;
@@ -165,6 +166,7 @@ export interface SegmentResponse {
   faceswap_image: string | null;
   faceswap_faces_order: string | null;
   faceswap_faces_index: string | null;
+  seed_faceswap: boolean;
   auto_finalize: boolean;
   transition: string | null;
   trim_start_frames: number;
@@ -487,7 +489,6 @@ export interface AppSettingsResponse {
   high_noise_steps: number;
   flow_shift: number;
   negative_prompt: string;
-  seed_faceswap: boolean;
 }
 
 export interface FavoriteToggleRequest {
@@ -536,7 +537,6 @@ export interface AppSettingsUpdate {
   high_noise_steps?: number;
   flow_shift?: number;
   negative_prompt?: string;
-  seed_faceswap?: boolean;
 }
 
 export interface SegmentReprocessRequest {

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -441,6 +441,7 @@ export default function CreateJobDialog({
           faceswap_faces_index: faceswap.enabled ? faceswap.facesIndex : null,
           negative_prompt: negativePrompt.trim() || null,
           faceswap_faces_order: faceswap.enabled ? faceswap.facesOrder : null,
+          seed_faceswap: faceswap.enabled && faceswap.seedFaceswap,
         },
       };
 

--- a/src/components/FaceswapConfig.tsx
+++ b/src/components/FaceswapConfig.tsx
@@ -29,6 +29,9 @@ export interface FaceswapConfigState {
   presetUri: string | null;
   facesIndex: string;
   facesOrder: string;
+  /** Also re-anchor the continuation seed: faceswap this segment's last frame to the same
+   *  face before it seeds the next segment. Uses the face selected above. */
+  seedFaceswap: boolean;
 }
 
 export function defaultFaceswapState(overrides?: Partial<FaceswapConfigState>): FaceswapConfigState {
@@ -40,6 +43,7 @@ export function defaultFaceswapState(overrides?: Partial<FaceswapConfigState>): 
     presetUri: null,
     facesIndex: DEFAULT_FACESWAP_FACES_INDEX,
     facesOrder: DEFAULT_FACESWAP_FACES_ORDER,
+    seedFaceswap: false,
     ...overrides,
   };
 }
@@ -118,6 +122,21 @@ export default function FaceswapConfig({
                 <MenuItem value="small-large">Small → Large</MenuItem>
               </TextField>
             </Box>
+            <FormControlLabel
+              control={
+                <Switch
+                  size="small"
+                  checked={state.seedFaceswap}
+                  onChange={(e) => update({ seedFaceswap: e.target.checked })}
+                />
+              }
+              label="Re-anchor continuation seed"
+            />
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: -0.5, mb: 1 }}>
+              Faceswaps this segment's last frame to the face above before it seeds the next
+              segment, so identity does not drift across a continuation. Falls back to the raw
+              frame when no face is detected.
+            </Typography>
             <ToggleButtonGroup
               value={state.sourceType}
               exclusive

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -2016,6 +2016,7 @@ function SegmentModal({
         presetUri: srcType === "preset" ? lastSegment.faceswap_image ?? null : null,
         facesIndex: lastSegment.faceswap_faces_index ?? DEFAULT_FACESWAP_FACES_INDEX,
         facesOrder: lastSegment.faceswap_faces_order ?? DEFAULT_FACESWAP_FACES_ORDER,
+        seedFaceswap: lastSegment.seed_faceswap ?? false,
       }));
       setStartImageMode("auto");
       setStartImagePath(null);
@@ -2148,6 +2149,7 @@ function SegmentModal({
         faceswap_image: faceswapImageUri,
         faceswap_faces_index: faceswap.enabled ? faceswap.facesIndex : null,
         faceswap_faces_order: faceswap.enabled ? faceswap.facesOrder : null,
+        seed_faceswap: faceswap.enabled && faceswap.seedFaceswap,
         loras:
           loraSlots.length > 0
             ? loraSlots.map((l) => ({

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -7,8 +7,6 @@ import {
   CardContent,
   Chip,
   CircularProgress,
-  FormControlLabel,
-  Switch,
   TextField,
   Typography,
   useMediaQuery,
@@ -26,11 +24,9 @@ export default function SettingsPage() {
   const [input2, setInput2] = useState("");
   const {
     negativePrompt,
-    seedFaceswap,
     loaded,
     fetchSettings,
     saveSettings,
-    setSeedFaceswap,
     setNegativePrompt,
   } = useSettingsStore();
   const [saving, setSaving] = useState(false);
@@ -59,7 +55,6 @@ export default function SettingsPage() {
     try {
       await saveSettings({
         negative_prompt: negativePrompt,
-        seed_faceswap: seedFaceswap,
       });
       setSaved(true);
     } catch (err) {
@@ -199,22 +194,6 @@ export default function SettingsPage() {
                 helperText="Sent as negative conditioning to ComfyUI"
                 sx={{ mt: 2, width: "100%", maxWidth: 500 }}
               />
-              <Box sx={{ mt: 2 }}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={seedFaceswap}
-                      onChange={(e) => setSeedFaceswap(e.target.checked)}
-                    />
-                  }
-                  label="Seed re-anchor (faceswap continuation seed)"
-                />
-                <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: -0.5 }}>
-                  Multi-segment: faceswap each segment's last frame to the canonical identity before it
-                  seeds the next segment. Falls back to the raw frame when no face is detected. Only fires
-                  when a later segment exists.
-                </Typography>
-              </Box>
               <Box sx={{ mt: 2 }}>
                 <Button
                   variant="contained"

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -11,7 +11,6 @@ interface SettingsState {
   defaultHighNoiseSteps: string;
   defaultFlowShift: string;
   negativePrompt: string;
-  seedFaceswap: boolean;
   loaded: boolean;
   fetchSettings: () => Promise<void>;
   saveSettings: (updates: AppSettingsUpdate) => Promise<void>;
@@ -23,7 +22,6 @@ interface SettingsState {
   setDefaultHighNoiseSteps: (value: string) => void;
   setDefaultFlowShift: (value: string) => void;
   setNegativePrompt: (value: string) => void;
-  setSeedFaceswap: (value: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()((set) => ({
@@ -35,7 +33,6 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
   defaultHighNoiseSteps: "2",
   defaultFlowShift: "5",
   negativePrompt: "",
-  seedFaceswap: false,
   loaded: false,
   fetchSettings: async () => {
     try {
@@ -49,7 +46,6 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
         defaultHighNoiseSteps: String(s.high_noise_steps),
         defaultFlowShift: String(s.flow_shift),
         negativePrompt: s.negative_prompt,
-        seedFaceswap: s.seed_faceswap,
         loaded: true,
       });
     } catch {
@@ -68,7 +64,6 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
       defaultHighNoiseSteps: String(s.high_noise_steps),
       defaultFlowShift: String(s.flow_shift),
       negativePrompt: s.negative_prompt,
-      seedFaceswap: s.seed_faceswap,
     });
   },
   setDefaultLightx2vHigh: (value) => set({ defaultLightx2vHigh: value }),
@@ -79,5 +74,4 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
   setDefaultHighNoiseSteps: (value) => set({ defaultHighNoiseSteps: value }),
   setDefaultFlowShift: (value) => set({ defaultFlowShift: value }),
   setNegativePrompt: (value) => set({ negativePrompt: value }),
-  setSeedFaceswap: (value) => set({ seedFaceswap: value }),
 }));


### PR DESCRIPTION
## Change

Replaces the global **Settings → Seed Faceswap** toggle with a per-segment switch inside `FaceswapConfig`, shown when faceswap is enabled:

```
[x] Face swap
    source: [preset ▼] kelly2026
    method: [facefusion ▼]
    Faces Index / Faces Order
    [x] Re-anchor continuation seed
         ↑ uses the face selected above
```

The re-anchor now uses whichever face that segment already selected, instead of the daemon's hardcoded per-character map — so it works for any character.

- `FaceswapConfigState.seedFaceswap` (defaults off)
- sent from **both** paths: `CreateJobDialog` (segment 0) and `JobDetail` (continuations)
- continuations **prefill** from the previous segment, so the choice carries forward
- global toggle, store field and `AppSettings*` types removed — one source of truth

## Verification

- `tsc --noEmit` clean
- `eslint` back to baseline (4 errors / 7 warnings, identical to `main` — all pre-existing)

## Note on tests

This repo has **no test runner** (no vitest/jest, no `test` script), so there's no automated coverage to add here — a known gap, not something introduced by this PR. The contract is covered on the API side instead (`test_seed_faceswap.py`). Happy to add vitest as a separate PR if you want console coverage.

Requires wanly-api + wanly-gpu-daemon PRs — same branch name.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct