### PR TITLE
fix(seed-faceswap): expose Method and face selection for a seed-only re-anchor

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -438,9 +438,9 @@ export default function CreateJobDialog({
           faceswap_method: faceswap.enabled || faceswap.seedFaceswap ? faceswap.method : null,
           faceswap_source_type: faceswap.enabled || faceswap.seedFaceswap ? faceswap.sourceType : null,
           faceswap_image: (faceswap.enabled || faceswap.seedFaceswap) && faceswap.sourceType === "preset" ? faceswap.presetUri : null,
-          faceswap_faces_index: faceswap.enabled ? faceswap.facesIndex : null,
+          faceswap_faces_index: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesIndex : null,
           negative_prompt: negativePrompt.trim() || null,
-          faceswap_faces_order: faceswap.enabled ? faceswap.facesOrder : null,
+          faceswap_faces_order: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesOrder : null,
           seed_faceswap: faceswap.seedFaceswap,
         },
       };

--- a/src/components/FaceswapConfig.tsx
+++ b/src/components/FaceswapConfig.tsx
@@ -101,48 +101,54 @@ export default function FaceswapConfig({
           segment, so identity does not drift across a continuation. Does not alter the video
           itself. Falls back to the raw frame when no face is detected.
         </Typography>
+        {state.enabled && state.seedFaceswap && (
+          <Typography variant="caption" color="warning.main" sx={{ display: "block", mb: 1 }}>
+            Both are on. The whole-video swap already swaps the frame the next segment seeds
+            from, so re-anchoring swaps an already-swapped face a second time — redundant, and
+            it can soften the result. Re-anchor is meant for when the video swap is off.
+          </Typography>
+        )}
         {(state.enabled || state.seedFaceswap) && (
           <Box sx={{ mt: 1 }}>
-            {state.enabled && (
-              <>
-                <TextField
-                  label="Method"
-                  select
-                  size="small"
-                  fullWidth
-                  value={state.method}
-                  onChange={(e) => update({ method: e.target.value })}
-                  sx={{ mb: 1 }}
-                >
-                  <MenuItem value="reactor">ReActor</MenuItem>
-                  <MenuItem value="facefusion">FaceFusion</MenuItem>
-                </TextField>
-                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mb: 1 }}>
-                  <TextField
-                    label="Faces Index"
-                    size="small"
-                    value={state.facesIndex}
-                    onChange={(e) => update({ facesIndex: e.target.value })}
-                    sx={{ flex: 1, minWidth: 120 }}
-                  />
-                  <TextField
-                    label="Faces Order"
-                    size="small"
-                    select
-                    value={state.facesOrder}
-                    onChange={(e) => update({ facesOrder: e.target.value })}
-                    sx={{ flex: 1, minWidth: 120 }}
-                  >
-                    <MenuItem value="left-right">Left → Right</MenuItem>
-                    <MenuItem value="right-left">Right → Left</MenuItem>
-                    <MenuItem value="top-bottom">Top → Bottom</MenuItem>
-                    <MenuItem value="bottom-top">Bottom → Top</MenuItem>
-                    <MenuItem value="large-small">Large → Small</MenuItem>
-                    <MenuItem value="small-large">Small → Large</MenuItem>
-                  </TextField>
-                </Box>
-              </>
-            )}
+            {/* Method and face selection apply to BOTH swaps: the seed re-anchor runs the
+                same node stack on one still. With two people in frame, faces order/index is
+                what stops the swap landing on the wrong face. */}
+            <TextField
+              label="Method"
+              select
+              size="small"
+              fullWidth
+              value={state.method}
+              onChange={(e) => update({ method: e.target.value })}
+              sx={{ mb: 1 }}
+            >
+              <MenuItem value="reactor">ReActor</MenuItem>
+              <MenuItem value="facefusion">FaceFusion</MenuItem>
+            </TextField>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mb: 1 }}>
+              <TextField
+                label="Faces Index"
+                size="small"
+                value={state.facesIndex}
+                onChange={(e) => update({ facesIndex: e.target.value })}
+                sx={{ flex: 1, minWidth: 120 }}
+              />
+              <TextField
+                label="Faces Order"
+                size="small"
+                select
+                value={state.facesOrder}
+                onChange={(e) => update({ facesOrder: e.target.value })}
+                sx={{ flex: 1, minWidth: 120 }}
+              >
+                <MenuItem value="left-right">Left → Right</MenuItem>
+                <MenuItem value="right-left">Right → Left</MenuItem>
+                <MenuItem value="top-bottom">Top → Bottom</MenuItem>
+                <MenuItem value="bottom-top">Bottom → Top</MenuItem>
+                <MenuItem value="large-small">Large → Small</MenuItem>
+                <MenuItem value="small-large">Small → Large</MenuItem>
+              </TextField>
+            </Box>
             <ToggleButtonGroup
               value={state.sourceType}
               exclusive

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -2148,8 +2148,8 @@ function SegmentModal({
         faceswap_method: faceswap.enabled || faceswap.seedFaceswap ? faceswap.method : null,
         faceswap_source_type: faceswap.enabled || faceswap.seedFaceswap ? faceswap.sourceType : null,
         faceswap_image: faceswapImageUri,
-        faceswap_faces_index: faceswap.enabled ? faceswap.facesIndex : null,
-        faceswap_faces_order: faceswap.enabled ? faceswap.facesOrder : null,
+        faceswap_faces_index: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesIndex : null,
+        faceswap_faces_order: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesOrder : null,
         seed_faceswap: faceswap.seedFaceswap,
         loras:
           loraSlots.length > 0


### PR DESCRIPTION
## Problem

`Method`, `Faces Index` and `Faces Order` were shown only when the whole-video swap was enabled, and sent as `null` otherwise. I'd reasoned they were "video-specific" — they aren't. They're **per-swap** parameters, and the seed re-anchor runs the same node stack on a single still.

The consequence is a correctness bug, not just a missing option:

```python
faces_order = segment.faceswap_faces_order or "left-right"
faces_index = segment.faceswap_faces_index or "0"
```

That's **the leftmost face in frame**. In a two-person scene it can paste the character's face onto the wrong person — and the controls to fix it were hidden.

`Method` was also hidden while still being sent, so a seed-only config was stuck on the default with no way to choose FaceFusion.

## Change

- Method / Faces Index / Faces Order now show whenever **either** switch is on
- All three sent for seed-only configs
- Both switches remain independently enableable, but a **warning** appears when both are on: the whole-video swap already swaps the frame the next segment seeds from, so re-anchoring swaps an already-swapped face a second time. Warn, don't block.
- Re-indented the block after the conditional wrapper was removed

## Verification

- `tsc --noEmit` clean
- `eslint` at baseline (4 errors / 7 warnings, unchanged from `main`)
- Daemon contract pinned in wanly-gpu-daemon PR #93 (52 tests passing)

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct