### PR TITLE
feat(identity): show the trajectory instead of a single number

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -181,6 +181,8 @@ export interface SegmentResponse {
   identity_no_face: number | null;
   identity_face_px_p50: number | null;
   identity_yaw_max: number | null;
+  identity_start_cos_ref: number | null;
+  identity_end_cos_ref: number | null;
   identity_metrics: Record<string, unknown> | null;
   reference_frames: string[] | null;
   negative_prompt: string | null;
@@ -287,6 +289,9 @@ export interface IdentityAggregate {
    *  average well while a late segment has lost the character entirely. */
   min_cos_ref: number | null;
   min_cos_ref_segment_index: number | null;
+  /** Job trajectory: first segment's opening frame -> last segment's closing frame. */
+  start_cos_ref: number | null;
+  end_cos_ref: number | null;
 }
 
 export interface JobDetailResponse extends JobResponse {

--- a/src/components/IdentityChip.tsx
+++ b/src/components/IdentityChip.tsx
@@ -62,9 +62,17 @@ export default function IdentityChip({ segment, aggregate, label, size = "small"
   // For a job badge, headline the worst segment's cumulative score rather than the average:
   // an average over segments hides a late collapse, which is the shape multi-segment drift
   // actually takes.
-  const cumulative = aggregate
-    ? aggregate.min_cos_ref ?? aggregate.mean_cos_ref ?? aggregate.mean_cos
-    : meanRef ?? mean;
+  // Trajectory against the job's ground truth: seg0 frame 0. Loss is start - end, and a
+  // continuation begins where the previous segment ended, so these chain across the job.
+  const startRef = segment ? segment.identity_start_cos_ref : aggregate?.start_cos_ref ?? null;
+  const endRef = segment ? segment.identity_end_cos_ref : aggregate?.end_cos_ref ?? null;
+  const loss = startRef != null && endRef != null ? startRef - endRef : null;
+
+  const cumulative =
+    endRef ??
+    (aggregate
+      ? aggregate.min_cos_ref ?? aggregate.mean_cos_ref ?? aggregate.mean_cos
+      : meanRef ?? mean);
   const local = mean;
   const showsBoth = meanRef != null && mean != null && Math.abs(meanRef - mean) > 0.005;
   const slope = segment ? segment.identity_slope : aggregate?.slope ?? null;
@@ -108,7 +116,11 @@ export default function IdentityChip({ segment, aggregate, label, size = "small"
           color={band(cumulative)}
           variant="outlined"
           icon={drifting ? <TrendingDownIcon /> : <TrendingFlatIcon />}
-          label={`${label ? `${label} ` : ""}${fmt(cumulative, 2)}${showsBoth ? ` (${fmt(local, 2)})` : ""}`}
+          label={
+            startRef != null && endRef != null
+              ? `${label ? `${label} ` : ""}${fmt(startRef, 2)}→${fmt(endRef, 2)}`
+              : `${label ? `${label} ` : ""}${fmt(cumulative, 2)}${showsBoth ? ` (${fmt(local, 2)})` : ""}`
+          }
           onClick={() => setOpen(true)}
           sx={{ cursor: "pointer" }}
         />
@@ -126,6 +138,17 @@ export default function IdentityChip({ segment, aggregate, label, size = "small"
 
           <Table size="small">
             <TableBody>
+              {startRef != null && endRef != null && (
+                <TableRow>
+                  <TableCell>trajectory</TableCell>
+                  <TableCell align="right">
+                    <strong>{fmt(startRef)} → {fmt(endRef)}</strong>
+                  </TableCell>
+                  <TableCell sx={{ color: "text.secondary" }}>
+                    lost {loss == null ? "—" : loss.toFixed(3)} against ground truth
+                  </TableCell>
+                </TableRow>
+              )}
               <TableRow>
                 <TableCell>vs job reference</TableCell>
                 <TableCell align="right"><strong>{fmt(meanRef)}</strong></TableCell>


### PR DESCRIPTION
## Why

The mean cosine blurs the shape of the drift. A segment sliding **0.95 → 0.65** averages about the same as one sitting flat at **0.80** — and only the first has lost the character.

David's model, which is the right one: **seg0's start frame is ground truth.** Every segment is measured against it, and because a continuation begins where the previous ended, the endpoints chain across the job:

```
seg0   0.98 -> 0.85    loss 0.13
seg1   0.85 -> 0.60    loss 0.25
job    0.98 -> 0.60
```

The reference was already correct — `initial_reference_image` resolves to the job's starting image for every segment. Only the aggregation was wrong.

## Verification

Ground truth re-checked on `real_CTRL.mp4`, means unchanged:

| | |
|---|---|
| frames / no_face | 73 / 0 |
| mean vs start | 0.8136 |
| mean vs ref | 0.4894 |
| **trajectory** | **0.6218 → 0.3871, loss +0.235** |

That trajectory is information the 0.489 mean was hiding — it is simply the midpoint of the slide.

New tests include one that builds a decaying clip and a flat clip with **matching means** and asserts only the loss separates them.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct

Chips read `0.98→0.60`. tsc clean, eslint at baseline.