### PR TITLE
fix(seed-faceswap): let the seed re-anchor run without a whole-video faceswap

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -435,13 +435,13 @@ export default function CreateJobDialog({
                 }))
               : null,
           faceswap_enabled: faceswap.enabled,
-          faceswap_method: faceswap.enabled ? faceswap.method : null,
-          faceswap_source_type: faceswap.enabled ? faceswap.sourceType : null,
-          faceswap_image: faceswap.enabled && faceswap.sourceType === "preset" ? faceswap.presetUri : null,
+          faceswap_method: faceswap.enabled || faceswap.seedFaceswap ? faceswap.method : null,
+          faceswap_source_type: faceswap.enabled || faceswap.seedFaceswap ? faceswap.sourceType : null,
+          faceswap_image: (faceswap.enabled || faceswap.seedFaceswap) && faceswap.sourceType === "preset" ? faceswap.presetUri : null,
           faceswap_faces_index: faceswap.enabled ? faceswap.facesIndex : null,
           negative_prompt: negativePrompt.trim() || null,
           faceswap_faces_order: faceswap.enabled ? faceswap.facesOrder : null,
-          seed_faceswap: faceswap.enabled && faceswap.seedFaceswap,
+          seed_faceswap: faceswap.seedFaceswap,
         },
       };
 
@@ -450,10 +450,11 @@ export default function CreateJobDialog({
       if (startingImage && !reuseHash) {
         formData.append("starting_image", startingImage);
       }
-      if (faceswap.enabled && faceswap.sourceType === "upload" && faceswap.file) {
+      // a face is needed for a whole-video swap OR a seed-only re-anchor
+      if ((faceswap.enabled || faceswap.seedFaceswap) && faceswap.sourceType === "upload" && faceswap.file) {
         formData.append("faceswap_image", faceswap.file);
       }
-      if (faceswap.enabled && faceswap.sourceType === "start_frame" && startingImage) {
+      if ((faceswap.enabled || faceswap.seedFaceswap) && faceswap.sourceType === "start_frame" && startingImage) {
         formData.append("faceswap_image", startingImage);
       }
 

--- a/src/components/FaceswapConfig.tsx
+++ b/src/components/FaceswapConfig.tsx
@@ -29,8 +29,9 @@ export interface FaceswapConfigState {
   presetUri: string | null;
   facesIndex: string;
   facesOrder: string;
-  /** Also re-anchor the continuation seed: faceswap this segment's last frame to the same
-   *  face before it seeds the next segment. Uses the face selected above. */
+  /** Re-anchor the continuation seed: faceswap this segment's last frame to the selected
+   *  face before it seeds the next segment. INDEPENDENT of `enabled` — the seed can be
+   *  re-anchored without swapping the video. Both share the same face source picker. */
   seedFaceswap: boolean;
 }
 
@@ -84,59 +85,64 @@ export default function FaceswapConfig({
           }
           label="Enable Faceswap"
         />
-        {state.enabled && (
-          <Box sx={{ mt: 1 }}>
-            <TextField
-              label="Method"
-              select
-              size="small"
-              fullWidth
-              value={state.method}
-              onChange={(e) => update({ method: e.target.value })}
-              sx={{ mb: 1 }}
-            >
-              <MenuItem value="reactor">ReActor</MenuItem>
-              <MenuItem value="facefusion">FaceFusion</MenuItem>
-            </TextField>
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mb: 1 }}>
-              <TextField
-                label="Faces Index"
-                size="small"
-                value={state.facesIndex}
-                onChange={(e) => update({ facesIndex: e.target.value })}
-                sx={{ flex: 1, minWidth: 120 }}
-              />
-              <TextField
-                label="Faces Order"
-                size="small"
-                select
-                value={state.facesOrder}
-                onChange={(e) => update({ facesOrder: e.target.value })}
-                sx={{ flex: 1, minWidth: 120 }}
-              >
-                <MenuItem value="left-right">Left → Right</MenuItem>
-                <MenuItem value="right-left">Right → Left</MenuItem>
-                <MenuItem value="top-bottom">Top → Bottom</MenuItem>
-                <MenuItem value="bottom-top">Bottom → Top</MenuItem>
-                <MenuItem value="large-small">Large → Small</MenuItem>
-                <MenuItem value="small-large">Small → Large</MenuItem>
-              </TextField>
-            </Box>
-            <FormControlLabel
-              control={
-                <Switch
-                  size="small"
-                  checked={state.seedFaceswap}
-                  onChange={(e) => update({ seedFaceswap: e.target.checked })}
-                />
-              }
-              label="Re-anchor continuation seed"
+        {/* Independent of the whole-video swap: re-anchoring only touches the single frame
+            that seeds the next segment. Both switches share the face source picker below. */}
+        <FormControlLabel
+          control={
+            <Switch
+              checked={state.seedFaceswap}
+              onChange={(e) => update({ seedFaceswap: e.target.checked })}
             />
-            <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: -0.5, mb: 1 }}>
-              Faceswaps this segment's last frame to the face above before it seeds the next
-              segment, so identity does not drift across a continuation. Falls back to the raw
-              frame when no face is detected.
-            </Typography>
+          }
+          label="Re-anchor continuation seed"
+        />
+        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: -0.5, mb: 1 }}>
+          Faceswaps this segment's last frame to the face below before it seeds the next
+          segment, so identity does not drift across a continuation. Does not alter the video
+          itself. Falls back to the raw frame when no face is detected.
+        </Typography>
+        {(state.enabled || state.seedFaceswap) && (
+          <Box sx={{ mt: 1 }}>
+            {state.enabled && (
+              <>
+                <TextField
+                  label="Method"
+                  select
+                  size="small"
+                  fullWidth
+                  value={state.method}
+                  onChange={(e) => update({ method: e.target.value })}
+                  sx={{ mb: 1 }}
+                >
+                  <MenuItem value="reactor">ReActor</MenuItem>
+                  <MenuItem value="facefusion">FaceFusion</MenuItem>
+                </TextField>
+                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mb: 1 }}>
+                  <TextField
+                    label="Faces Index"
+                    size="small"
+                    value={state.facesIndex}
+                    onChange={(e) => update({ facesIndex: e.target.value })}
+                    sx={{ flex: 1, minWidth: 120 }}
+                  />
+                  <TextField
+                    label="Faces Order"
+                    size="small"
+                    select
+                    value={state.facesOrder}
+                    onChange={(e) => update({ facesOrder: e.target.value })}
+                    sx={{ flex: 1, minWidth: 120 }}
+                  >
+                    <MenuItem value="left-right">Left → Right</MenuItem>
+                    <MenuItem value="right-left">Right → Left</MenuItem>
+                    <MenuItem value="top-bottom">Top → Bottom</MenuItem>
+                    <MenuItem value="bottom-top">Bottom → Top</MenuItem>
+                    <MenuItem value="large-small">Large → Small</MenuItem>
+                    <MenuItem value="small-large">Small → Large</MenuItem>
+                  </TextField>
+                </Box>
+              </>
+            )}
             <ToggleButtonGroup
               value={state.sourceType}
               exclusive
@@ -221,7 +227,7 @@ export default function FaceswapConfig({
     <Typography variant="subtitle2">
       Faceswap
       <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
-        {state.enabled ? `ON — ${state.method}` : "OFF"}
+        {state.enabled ? `ON — ${state.method}` : state.seedFaceswap ? "seed re-anchor only" : "OFF"}
       </Typography>
     </Typography>
   );

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -2117,7 +2117,8 @@ function SegmentModal({
     setSubmitting(true);
     try {
       let faceswapImageUri: string | null = null;
-      if (faceswap.enabled) {
+      // face is needed for a whole-video swap OR a seed-only re-anchor
+      if (faceswap.enabled || faceswap.seedFaceswap) {
         if (faceswap.sourceType === "preset") {
           faceswapImageUri = faceswap.presetUri;
         } else if (faceswap.sourceType === "start_frame") {
@@ -2144,12 +2145,12 @@ function SegmentModal({
         speed,
         start_image: startImageUri,
         faceswap_enabled: faceswap.enabled,
-        faceswap_method: faceswap.enabled ? faceswap.method : null,
-        faceswap_source_type: faceswap.enabled ? faceswap.sourceType : null,
+        faceswap_method: faceswap.enabled || faceswap.seedFaceswap ? faceswap.method : null,
+        faceswap_source_type: faceswap.enabled || faceswap.seedFaceswap ? faceswap.sourceType : null,
         faceswap_image: faceswapImageUri,
         faceswap_faces_index: faceswap.enabled ? faceswap.facesIndex : null,
         faceswap_faces_order: faceswap.enabled ? faceswap.facesOrder : null,
-        seed_faceswap: faceswap.enabled && faceswap.seedFaceswap,
+        seed_faceswap: faceswap.seedFaceswap,
         loras:
           loraSlots.length > 0
             ? loraSlots.map((l) => ({


### PR DESCRIPTION
## Problem

PR #266 nested the re-anchor switch inside the `Enable Faceswap` block, and both payloads sent `faceswap.enabled && faceswap.seedFaceswap`. So the feature was only reachable **with a full-sequence swap turned on — the one configuration where it does nothing.**

With the whole video swapped, `_add_faceswap` feeds VideoCombine from node 87, so the output video is already swapped and the extracted last frame is swapped too. Re-anchoring it would swap an already-swapped face a second time: redundant, and quality-degrading.

The point of the re-anchor is the *opposite* case — no video swap, just a cheap identity anchor on the one frame that seeds the next segment.

## Change

```
[ ] Enable Faceswap              ← whole video
[x] Re-anchor continuation seed  ← last frame only, INDEPENDENT

  ── shown when EITHER is on ──
  Face source: Upload / Preset / Start Frame

  ── shown only with Enable Faceswap ──
  Method, Faces Index, Faces Order
```

- re-anchor promoted to a top-level switch
- face source picker shows when either switch is on
- `faceswap_image`, `faceswap_method`, `faceswap_source_type` now sent for seed-only configs, across **all three** source paths (preset, upload via FormData, start frame)
- `facesIndex`/`facesOrder` stay video-only — the daemon defaults them (`faceswap_faces_order or "left-right"`)
- accordion summary reads `seed re-anchor only` when the video swap is off

Daemon needs no change: `_reanchor_seed_frame` already resolves an unresolved `s3://` URI, which is exactly the seed-only path (`_resolve_faceswap_image` returns `None` when `faceswap_enabled` is false).

## Verification

- `tsc --noEmit` clean
- `eslint` at baseline (4 errors / 7 warnings, unchanged from `main`)
- API contract tests in wanly-api PR #137 pin both directions
- No console test runner — tracked as a separate todo

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct