### PR TITLE
Expose swapper model and pixel boost, default to FaceFusion

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -20,6 +20,8 @@ export interface SegmentCreate {
   faceswap_image?: string | null;
   faceswap_faces_order?: string | null;
   faceswap_faces_index?: string | null;
+  faceswap_model?: string | null;
+  faceswap_pixel_boost?: string | null;
   seed_faceswap?: boolean;
   negative_prompt?: string | null;
   auto_finalize?: boolean;
@@ -166,6 +168,8 @@ export interface SegmentResponse {
   faceswap_image: string | null;
   faceswap_faces_order: string | null;
   faceswap_faces_index: string | null;
+  faceswap_model: string | null;
+  faceswap_pixel_boost: string | null;
   seed_faceswap: boolean;
   auto_finalize: boolean;
   transition: string | null;
@@ -578,4 +582,6 @@ export interface SegmentReprocessRequest {
   faceswap_image?: string | null;
   faceswap_faces_order?: string | null;
   faceswap_faces_index?: string | null;
+  faceswap_model?: string | null;
+  faceswap_pixel_boost?: string | null;
 }

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -439,6 +439,8 @@ export default function CreateJobDialog({
           faceswap_source_type: faceswap.enabled || faceswap.seedFaceswap ? faceswap.sourceType : null,
           faceswap_image: (faceswap.enabled || faceswap.seedFaceswap) && faceswap.sourceType === "preset" ? faceswap.presetUri : null,
           faceswap_faces_index: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesIndex : null,
+          faceswap_model: faceswap.enabled || faceswap.seedFaceswap ? faceswap.model : null,
+          faceswap_pixel_boost: faceswap.enabled || faceswap.seedFaceswap ? faceswap.pixelBoost : null,
           negative_prompt: negativePrompt.trim() || null,
           faceswap_faces_order: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesOrder : null,
           seed_faceswap: faceswap.seedFaceswap,

--- a/src/components/FaceswapConfig.tsx
+++ b/src/components/FaceswapConfig.tsx
@@ -19,6 +19,10 @@ import {
   DEFAULT_FACESWAP_METHOD,
   DEFAULT_FACESWAP_FACES_INDEX,
   DEFAULT_FACESWAP_FACES_ORDER,
+  DEFAULT_FACESWAP_MODEL,
+  DEFAULT_FACESWAP_PIXEL_BOOST,
+  FACESWAP_MODELS,
+  FACESWAP_PIXEL_BOOSTS,
 } from "../constants";
 
 export interface FaceswapConfigState {
@@ -29,6 +33,9 @@ export interface FaceswapConfigState {
   presetUri: string | null;
   facesIndex: string;
   facesOrder: string;
+  /** FaceFusion only. Swapper network and the resolution the target crop is sampled at. */
+  model: string;
+  pixelBoost: string;
   /** Re-anchor the continuation seed: faceswap this segment's last frame to the selected
    *  face before it seeds the next segment. INDEPENDENT of `enabled` — the seed can be
    *  re-anchored without swapping the video. Both share the same face source picker. */
@@ -44,6 +51,8 @@ export function defaultFaceswapState(overrides?: Partial<FaceswapConfigState>): 
     presetUri: null,
     facesIndex: DEFAULT_FACESWAP_FACES_INDEX,
     facesOrder: DEFAULT_FACESWAP_FACES_ORDER,
+    model: DEFAULT_FACESWAP_MODEL,
+    pixelBoost: DEFAULT_FACESWAP_PIXEL_BOOST,
     seedFaceswap: false,
     ...overrides,
   };
@@ -125,6 +134,38 @@ export default function FaceswapConfig({
               <MenuItem value="reactor">ReActor</MenuItem>
               <MenuItem value="facefusion">FaceFusion</MenuItem>
             </TextField>
+            {/* FaceFusion-only knobs. Neither moved identity or face detail in testing
+                (inswapper_128@512 vs hyperswap_1c_256@256: 0.910 vs 0.908 identity, 177.1 vs
+                176.5 detail) — exposed because they are the levers for speckling on off-axis
+                faces, which no metric here can see. */}
+            {state.method === "facefusion" && (
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mb: 1 }}>
+                <TextField
+                  label="Swapper Model"
+                  select
+                  size="small"
+                  value={state.model}
+                  onChange={(e) => update({ model: e.target.value })}
+                  sx={{ flex: 1, minWidth: 160 }}
+                >
+                  {FACESWAP_MODELS.map((m) => (
+                    <MenuItem key={m} value={m}>{m}</MenuItem>
+                  ))}
+                </TextField>
+                <TextField
+                  label="Pixel Boost"
+                  select
+                  size="small"
+                  value={state.pixelBoost}
+                  onChange={(e) => update({ pixelBoost: e.target.value })}
+                  sx={{ flex: 1, minWidth: 120 }}
+                >
+                  {FACESWAP_PIXEL_BOOSTS.map((b) => (
+                    <MenuItem key={b} value={b}>{b}</MenuItem>
+                  ))}
+                </TextField>
+              </Box>
+            )}
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mb: 1 }}>
               <TextField
                 label="Faces Index"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,24 @@ export const DEFAULT_SPEED = 1.0;
 // Faceswap defaults
 export const DEFAULT_FACESWAP_ENABLED = false;
 export const DEFAULT_FACESWAP_SOURCE_TYPE = "preset" as const;
-export const DEFAULT_FACESWAP_METHOD = "reactor";
+// FaceFusion selects the target face by MATCHING the source identity (face_selector_mode
+// "reference"). ReActor selects by POSITION (faces index 0, left-right), so on a two-person
+// frame it swaps whichever face is furthest left - frequently the wrong person - while still
+// changing pixels, so it reports success. That is what made the seed re-anchor a measured
+// no-op (+0.014 identity from a full swap). The validated recipe uses FaceFusion.
+export const DEFAULT_FACESWAP_METHOD = "facefusion";
+// Swapper model + pixel boost. inswapper_128 at 512x512 is the validated pair; measured
+// identical to hyperswap_1c_256 at 256 on both identity (0.910 vs 0.908) and face detail
+// (177.1 vs 176.5), and David preferred it visually on speckling.
+export const DEFAULT_FACESWAP_MODEL = "inswapper_128";
+export const DEFAULT_FACESWAP_PIXEL_BOOST = "512x512";
+export const FACESWAP_MODELS = [
+  "inswapper_128", "inswapper_128_fp16", "hyperswap_1a_256", "hyperswap_1b_256",
+  "hyperswap_1c_256", "ghost_1_256", "ghost_2_256", "ghost_3_256",
+  "hififace_unofficial_256", "blendswap_256", "simswap_256", "simswap_unofficial_512",
+  "uniface_256",
+] as const;
+export const FACESWAP_PIXEL_BOOSTS = ["256x256", "512x512", "768x768", "1024x1024"] as const;
 export const DEFAULT_FACESWAP_FACES_INDEX = "0";
 export const DEFAULT_FACESWAP_FACES_ORDER = "left-right";
 

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -97,6 +97,8 @@ import {
   DEFAULT_SPEED,
   DEFAULT_FACESWAP_METHOD,
   DEFAULT_FACESWAP_FACES_INDEX,
+  DEFAULT_FACESWAP_MODEL,
+  DEFAULT_FACESWAP_PIXEL_BOOST,
   DEFAULT_FACESWAP_FACES_ORDER,
   MAX_LORAS,
   POLL_INTERVAL_FAST,
@@ -2021,6 +2023,8 @@ function SegmentModal({
         method: lastSegment.faceswap_method ?? DEFAULT_FACESWAP_METHOD,
         presetUri: srcType === "preset" ? lastSegment.faceswap_image ?? null : null,
         facesIndex: lastSegment.faceswap_faces_index ?? DEFAULT_FACESWAP_FACES_INDEX,
+        model: lastSegment.faceswap_model ?? DEFAULT_FACESWAP_MODEL,
+        pixelBoost: lastSegment.faceswap_pixel_boost ?? DEFAULT_FACESWAP_PIXEL_BOOST,
         facesOrder: lastSegment.faceswap_faces_order ?? DEFAULT_FACESWAP_FACES_ORDER,
         seedFaceswap: lastSegment.seed_faceswap ?? false,
       }));
@@ -2161,6 +2165,8 @@ function SegmentModal({
         faceswap_source_type: faceswap.enabled || faceswap.seedFaceswap ? faceswap.sourceType : null,
         faceswap_image: faceswapImageUri,
         faceswap_faces_index: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesIndex : null,
+        faceswap_model: faceswap.enabled || faceswap.seedFaceswap ? faceswap.model : null,
+        faceswap_pixel_boost: faceswap.enabled || faceswap.seedFaceswap ? faceswap.pixelBoost : null,
         faceswap_faces_order: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesOrder : null,
         seed_faceswap: faceswap.seedFaceswap,
         loras:


### PR DESCRIPTION
## Why

The UI could not reproduce the validated identity recipe. `faceswap_model` and `faceswap_pixel_boost` existed in the API ([#143](https://github.com/DavidJBarnes/wanly-api/pull/143)) with no control, and the default method was wrong.

## The default was actively harmful

```
DEFAULT_FACESWAP_METHOD = "reactor"   ->   "facefusion"
```

ReActor selects the target face by **position** (`faces_index 0`, `left-right`), so on a two-person frame it swaps whichever face is furthest left — frequently the wrong person — while still rewriting pixels, so `_images_differ` reports success. That is exactly what made the seed re-anchor a measured no-op: a full face swap that moved identity by **+0.014**.

FaceFusion uses `face_selector_mode="reference"` and targets the face **matching the source**, which is the only correct semantics when the goal is restoring one specific person.

## New controls

**Swapper Model** and **Pixel Boost**, shown for FaceFusion only since they're its parameters. Neither moved the numbers in testing:

```
inswapper_128 @ 512x512     identity 0.910   detail 177.1
hyperswap_1c_256 @ 256x256  identity 0.908   detail 176.5
```

They're exposed because they're the levers for **speckling on off-axis faces** — an artifact no metric here can see, so it stays a human judgement and needs controls to make it.

Both rehydrate from the last segment when continuing a job, so a chain doesn't silently revert to defaults halfway through.

`tsc` clean, build passes. The one eslint error in `FaceswapConfig.tsx` (`react-refresh/only-export-components`) is pre-existing — verified against a clean stash.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct