### PR TITLE
Show the per-frame identity trajectory in the segment modal

### DIFF
--- a/src/components/IdentityChip.tsx
+++ b/src/components/IdentityChip.tsx
@@ -16,6 +16,7 @@ import {
 import TrendingDownIcon from "@mui/icons-material/TrendingDown";
 import TrendingFlatIcon from "@mui/icons-material/TrendingFlat";
 import type { SegmentResponse, IdentityAggregate } from "../api/types";
+import IdentityTrajectory from "./IdentityTrajectory";
 
 /** Cosine bands. ArcFace on buffalo_l: ~0.4 is the same-person threshold, 0.6+ is a solid
  *  match, 0.8+ is strong. These are deliberately not "good/bad" — a profile-heavy clip
@@ -133,8 +134,10 @@ export default function IdentityChip({ segment, aggregate, label, size = "small"
         <DialogContent>
           <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1.5 }}>
             Everything here is measured against <strong>segment 0's start frame</strong> —
-            that image defines the character, and nothing else is used. The headline is the
-            trajectory: where identity started and where it ended. Judge by the loss.
+            that image defines the character, and nothing else is used. Judge by{" "}
+            <strong>mean and min</strong>, not the loss: loss is start minus end, so on a clip
+            that dips and recovers it can point the wrong way. One real segment scored a mean of
+            0.609 while sitting <em>above</em> that at both endpoints.
           </Typography>
 
           <Table size="small">
@@ -213,6 +216,8 @@ export default function IdentityChip({ segment, aggregate, label, size = "small"
               )}
             </TableBody>
           </Table>
+
+          <IdentityTrajectory metrics={segment?.identity_metrics} />
 
           {yawBands && Object.keys(yawBands).length > 0 && (
             <Box sx={{ mt: 2 }}>

--- a/src/components/IdentityTrajectory.tsx
+++ b/src/components/IdentityTrajectory.tsx
@@ -1,0 +1,151 @@
+import { Box, Typography, useTheme } from "@mui/material";
+
+/** Per-frame cosine, already stored by the daemon in identity_metrics.series.
+ *
+ *  WHY THIS EXISTS: start and end alone cannot distinguish a clip that decayed steadily
+ *  from one that held and then dipped on the final frames. Those two produce identical
+ *  headline numbers and call for opposite fixes — and it matters more than a display
+ *  detail, because the daemon seeds the NEXT segment from the LAST frame. If that frame
+ *  is a blink or a motion blur, the continuation inherits the worst moment of the clip
+ *  and every later segment compounds an artifact that was never really there.
+ *
+ *  Observed on a real 2-segment job: seg1 read 0.851 -> 0.506 while the fitted slope was
+ *  POSITIVE (+3.5e-4/frame). Endpoints falling while the trend rises is exactly the shape
+ *  the summary stats cannot express. */
+
+/** How many trailing samples count as "the end" when judging whether the last frame is
+ *  representative. Short enough to be local, long enough not to be one noisy sample. */
+const TAIL = 12;
+/** Below this the endpoint is just noise; a dip has to be worth acting on. */
+const DIP_THRESHOLD = 0.05;
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = s.length >> 1;
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+interface Props {
+  metrics: Record<string, unknown> | null | undefined;
+}
+
+export default function IdentityTrajectory({ metrics }: Props) {
+  const theme = useTheme();
+
+  const series = (metrics?.series as number[] | undefined) ?? undefined;
+  const stride = (metrics?.stride as number | undefined) ?? 1;
+  if (!series || series.length < 8) return null;
+
+  const lo = Math.min(...series);
+  const hi = Math.max(...series);
+  const span = Math.max(hi - lo, 0.02); // guard a flat clip from dividing by ~0
+  const mean = series.reduce((a, b) => a + b, 0) / series.length;
+
+  const W = 600;
+  const H = 120;
+  const x = (i: number) => (i / (series.length - 1)) * W;
+  const y = (v: number) => H - ((v - lo) / span) * H;
+  const points = series.map((v, i) => `${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(" ");
+
+  // Is the final frame representative of where the clip actually settled?
+  const end = series[series.length - 1];
+  const body = series.slice(-TAIL, -2);
+  const bodyMedian = body.length >= 4 ? median(body) : null;
+  const dip = bodyMedian != null ? bodyMedian - end : null;
+  const isDip = dip != null && dip >= DIP_THRESHOLD;
+
+  // If it IS a dip, the fix is to seed the next segment from the best frame in the tail
+  // rather than strictly the last one — so show what that frame would have been worth.
+  const tail = series.slice(-TAIL);
+  const bestTail = Math.max(...tail);
+  const bestOffset = tail.length - 1 - tail.lastIndexOf(bestTail);
+
+  const line = theme.palette.mode === "dark" ? theme.palette.primary.light : theme.palette.primary.main;
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Typography variant="subtitle2">Per-frame trajectory</Typography>
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+        Cosine for every scored frame. The next segment is seeded from the <strong>last</strong>{" "}
+        frame, so a dip at the right-hand edge propagates into everything that follows.
+        {stride > 1 && ` Sampled every ${stride} frames.`}
+      </Typography>
+
+      <Box
+        sx={{
+          border: 1,
+          borderColor: "divider",
+          borderRadius: 1,
+          p: 1,
+          overflowX: "auto",
+        }}
+      >
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          preserveAspectRatio="none"
+          style={{ width: "100%", height: 120, display: "block" }}
+        >
+          {/* the clip's own mean — makes "the end is below typical" visible at a glance */}
+          <line
+            x1={0}
+            x2={W}
+            y1={y(mean)}
+            y2={y(mean)}
+            stroke={theme.palette.text.disabled}
+            strokeDasharray="4 4"
+            strokeWidth={1}
+            vectorEffect="non-scaling-stroke"
+          />
+          <polyline
+            points={points}
+            fill="none"
+            stroke={line}
+            strokeWidth={1.5}
+            vectorEffect="non-scaling-stroke"
+          />
+          <circle
+            cx={x(series.length - 1)}
+            cy={y(end)}
+            r={3}
+            fill={isDip ? theme.palette.error.main : theme.palette.success.main}
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+      </Box>
+
+      <Box sx={{ display: "flex", justifyContent: "space-between", mt: 0.5 }}>
+        <Typography variant="caption" color="text.secondary">
+          y-axis {lo.toFixed(3)} – {hi.toFixed(3)} (dashed = mean {mean.toFixed(3)})
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {series.length} samples
+        </Typography>
+      </Box>
+
+      <Typography
+        variant="caption"
+        component="div"
+        sx={{ mt: 1, fontFamily: "monospace", wordBreak: "break-word" }}
+      >
+        last {TAIL}: {tail.map((v) => v.toFixed(3)).join("  ")}
+      </Typography>
+
+      {isDip ? (
+        <Typography variant="caption" component="div" color="error.main" sx={{ mt: 1 }}>
+          <strong>The final frame is a dip, not the settled state.</strong> The clip sits around{" "}
+          {bodyMedian!.toFixed(3)} through its tail and ends at {end.toFixed(3)} —{" "}
+          {dip!.toFixed(3)} lower. The next segment is seeded from that frame. The best frame in
+          the last {TAIL} scores {bestTail.toFixed(3)} ({bestOffset} frames from the end), so
+          re-anchoring — or seeding from the best tail frame instead of the last — would start the
+          continuation {(bestTail - end).toFixed(3)} higher.
+        </Typography>
+      ) : (
+        <Typography variant="caption" component="div" color="text.secondary" sx={{ mt: 1 }}>
+          The final frame is consistent with the tail (median {bodyMedian?.toFixed(3) ?? "—"}), so
+          the endpoint reflects where the clip actually settled — any loss here is real drift, not
+          a bad frame.
+        </Typography>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Why

Start and end alone cannot distinguish these two clips:

```
A  real decay    0.85 ▔▔▚▄▄▃▃▂▂▁▁ 0.51   endpoint reflects where the clip settled
B  end blip      0.85 ▔▚▃▃▃▃▃▃▃▚▁ 0.51   clip is really ~0.65; last frame caught a blink
```

Identical headline numbers, opposite diagnoses, opposite fixes.

This is not a display nicety. The daemon seeds the next segment from `_extract_last_frame`, so under shape **B** the continuation is anchored to the single worst frame in the segment and every later segment compounds an artifact that was never really there.

Seen on a real 2-segment job today: seg1 read `0.851 → 0.506` while its fitted slope was **positive** (+3.5e-4/frame). Endpoints falling while the trend rises is exactly the shape summary stats cannot express.

## What

The daemon has been storing per-frame cosine in `identity_metrics.series` since the feature shipped — nothing surfaced it. This adds `IdentityTrajectory`, rendered in the segment modal:

- inline SVG sparkline (no new dependency), dashed line at the clip's own mean, endpoint marked
- the last 12 values as plain numbers
- a verdict: whether the endpoint is consistent with the tail, or a dip — and if a dip, what the best tail frame would be worth as an anchor

Also corrects the modal's "judge by the loss" guidance. Loss is start − end, which points the wrong way on a non-monotonic clip; one real segment scored a mean of 0.609 while sitting *above* that at both endpoints. Mean and min are now the stated headline.

## Verification

`tsc --noEmit` clean, `eslint` clean, `npm run build` succeeds.

No console test runner exists yet (tracked separately), so the dip detector was checked against two synthetic series that both end at ~0.506:

```
A steady decay  end 0.506  tail median 0.519  dip 0.013  -> "real drift"
B end blip      end 0.505  tail median 0.641  dip 0.136  -> "dip; best tail frame +0.146"
```

Console-only change — no API, daemon, or schema changes. Reads a field the API already returns via `SegmentResponse.model_validate`.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct