### PR TITLE
feat(identity): surface per-segment identity scores in the UI

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -173,6 +173,15 @@ export interface SegmentResponse {
   trim_end_frames: number;
   motion_keywords: string[] | null;
   motion_magnitude: number | null;
+  identity_mean_cos: number | null;
+  identity_mean_cos_ref: number | null;
+  identity_min_cos: number | null;
+  identity_slope: number | null;
+  identity_frames: number | null;
+  identity_no_face: number | null;
+  identity_face_px_p50: number | null;
+  identity_yaw_max: number | null;
+  identity_metrics: Record<string, unknown> | null;
   reference_frames: string[] | null;
   negative_prompt: string | null;
   status: SegmentStatus;
@@ -263,6 +272,19 @@ export interface JobListResponse {
   offset: number;
 }
 
+/** Job-level identity, derived from per-segment scores. Two means kept separate:
+ *  mean_cos = drift from the start frame, mean_cos_ref = is it the character. */
+export interface IdentityAggregate {
+  mean_cos: number | null;
+  mean_cos_ref: number | null;
+  slope: number | null;
+  frames: number;
+  no_face: number;
+  scored_segments: number;
+  worst_segment_index: number | null;
+  worst_segment_slope: number | null;
+}
+
 export interface JobDetailResponse extends JobResponse {
   segments: SegmentResponse[];
   videos: VideoResponse[];
@@ -270,6 +292,7 @@ export interface JobDetailResponse extends JobResponse {
   completed_segment_count: number;
   total_run_time: number;
   total_video_time: number;
+  identity: IdentityAggregate | null;
 }
 
 export interface JobUpdate {

--- a/src/components/IdentityChip.tsx
+++ b/src/components/IdentityChip.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import {
+  Box,
+  Chip,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import TrendingDownIcon from "@mui/icons-material/TrendingDown";
+import TrendingFlatIcon from "@mui/icons-material/TrendingFlat";
+import type { SegmentResponse, IdentityAggregate } from "../api/types";
+
+/** Cosine bands. ArcFace on buffalo_l: ~0.4 is the same-person threshold, 0.6+ is a solid
+ *  match, 0.8+ is strong. These are deliberately not "good/bad" — a profile-heavy clip
+ *  legitimately scores lower than a frontal one, so colour is a hint, not a verdict. */
+function band(v: number | null | undefined): "success" | "warning" | "error" | "default" {
+  if (v == null) return "default";
+  if (v >= 0.7) return "success";
+  if (v >= 0.5) return "warning";
+  return "error";
+}
+
+/** Total drift across the clip, which is more readable than a per-frame slope. */
+function totalDrift(slope: number | null, frames: number | null): number | null {
+  if (slope == null || !frames || frames < 2) return null;
+  return slope * (frames - 1);
+}
+
+function fmt(v: number | null | undefined, digits = 3): string {
+  return v == null ? "—" : v.toFixed(digits);
+}
+
+interface Props {
+  /** A scored segment, or a job-level aggregate. */
+  segment?: SegmentResponse;
+  aggregate?: IdentityAggregate | null;
+  label?: string;
+  size?: "small" | "medium";
+}
+
+export default function IdentityChip({ segment, aggregate, label, size = "small" }: Props) {
+  const [open, setOpen] = useState(false);
+
+  const mean = segment ? segment.identity_mean_cos : aggregate?.mean_cos ?? null;
+  const meanRef = segment ? segment.identity_mean_cos_ref : aggregate?.mean_cos_ref ?? null;
+  const slope = segment ? segment.identity_slope : aggregate?.slope ?? null;
+  const frames = segment ? segment.identity_frames : aggregate?.frames ?? null;
+  const noFace = segment ? segment.identity_no_face : aggregate?.no_face ?? null;
+
+  // Nothing scored — older segments predate the feature. Render nothing rather than a
+  // misleading zero.
+  if (mean == null && meanRef == null) return null;
+
+  const drift = totalDrift(slope, frames);
+  const drifting = drift != null && drift <= -0.02;
+
+  const yawBands = (segment?.identity_metrics as
+    | { yaw_bands?: Record<string, { n: number; mean: number; min: number }> }
+    | null
+    | undefined)?.yaw_bands;
+
+  return (
+    <>
+      <Tooltip
+        title={
+          <>
+            <div>{fmt(mean)} vs start frame — how far this generation drifted</div>
+            <div>{fmt(meanRef)} vs identity reference — is it the character</div>
+            {drift != null && <div>drift {drift >= 0 ? "+" : ""}{drift.toFixed(3)} over {frames} frames</div>}
+            {!!noFace && <div>{noFace} frames with no face detected</div>}
+          </>
+        }
+      >
+        <Chip
+          size={size}
+          color={band(mean)}
+          variant="outlined"
+          icon={drifting ? <TrendingDownIcon /> : <TrendingFlatIcon />}
+          label={`${label ? `${label} ` : ""}${fmt(mean, 2)}`}
+          onClick={() => setOpen(true)}
+          sx={{ cursor: "pointer" }}
+        />
+      </Tooltip>
+
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Identity{segment ? ` — segment ${segment.index}` : ""}</DialogTitle>
+        <DialogContent>
+          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1.5 }}>
+            Two references, because they answer different questions. A low mean with a flat
+            line is a weak-identity problem (dataset or LoRA); a good mean with a steep line is
+            drift over time. The fixes are different.
+          </Typography>
+
+          <Table size="small">
+            <TableBody>
+              <TableRow>
+                <TableCell>vs start frame</TableCell>
+                <TableCell align="right"><strong>{fmt(mean)}</strong></TableCell>
+                <TableCell sx={{ color: "text.secondary" }}>drift of this generation</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>vs identity reference</TableCell>
+                <TableCell align="right"><strong>{fmt(meanRef)}</strong></TableCell>
+                <TableCell sx={{ color: "text.secondary" }}>is it the character</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>drift over clip</TableCell>
+                <TableCell align="right">
+                  {drift == null ? "—" : `${drift >= 0 ? "+" : ""}${drift.toFixed(3)}`}
+                </TableCell>
+                <TableCell sx={{ color: "text.secondary" }}>
+                  {slope == null ? "" : `${slope.toExponential(2)}/frame`}
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>frames</TableCell>
+                <TableCell align="right">{frames ?? "—"}</TableCell>
+                <TableCell sx={{ color: "text.secondary" }}>
+                  {noFace ? `${noFace} with no face detected` : "face found in every frame"}
+                </TableCell>
+              </TableRow>
+              {segment?.identity_face_px_p50 != null && (
+                <TableRow>
+                  <TableCell>face size (median)</TableCell>
+                  <TableCell align="right">{Math.round(segment.identity_face_px_p50)} px</TableCell>
+                  <TableCell sx={{ color: "text.secondary" }}>
+                    max yaw {segment.identity_yaw_max == null ? "—" : `${Math.round(segment.identity_yaw_max)}°`}
+                  </TableCell>
+                </TableRow>
+              )}
+              {aggregate?.worst_segment_index != null && (
+                <TableRow>
+                  <TableCell>worst segment</TableCell>
+                  <TableCell align="right">#{aggregate.worst_segment_index}</TableCell>
+                  <TableCell sx={{ color: "text.secondary" }}>
+                    slope {aggregate.worst_segment_slope?.toExponential(2)}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+
+          {yawBands && Object.keys(yawBands).length > 0 && (
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="subtitle2">By head angle</Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+                Cosine legitimately falls off with pose, so a low overall mean on a
+                profile-heavy clip means something different than on a frontal one.
+              </Typography>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>|yaw|</TableCell>
+                    <TableCell align="right">frames</TableCell>
+                    <TableCell align="right">mean</TableCell>
+                    <TableCell align="right">min</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {Object.entries(yawBands).map(([k, v]) => (
+                    <TableRow key={k}>
+                      <TableCell>{k}°</TableCell>
+                      <TableCell align="right">{v.n}</TableCell>
+                      <TableCell align="right">{v.mean.toFixed(3)}</TableCell>
+                      <TableCell align="right">{v.min.toFixed(3)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </Box>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -88,6 +88,7 @@ import type {
   ImageFile,
 } from "../api/types";
 import StatusChip from "../components/StatusChip";
+import IdentityChip from "../components/IdentityChip";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
 import HologramConfig from "../components/HologramConfig";
 import { QRCodeCanvas } from "qrcode.react";
@@ -696,6 +697,7 @@ export default function JobDetail() {
           </IconButton>
         </Tooltip>
         <StatusChip status={job.status} />
+        <IdentityChip aggregate={job.identity} label="identity" size="medium" />
       </Box>
 
       {error && (
@@ -1121,7 +1123,10 @@ export default function JobDetail() {
                       )}
                     </TableCell>
                     <TableCell>
-                      <StatusChip status={seg.status} />
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap" }}>
+                        <StatusChip status={seg.status} />
+                        <IdentityChip segment={seg} />
+                      </Box>
                     </TableCell>
                     <TableCell>
                       {seg.worker_id ? (
@@ -1326,6 +1331,7 @@ export default function JobDetail() {
                         #{seg.index}
                       </Typography>
                       <StatusChip status={seg.status} />
+                      <IdentityChip segment={seg} />
                       <Box sx={{ ml: "auto", display: "flex", gap: 0.5 }}>
                         {(seg.status === "claimed" || seg.status === "processing") && seg.claimed_at && (
                           <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end" }}>

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -22,6 +22,7 @@ import { Close, Error as ErrorIcon, Favorite, NavigateBefore, NavigateNext, Play
 import { useNavigate } from "react-router";
 import { getJobs, getJob, getFileUrl, getFavorites, toggleFavorite } from "../api/client";
 import type { JobDetailResponse, JobResponse } from "../api/types";
+import IdentityChip from "../components/IdentityChip";
 import { DEFAULT_JOB_FETCH_LIMIT, POLL_INTERVAL_FAST } from "../constants";
 import FavoriteHeart from "../components/FavoriteHeart";
 import { useQueryState, getPage, pageValue, getPerPage, perPageValue } from "../hooks/useQueryState";
@@ -406,9 +407,12 @@ export default function Videos() {
                     </Box>
                   </CardActionArea>
                   <CardContent sx={{ pb: "12px !important" }}>
-                    <Typography variant="subtitle2" noWrap sx={{ mb: 0.5 }}>
-                      {job.name}
-                    </Typography>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 0.5 }}>
+                      <Typography variant="subtitle2" noWrap sx={{ flex: 1, minWidth: 0 }}>
+                        {job.name}
+                      </Typography>
+                      <IdentityChip aggregate={jobDetails[job.id]?.identity ?? null} />
+                    </Box>
                     {job.tags && (
                       <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mb: 0.5 }}>
                         {job.tags.split(",").map((tag, i) => {


### PR DESCRIPTION
Console half of per-segment identity scoring. Pairs with wanly-api #139 and wanly-gpu-daemon #94.

## Changes

**New `IdentityChip`** — one component used in three places so the segment chip and the job/video badge can't drift apart:

- per-segment in the JobDetail table **and** mobile cards
- job-level next to the job status chip
- aggregate badge on each Videos grid card

```
Job "kelly bedroom"   [identity 0.78 ↓]
  seg 0  [completed] [0.83 →]
  seg 1  [completed] [0.79 ↓]
  seg 2  [completed] [0.71 ↓]   ← click for the breakdown
```

## The dialog shows both means, not one

| | |
|---|---|
| vs start frame | how far *this generation* drifted |
| vs identity reference | is it the character at all |
| drift over clip | total, plus the per-frame slope |

On the CTRL clip these were **0.811** and **0.489** — either alone is misleading. The first hides that the start frame was already 0.29 off the character; the second looks like catastrophic failure when the generation actually held well.

Also breaks cosine down **by |yaw| band**, because identity legitimately falls off with pose — a low overall mean on a profile-heavy clip means something different than on a frontal one.

## Details

- **Renders nothing** when a segment has no score, so jobs predating the feature look normal rather than showing a misleading zero
- Colour bands are a hint, not a verdict (~0.4 same-person threshold, 0.6+ solid, 0.7+ strong on buffalo_l)
- Drift is shown as **total over the clip** rather than a raw per-frame slope, which is unreadable at ~1e-3

## Verification

`tsc --noEmit` clean; eslint **at baseline** (4 errors / 7 warnings, identical to `main` — all pre-existing).

No automated coverage: this repo still has no test runner, tracked separately. That gap is why the payload types matter here — the new fields are typed on `SegmentResponse` and `JobDetailResponse` so `tsc` catches a rename, though not an omission.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct