### PR TITLE
Source a continuation's faceswap from the job's start image

### DIFF
--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -2128,7 +2128,13 @@ function SegmentModal({
         if (faceswap.sourceType === "preset") {
           faceswapImageUri = faceswap.presetUri;
         } else if (faceswap.sourceType === "start_frame") {
-          faceswapImageUri = lastSegment?.last_frame_path ?? job.starting_image ?? null;
+          // The JOB's starting image — segment 0's start frame — not the previous segment's
+          // last frame. A continuation's last frame has already drifted; swapping toward it
+          // locks that drift in permanently. Measured: sourcing the swap from the job's start
+          // image scores 0.906 mean identity, sourcing it from a drifted/other face scores
+          // 0.644 and pulls the face away from the reference before a single frame of motion.
+          // It also matches identity_ground_truth, which is what the score is computed against.
+          faceswapImageUri = job.starting_image ?? lastSegment?.last_frame_path ?? null;
         } else if (faceswap.file) {
           const result = await uploadFile(faceswap.file, jobId);
           faceswapImageUri = result.path;


### PR DESCRIPTION
## The bug

Choosing **Faceswap → Start Frame** on a continuation resolved to the *previous segment's* last frame:

```js
faceswapImageUri = lastSegment?.last_frame_path ?? job.starting_image ?? null;
```

That frame has already drifted. Swapping toward it pulls identity toward the drift and locks it in — the opposite of what the control exists for.

## Impact, measured

On the fixed harness (same start image, seed, prompt, sampler; only the swap source differs):

```
swap sourced from the job's start image    mean 0.906
swap sourced from another/drifted face     mean 0.644
                                           start cosine 0.955 -> 0.686 before any motion
```

The swap is competent either way — it was aimed at the wrong face. This is also the same class of bug that made the seed re-anchor a no-op ([daemon#98](https://github.com/DavidJBarnes/wanly-gpu-daemon/pull/98)).

The job's start image is what `identity_ground_truth` is set to, so this aligns the correction with what the score is computed against.

## Scope

Job creation already did the right thing (`CreateJobDialog` passes `startingImage`), so this only ever affected continuations — which is precisely where identity mattered most.

`tsc` clean, `eslint` clean (6 pre-existing warnings unchanged), build passes.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct