### PR TITLE
fix(identity): headline the cumulative score, not the per-segment one

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -283,6 +283,10 @@ export interface IdentityAggregate {
   scored_segments: number;
   worst_segment_index: number | null;
   worst_segment_slope: number | null;
+  /** Cumulative low point across the job's segments, and where it happened. A job can
+   *  average well while a late segment has lost the character entirely. */
+  min_cos_ref: number | null;
+  min_cos_ref_segment_index: number | null;
 }
 
 export interface JobDetailResponse extends JobResponse {

--- a/src/components/IdentityChip.tsx
+++ b/src/components/IdentityChip.tsx
@@ -50,6 +50,23 @@ export default function IdentityChip({ segment, aggregate, label, size = "small"
 
   const mean = segment ? segment.identity_mean_cos : aggregate?.mean_cos ?? null;
   const meanRef = segment ? segment.identity_mean_cos_ref : aggregate?.mean_cos_ref ?? null;
+
+  // HEADLINE THE CUMULATIVE NUMBER, not the per-segment one.
+  //
+  // "vs start" measures drift within a segment, from ITS OWN first frame. For a
+  // continuation that first frame is the previous segment's LAST frame, which has already
+  // drifted - so a segment can look internally stable while identity has collapsed since
+  // the job began. Observed on a real 2-segment job: seg1 read 0.785 vs start (green,
+  // "healthy") while sitting at 0.544 vs the job's original image - visibly a different
+  // person. Showing the reassuring number is worse than showing none.
+  // For a job badge, headline the worst segment's cumulative score rather than the average:
+  // an average over segments hides a late collapse, which is the shape multi-segment drift
+  // actually takes.
+  const cumulative = aggregate
+    ? aggregate.min_cos_ref ?? aggregate.mean_cos_ref ?? aggregate.mean_cos
+    : meanRef ?? mean;
+  const local = mean;
+  const showsBoth = meanRef != null && mean != null && Math.abs(meanRef - mean) > 0.005;
   const slope = segment ? segment.identity_slope : aggregate?.slope ?? null;
   const frames = segment ? segment.identity_frames : aggregate?.frames ?? null;
   const noFace = segment ? segment.identity_no_face : aggregate?.no_face ?? null;
@@ -71,8 +88,16 @@ export default function IdentityChip({ segment, aggregate, label, size = "small"
       <Tooltip
         title={
           <>
-            <div>{fmt(mean)} vs start frame — how far this generation drifted</div>
-            <div>{fmt(meanRef)} vs identity reference — is it the character</div>
+            <div>
+              <strong>{fmt(meanRef)}</strong> vs the job's reference — cumulative, since the job began
+            </div>
+            <div>{fmt(mean)} vs this segment's own start frame — drift within this segment only</div>
+            {showsBoth && (
+              <div style={{ marginTop: 4 }}>
+                A continuation starts from the previous segment's last frame, so the second
+                number can look healthy while identity has already been lost.
+              </div>
+            )}
             {drift != null && <div>drift {drift >= 0 ? "+" : ""}{drift.toFixed(3)} over {frames} frames</div>}
             {!!noFace && <div>{noFace} frames with no face detected</div>}
           </>
@@ -80,10 +105,10 @@ export default function IdentityChip({ segment, aggregate, label, size = "small"
       >
         <Chip
           size={size}
-          color={band(mean)}
+          color={band(cumulative)}
           variant="outlined"
           icon={drifting ? <TrendingDownIcon /> : <TrendingFlatIcon />}
-          label={`${label ? `${label} ` : ""}${fmt(mean, 2)}`}
+          label={`${label ? `${label} ` : ""}${fmt(cumulative, 2)}${showsBoth ? ` (${fmt(local, 2)})` : ""}`}
           onClick={() => setOpen(true)}
           sx={{ cursor: "pointer" }}
         />
@@ -93,22 +118,27 @@ export default function IdentityChip({ segment, aggregate, label, size = "small"
         <DialogTitle>Identity{segment ? ` — segment ${segment.index}` : ""}</DialogTitle>
         <DialogContent>
           <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1.5 }}>
-            Two references, because they answer different questions. A low mean with a flat
-            line is a weak-identity problem (dataset or LoRA); a good mean with a steep line is
-            drift over time. The fixes are different.
+            The headline is the CUMULATIVE number — how far identity has moved since the job
+            started. A continuation segment begins from the previous segment's last frame, so
+            its "own start frame" score can look healthy while the character has already been
+            lost. Judge a job by the cumulative column.
           </Typography>
 
           <Table size="small">
             <TableBody>
               <TableRow>
-                <TableCell>vs start frame</TableCell>
-                <TableCell align="right"><strong>{fmt(mean)}</strong></TableCell>
-                <TableCell sx={{ color: "text.secondary" }}>drift of this generation</TableCell>
+                <TableCell>vs job reference</TableCell>
+                <TableCell align="right"><strong>{fmt(meanRef)}</strong></TableCell>
+                <TableCell sx={{ color: "text.secondary" }}>
+                  cumulative — since the job began
+                </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell>vs identity reference</TableCell>
-                <TableCell align="right"><strong>{fmt(meanRef)}</strong></TableCell>
-                <TableCell sx={{ color: "text.secondary" }}>is it the character</TableCell>
+                <TableCell>vs own start frame</TableCell>
+                <TableCell align="right">{fmt(mean)}</TableCell>
+                <TableCell sx={{ color: "text.secondary" }}>
+                  within this segment only
+                </TableCell>
               </TableRow>
               <TableRow>
                 <TableCell>drift over clip</TableCell>
@@ -132,6 +162,15 @@ export default function IdentityChip({ segment, aggregate, label, size = "small"
                   <TableCell align="right">{Math.round(segment.identity_face_px_p50)} px</TableCell>
                   <TableCell sx={{ color: "text.secondary" }}>
                     max yaw {segment.identity_yaw_max == null ? "—" : `${Math.round(segment.identity_yaw_max)}°`}
+                  </TableCell>
+                </TableRow>
+              )}
+              {aggregate?.min_cos_ref != null && (
+                <TableRow>
+                  <TableCell>lowest segment</TableCell>
+                  <TableCell align="right"><strong>{fmt(aggregate.min_cos_ref)}</strong></TableCell>
+                  <TableCell sx={{ color: "text.secondary" }}>
+                    segment #{aggregate.min_cos_ref_segment_index} — cumulative low point
                   </TableCell>
                 </TableRow>
               )}


### PR DESCRIPTION
## The bug

A real 2-segment job rendered like this:

```
seg 0   [completed]  [0.76]   green
seg 1   [completed]  [0.78]   green   ← visibly a different person
```

The underlying numbers:

```
seg 0   0.764 vs own start   0.764 vs job reference
seg 1   0.785 vs own start   0.544 vs job reference
```

I headlined `identity_mean_cos` — drift **within** a segment, from its own first frame. A continuation's first frame is the previous segment's **already-drifted** last frame, so the number measures local stability while cumulative identity collapses. Segment 1 should have read **0.54**, not 0.78.

The colour band made it worse: both cleared the 0.7 threshold and rendered green, so the UI actively said "healthy" while the character was being lost. **Showing the reassuring number is worse than showing none** — this is exactly the failure the feature exists to catch, reintroduced in the display layer.

## Fix

- **Chip headlines the cumulative score**, with the local one in parentheses when they differ: `0.54 (0.79)`
- **Colour bands off the cumulative number**, so it can't read green while identity has gone
- **Job badges headline their worst segment** (`min_cos_ref`), not the average — an average over segments hides a late collapse, which is the shape multi-segment drift actually takes
- **Dialog leads with the cumulative row**, labels the other "within this segment only", adds a "lowest segment" row, and explains why a continuation's own-start score can look healthy when it isn't

## Verification

`tsc --noEmit` clean; eslint at baseline (4 errors / 7 warnings, unchanged from `main`).

Requires wanly-api #140 for `min_cos_ref` / `min_cos_ref_segment_index`.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct