### PR TITLE
Add a test runner, and extract the payload logic it exists to cover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci || npm install
-      - run: npx tsc --noEmit
+      # `tsc --noEmit` at the root checks NOTHING: tsconfig.json has "files": [] and only
+      # project references, so src/ is never type-checked by it. Only `tsc -b` walks the
+      # references. This step passed on a file with an undefined identifier in it.
+      - run: npx tsc -b --force
       - run: npm run lint || echo "lint not configured — skipping"
+      - run: npm test
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "globals": "^16.5.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1850,6 +1851,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -1901,6 +1909,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2285,6 +2311,126 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@webgpu/types": {
       "version": "0.1.71",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
@@ -2354,6 +2500,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2491,6 +2647,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2712,6 +2878,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2978,6 +3151,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2986,6 +3169,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3550,6 +3743,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3652,6 +3855,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/optionator": {
@@ -3768,6 +3985,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4077,6 +4301,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -4095,6 +4326,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -4146,6 +4391,23 @@
       "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4161,6 +4423,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4356,6 +4628,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4370,6 +4732,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@dnd-kit/react": "^0.3.2",
@@ -37,6 +39,7 @@
     "globals": "^16.5.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.1.10"
   }
 }

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -29,6 +29,7 @@ import SettingsSignature from "./SettingsSignature";
 import { createJob, getFileUrl, getFaceswapPresets, sha256Hex, checkStartingImageExists } from "../api/client";
 import type { JobCreate, LoraListItem, FaceswapPreset } from "../api/types";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "./FaceswapConfig";
+import { buildFaceswapFields, shouldAttachStartImageAsFace } from "../lib/faceswapPayload";
 import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
@@ -434,29 +435,11 @@ export default function CreateJobDialog({
                   low_weight: l.low_weight,
                 }))
               : null,
-          faceswap_enabled: faceswap.enabled,
-          faceswap_method: faceswap.enabled || faceswap.seedFaceswap ? faceswap.method : null,
-          faceswap_source_type: faceswap.enabled || faceswap.seedFaceswap ? faceswap.sourceType : null,
-          // "Start Frame" has two shapes: a freshly uploaded File, which goes up as multipart
-          // below, and an image picked from the repo, which is only ever a URI. The multipart
-          // branch is guarded on `startingImage` (the File), so picking from the repo used to
-          // send NO face at all -- and the daemon gates on
-          // `faceswap_enabled AND faceswap_image`, so the swap silently did not run while the
-          // UI still showed Start Frame selected. Pass the URI through here.
-          faceswap_image:
-            (faceswap.enabled || faceswap.seedFaceswap)
-              ? faceswap.sourceType === "preset"
-                ? faceswap.presetUri
-                : faceswap.sourceType === "start_frame" && !startingImage && startingImageUri
-                  ? startingImageUri
-                  : null
-              : null,
-          faceswap_faces_index: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesIndex : null,
-          faceswap_model: faceswap.enabled || faceswap.seedFaceswap ? faceswap.model : null,
-          faceswap_pixel_boost: faceswap.enabled || faceswap.seedFaceswap ? faceswap.pixelBoost : null,
+          ...buildFaceswapFields(faceswap, {
+            startingImageFile: startingImage,
+            startingImageUri,
+          }),
           negative_prompt: negativePrompt.trim() || null,
-          faceswap_faces_order: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesOrder : null,
-          seed_faceswap: faceswap.seedFaceswap,
         },
       };
 
@@ -469,7 +452,7 @@ export default function CreateJobDialog({
       if ((faceswap.enabled || faceswap.seedFaceswap) && faceswap.sourceType === "upload" && faceswap.file) {
         formData.append("faceswap_image", faceswap.file);
       }
-      if ((faceswap.enabled || faceswap.seedFaceswap) && faceswap.sourceType === "start_frame" && startingImage) {
+      if (shouldAttachStartImageAsFace(faceswap, { startingImageFile: startingImage }) && startingImage) {
         formData.append("faceswap_image", startingImage);
       }
 

--- a/src/components/FaceswapConfig.tsx
+++ b/src/components/FaceswapConfig.tsx
@@ -14,6 +14,9 @@ import {
 } from "@mui/material";
 import { ExpandMore } from "@mui/icons-material";
 import { getFileUrl } from "../api/client";
+import type { FaceswapConfigState } from "../lib/faceswapPayload";
+
+export type { FaceswapConfigState };
 import type { FaceswapPreset } from "../api/types";
 import {
   DEFAULT_FACESWAP_METHOD,
@@ -26,22 +29,6 @@ import {
   FACESWAP_PIXEL_BOOSTS,
 } from "../constants";
 
-export interface FaceswapConfigState {
-  enabled: boolean;
-  method: string;
-  sourceType: "upload" | "preset" | "start_frame";
-  file: File | null;
-  presetUri: string | null;
-  facesIndex: string;
-  facesOrder: string;
-  /** FaceFusion only. Swapper network and the resolution the target crop is sampled at. */
-  model: string;
-  pixelBoost: string;
-  /** Re-anchor the continuation seed: faceswap this segment's last frame to the selected
-   *  face before it seeds the next segment. INDEPENDENT of `enabled` — the seed can be
-   *  re-anchored without swapping the video. Both share the same face source picker. */
-  seedFaceswap: boolean;
-}
 
 export function defaultFaceswapState(overrides?: Partial<FaceswapConfigState>): FaceswapConfigState {
   return {

--- a/src/components/IdentityChip.tsx
+++ b/src/components/IdentityChip.tsx
@@ -17,26 +17,10 @@ import TrendingDownIcon from "@mui/icons-material/TrendingDown";
 import TrendingFlatIcon from "@mui/icons-material/TrendingFlat";
 import type { SegmentResponse, IdentityAggregate } from "../api/types";
 import IdentityTrajectory from "./IdentityTrajectory";
+import { band, fmt, totalDrift } from "../lib/identityHelpers";
 
-/** Cosine bands. ArcFace on buffalo_l: ~0.4 is the same-person threshold, 0.6+ is a solid
- *  match, 0.8+ is strong. These are deliberately not "good/bad" — a profile-heavy clip
- *  legitimately scores lower than a frontal one, so colour is a hint, not a verdict. */
-function band(v: number | null | undefined): "success" | "warning" | "error" | "default" {
-  if (v == null) return "default";
-  if (v >= 0.7) return "success";
-  if (v >= 0.5) return "warning";
-  return "error";
-}
 
-/** Total drift across the clip, which is more readable than a per-frame slope. */
-function totalDrift(slope: number | null, frames: number | null): number | null {
-  if (slope == null || !frames || frames < 2) return null;
-  return slope * (frames - 1);
-}
 
-function fmt(v: number | null | undefined, digits = 3): string {
-  return v == null ? "—" : v.toFixed(digits);
-}
 
 interface Props {
   /** A scored segment, or a job-level aggregate. */

--- a/src/components/IdentityTrajectory.tsx
+++ b/src/components/IdentityTrajectory.tsx
@@ -1,4 +1,5 @@
 import { Box, Typography, useTheme } from "@mui/material";
+import { DIP_THRESHOLD, TAIL, median } from "../lib/identityHelpers";
 
 /** Per-frame cosine, already stored by the daemon in identity_metrics.series.
  *
@@ -13,17 +14,6 @@ import { Box, Typography, useTheme } from "@mui/material";
  *  POSITIVE (+3.5e-4/frame). Endpoints falling while the trend rises is exactly the shape
  *  the summary stats cannot express. */
 
-/** How many trailing samples count as "the end" when judging whether the last frame is
- *  representative. Short enough to be local, long enough not to be one noisy sample. */
-const TAIL = 12;
-/** Below this the endpoint is just noise; a dip has to be worth acting on. */
-const DIP_THRESHOLD = 0.05;
-
-function median(xs: number[]): number {
-  const s = [...xs].sort((a, b) => a - b);
-  const m = s.length >> 1;
-  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
-}
 
 interface Props {
   metrics: Record<string, unknown> | null | undefined;

--- a/src/lib/faceswapPayload.test.ts
+++ b/src/lib/faceswapPayload.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFaceswapFields,
+  resolveFaceswapImage,
+  shouldAttachStartImageAsFace,
+  type FaceswapConfigState,
+} from "./faceswapPayload";
+
+/** A state with the swap on and Start Frame selected -- the validated recipe. */
+function state(overrides: Partial<FaceswapConfigState> = {}): FaceswapConfigState {
+  return {
+    enabled: true,
+    method: "facefusion",
+    sourceType: "start_frame",
+    file: null,
+    presetUri: null,
+    facesIndex: "0",
+    facesOrder: "left-right",
+    model: "inswapper_128",
+    pixelBoost: "512x512",
+    seedFaceswap: false,
+    ...overrides,
+  };
+}
+
+/** Stand-in for an uploaded start image. Only its presence matters here. */
+const FILE = { name: "start.png" } as unknown as File;
+
+const JOB_IMAGE = "s3://wanly-images/2026-08-03/00003-710610150-swapped.png";
+const REPO_IMAGE = "s3://wanly-images/2026-08-03/00010-398706875-swapped.png";
+const LAST_FRAME = "s3://wanly-jobs/abc/1_last_frame.png";
+
+describe("regressions — each of these shipped to production", () => {
+  it("#276: a repo-picked start image travels as a URI in the body", () => {
+    // The attach branch was guarded on the uploaded File, so a repo pick sent no face at all.
+    // The daemon gates on `faceswap_enabled AND faceswap_image`, so the swap silently did not
+    // run while the UI still showed it on. Nine queued jobs were affected.
+    const f = buildFaceswapFields(state(), {
+      startingImageFile: null,
+      startingImageUri: REPO_IMAGE,
+    });
+    expect(f.faceswap_image).toBe(REPO_IMAGE);
+  });
+
+  it("#274: a continuation swaps toward the JOB's image, never the previous last frame", () => {
+    // The last frame has already drifted; swapping toward it locks the drift in.
+    // Measured 0.906 (job image) vs 0.644 (other face).
+    const img = resolveFaceswapImage(state(), {
+      jobStartingImage: JOB_IMAGE,
+      startingImageUri: LAST_FRAME,
+    });
+    expect(img).toBe(JOB_IMAGE);
+    expect(img).not.toBe(LAST_FRAME);
+  });
+
+  it("the job image wins even when a repo URI is also present", () => {
+    expect(
+      resolveFaceswapImage(state(), {
+        jobStartingImage: JOB_IMAGE,
+        startingImageUri: REPO_IMAGE,
+      }),
+    ).toBe(JOB_IMAGE);
+  });
+});
+
+describe("upload vs URI — exactly one path may produce the face", () => {
+  it("an uploaded File is attached as multipart, so the body field stays null", () => {
+    const ctx = { startingImageFile: FILE, startingImageUri: null };
+    expect(resolveFaceswapImage(state(), ctx)).toBeNull();
+    expect(shouldAttachStartImageAsFace(state(), ctx)).toBe(true);
+  });
+
+  it("a repo URI goes in the body and nothing is attached", () => {
+    const ctx = { startingImageFile: null, startingImageUri: REPO_IMAGE };
+    expect(resolveFaceswapImage(state(), ctx)).toBe(REPO_IMAGE);
+    expect(shouldAttachStartImageAsFace(state(), ctx)).toBe(false);
+  });
+
+  it("never both — that would send two different faces", () => {
+    for (const ctx of [
+      { startingImageFile: FILE, startingImageUri: null },
+      { startingImageFile: null, startingImageUri: REPO_IMAGE },
+      { jobStartingImage: JOB_IMAGE },
+      {},
+    ]) {
+      const inBody = resolveFaceswapImage(state(), ctx) !== null;
+      const attached = shouldAttachStartImageAsFace(state(), ctx);
+      expect(inBody && attached).toBe(false);
+    }
+  });
+});
+
+describe("gating", () => {
+  it("seed-only re-anchor still carries the face and settings", () => {
+    // seedFaceswap is independent of enabled: the seed is re-anchored without swapping the
+    // video, so every field except faceswap_enabled must still be populated.
+    const f = buildFaceswapFields(state({ enabled: false, seedFaceswap: true }), {
+      jobStartingImage: JOB_IMAGE,
+    });
+    expect(f.faceswap_enabled).toBe(false);
+    expect(f.seed_faceswap).toBe(true);
+    expect(f.faceswap_image).toBe(JOB_IMAGE);
+    expect(f.faceswap_method).toBe("facefusion");
+    expect(f.faceswap_model).toBe("inswapper_128");
+  });
+
+  it("both off nulls every field", () => {
+    const f = buildFaceswapFields(state({ enabled: false, seedFaceswap: false }), {
+      jobStartingImage: JOB_IMAGE,
+    });
+    expect(f).toEqual({
+      faceswap_enabled: false,
+      faceswap_method: null,
+      faceswap_source_type: null,
+      faceswap_image: null,
+      faceswap_faces_index: null,
+      faceswap_faces_order: null,
+      faceswap_model: null,
+      faceswap_pixel_boost: null,
+      seed_faceswap: false,
+    });
+  });
+
+  it("preset source uses the preset URI, ignoring start images", () => {
+    const f = buildFaceswapFields(
+      state({ sourceType: "preset", presetUri: "s3://wanly-faces/kelly.jpg" }),
+      { jobStartingImage: JOB_IMAGE, startingImageUri: REPO_IMAGE },
+    );
+    expect(f.faceswap_image).toBe("s3://wanly-faces/kelly.jpg");
+  });
+
+  it("start_frame with nothing configured yields null rather than throwing", () => {
+    // Null is a silent no-op downstream, so this asserts the shape, not that it is desirable.
+    expect(resolveFaceswapImage(state(), {})).toBeNull();
+  });
+});
+
+describe("passthrough fields", () => {
+  it("carries method, selector and swapper settings verbatim", () => {
+    const f = buildFaceswapFields(
+      state({
+        method: "reactor",
+        facesIndex: "1",
+        facesOrder: "large-small",
+        model: "hyperswap_1c_256",
+        pixelBoost: "256x256",
+      }),
+      { jobStartingImage: JOB_IMAGE },
+    );
+    expect(f.faceswap_method).toBe("reactor");
+    expect(f.faceswap_source_type).toBe("start_frame");
+    expect(f.faceswap_faces_index).toBe("1");
+    expect(f.faceswap_faces_order).toBe("large-small");
+    expect(f.faceswap_model).toBe("hyperswap_1c_256");
+    expect(f.faceswap_pixel_boost).toBe("256x256");
+  });
+});

--- a/src/lib/faceswapPayload.ts
+++ b/src/lib/faceswapPayload.ts
@@ -1,0 +1,134 @@
+/**
+ * Faceswap fields for a job/segment request body.
+ *
+ * WHY THIS EXISTS: CreateJobDialog and JobDetail each built this block independently and
+ * repeated seven identical lines verbatim. They diverged in exactly one field -- faceswap_image
+ * -- and that is precisely where two production bugs lived:
+ *
+ *   - a continuation resolved "Start Frame" to the PREVIOUS segment's last frame, which has
+ *     already drifted. Swapping toward it locks the drift in. Measured 0.906 -> 0.644 identity.
+ *   - a starting image picked from the repo (a URI, not a File) sent NO face at all, because
+ *     the attach branch was guarded on the uploaded File. The daemon gates on
+ *     `faceswap_enabled AND faceswap_image`, so the swap silently did not run while the UI
+ *     still showed it enabled. Nine queued jobs were affected before anyone noticed.
+ *
+ * Both are pure state -> payload logic, which is why they survived tsc, eslint and a build.
+ * One implementation, one set of tests.
+ *
+ * Deliberately imports nothing from `../api/client`: that module installs axios interceptors at
+ * import time, one of which assigns `window.location.href` on a 401.
+ */
+
+/** Mirrors the faceswap UI state. Lives here rather than in FaceswapConfig.tsx so tests can
+ *  import it without dragging MUI in; the component imports it back. */
+export interface FaceswapConfigState {
+  enabled: boolean;
+  method: string;
+  sourceType: "upload" | "preset" | "start_frame";
+  file: File | null;
+  presetUri: string | null;
+  facesIndex: string;
+  facesOrder: string;
+  /** FaceFusion only: swapper network and the resolution the target crop is sampled at. */
+  model: string;
+  pixelBoost: string;
+  /** Re-anchor the continuation seed by swapping this segment's last frame before it seeds the
+   *  next one. INDEPENDENT of `enabled` -- the seed can be re-anchored without swapping the
+   *  video, and both share the same face source. */
+  seedFaceswap: boolean;
+}
+
+export interface FaceswapFields {
+  faceswap_enabled: boolean;
+  faceswap_method: string | null;
+  faceswap_source_type: string | null;
+  faceswap_image: string | null;
+  faceswap_faces_index: string | null;
+  faceswap_faces_order: string | null;
+  faceswap_model: string | null;
+  faceswap_pixel_boost: string | null;
+  seed_faceswap: boolean;
+}
+
+export interface FaceswapContext {
+  /** A freshly uploaded start image. Travels as multipart, so it is NOT a URI and must not be
+   *  placed in the JSON body -- the caller attaches the File separately. */
+  startingImageFile?: File | null;
+  /** A start image picked from the repo. URI only, so it MUST travel in the JSON body. */
+  startingImageUri?: string | null;
+  /** The JOB's starting image. On a continuation this is the correct "start frame": segment 0's
+   *  image, which is also what identity is scored against (identity_ground_truth). Never the
+   *  previous segment's last frame -- that one has already drifted. */
+  jobStartingImage?: string | null;
+}
+
+/**
+ * Resolve the face the swap should target.
+ *
+ * Returns null when the swap is off, when the source is an upload (the File goes multipart), or
+ * when nothing usable is configured -- and null means the daemon skips the swap entirely, so a
+ * null here is a silent no-op rather than an error. That is exactly how the repo-image bug hid.
+ */
+export function resolveFaceswapImage(
+  faceswap: FaceswapConfigState,
+  ctx: FaceswapContext = {},
+): string | null {
+  if (!faceswap.enabled && !faceswap.seedFaceswap) return null;
+
+  if (faceswap.sourceType === "preset") return faceswap.presetUri ?? null;
+
+  if (faceswap.sourceType === "start_frame") {
+    // Job image first. On a continuation the alternative -- the previous segment's last frame --
+    // is the drifted one, and swapping toward it locks the drift in permanently.
+    if (ctx.jobStartingImage) return ctx.jobStartingImage;
+    // A repo pick is URI-only and has to travel in the body. An upload does not: the File is
+    // attached as multipart by the caller, so the body field stays null.
+    if (!ctx.startingImageFile && ctx.startingImageUri) return ctx.startingImageUri;
+    return null;
+  }
+
+  return null; // "upload" -- the File is attached separately
+}
+
+/**
+ * Build every faceswap_* field for a request body.
+ *
+ * The gate is `enabled || seedFaceswap`, not `enabled`: a seed-only re-anchor still needs the
+ * face, the method and the selector settings, and only differs in that the video itself is not
+ * swapped.
+ */
+export function buildFaceswapFields(
+  faceswap: FaceswapConfigState,
+  ctx: FaceswapContext = {},
+): FaceswapFields {
+  const active = faceswap.enabled || faceswap.seedFaceswap;
+  return {
+    faceswap_enabled: faceswap.enabled,
+    faceswap_method: active ? faceswap.method : null,
+    faceswap_source_type: active ? faceswap.sourceType : null,
+    faceswap_image: resolveFaceswapImage(faceswap, ctx),
+    faceswap_faces_index: active ? faceswap.facesIndex : null,
+    faceswap_faces_order: active ? faceswap.facesOrder : null,
+    faceswap_model: active ? faceswap.model : null,
+    faceswap_pixel_boost: active ? faceswap.pixelBoost : null,
+    seed_faceswap: faceswap.seedFaceswap,
+  };
+}
+
+/**
+ * Should the caller attach the start image File as the faceswap source (multipart)?
+ *
+ * The other half of the same decision as resolveFaceswapImage: exactly one of the two should
+ * produce a face for any given state. Splitting them across 30 lines of a submit handler is how
+ * they drifted apart in the first place.
+ */
+export function shouldAttachStartImageAsFace(
+  faceswap: FaceswapConfigState,
+  ctx: FaceswapContext = {},
+): boolean {
+  return (
+    (faceswap.enabled || faceswap.seedFaceswap) &&
+    faceswap.sourceType === "start_frame" &&
+    !!ctx.startingImageFile
+  );
+}

--- a/src/lib/identityHelpers.test.ts
+++ b/src/lib/identityHelpers.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  band,
+  totalDrift,
+  fmt,
+  median,
+  tailVerdict,
+  DIP_THRESHOLD,
+} from "./identityHelpers";
+
+describe("band", () => {
+  it("null and undefined are 'default', not 'error'", () => {
+    // An unscored segment must not render as a failure.
+    expect(band(null)).toBe("default");
+    expect(band(undefined)).toBe("default");
+  });
+
+  it.each([
+    [0.0, "error"],
+    [0.499, "error"],
+    [0.5, "warning"],
+    [0.699, "warning"],
+    [0.7, "success"],
+    [1.0, "success"],
+  ])("%s -> %s", (v, expected) => {
+    expect(band(v as number)).toBe(expected);
+  });
+});
+
+describe("totalDrift", () => {
+  it("is slope across the gaps, not across the frames", () => {
+    // frames-1 gaps, not frames. Off by one here silently misreports every clip.
+    expect(totalDrift(-0.002, 177)).toBeCloseTo(-0.352, 6);
+  });
+
+  it("returns null when it cannot be computed", () => {
+    expect(totalDrift(null, 177)).toBeNull();
+    expect(totalDrift(-0.002, null)).toBeNull();
+    expect(totalDrift(-0.002, 0)).toBeNull();
+    expect(totalDrift(-0.002, 1)).toBeNull(); // one frame = no interval
+  });
+});
+
+describe("fmt", () => {
+  it("renders an em dash for missing values rather than 0.000", () => {
+    expect(fmt(null)).toBe("—");
+    expect(fmt(undefined)).toBe("—");
+    expect(fmt(0)).toBe("0.000");
+  });
+});
+
+describe("median", () => {
+  it("averages the middle pair on even length", () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it("takes the middle on odd length", () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+
+  it("does not mutate its input", () => {
+    const xs = [3, 1, 2];
+    median(xs);
+    expect(xs).toEqual([3, 1, 2]);
+  });
+});
+
+describe("tailVerdict — the discrimination the panel exists for", () => {
+  // Both series END at ~0.506. Endpoint numbers alone cannot tell them apart, and they call for
+  // opposite responses: one is genuine drift, the other is a bad anchor frame that the next
+  // segment would inherit.
+  const steadyDecay = Array.from({ length: 177 }, (_, i) => 0.851 - (0.345 * i) / 176);
+  const endBlip = Array.from({ length: 177 }, (_, i) =>
+    i < 20 ? 0.851 - (0.2 * i) / 20 : i < 171 ? 0.65 : 0.65 - (0.145 * (i - 170)) / 6,
+  );
+
+  it("a steady decay is NOT flagged — the endpoint is where the clip really is", () => {
+    const v = tailVerdict(steadyDecay);
+    expect(v.end).toBeCloseTo(0.506, 2);
+    expect(v.isDip).toBe(false);
+  });
+
+  it("an end blip IS flagged, at the same endpoint", () => {
+    const v = tailVerdict(endBlip);
+    expect(v.end).toBeCloseTo(0.505, 2);
+    expect(v.isDip).toBe(true);
+    expect(v.dip!).toBeGreaterThan(DIP_THRESHOLD);
+  });
+
+  it("reports what a better anchor in the tail would be worth", () => {
+    const v = tailVerdict(endBlip);
+    expect(v.bestTail - v.end).toBeGreaterThan(0.1);
+    expect(v.bestOffset).toBeGreaterThan(0);
+  });
+
+  it("a rising tail gives a negative dip, never a flag", () => {
+    const rising = [...Array(20).fill(0.5), 0.55, 0.6, 0.65, 0.7];
+    const v = tailVerdict(rising);
+    expect(v.dip!).toBeLessThan(0);
+    expect(v.isDip).toBe(false);
+  });
+
+  it("too short to judge yields a null median rather than a wrong verdict", () => {
+    const v = tailVerdict([0.9, 0.8, 0.7]);
+    expect(v.bodyMedian).toBeNull();
+    expect(v.isDip).toBe(false);
+  });
+});

--- a/src/lib/identityHelpers.ts
+++ b/src/lib/identityHelpers.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure helpers behind the identity chip and trajectory panel.
+ *
+ * These live here rather than as exports from the components because eslint runs
+ * `reactRefresh.configs.vite`, which errors on non-component exports from a component file.
+ * Moving them keeps the components export-only and makes the numeric thresholds testable --
+ * and every threshold in here was set from measurement, so a silent change to one would be
+ * hard to notice by eye.
+ */
+
+/** Cosine bands. ArcFace on buffalo_l: ~0.4 is the same-person threshold, 0.6+ is a solid
+ *  match, 0.8+ is strong. Deliberately not "good/bad" -- a profile-heavy clip legitimately
+ *  scores lower than a frontal one, so colour is a hint, not a verdict. */
+export function band(v: number | null | undefined): "success" | "warning" | "error" | "default" {
+  if (v == null) return "default";
+  if (v >= 0.7) return "success";
+  if (v >= 0.5) return "warning";
+  return "error";
+}
+
+/** Total drift across the clip, which reads better than a per-frame slope. */
+export function totalDrift(slope: number | null, frames: number | null): number | null {
+  if (slope == null || !frames || frames < 2) return null;
+  return slope * (frames - 1);
+}
+
+export function fmt(v: number | null | undefined, digits = 3): string {
+  return v == null ? "—" : v.toFixed(digits);
+}
+
+export function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = s.length >> 1;
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+/** How many trailing samples count as "the end" when judging whether the last frame is
+ *  representative. Short enough to be local, long enough not to be one noisy sample. */
+export const TAIL = 12;
+/** Below this the endpoint is just noise; a dip has to be worth acting on. */
+export const DIP_THRESHOLD = 0.05;
+
+export interface TailVerdict {
+  end: number;
+  /** Median of the samples just before the end, or null when the tail is too short to judge. */
+  bodyMedian: number | null;
+  /** How far the final frame sits below that median. Negative means it sits above. */
+  dip: number | null;
+  isDip: boolean;
+  /** Best frame in the tail, and how far back it is -- what a better anchor would be worth. */
+  bestTail: number;
+  bestOffset: number;
+}
+
+/**
+ * Is the final frame representative of where the clip settled, or a transient dip?
+ *
+ * This is not cosmetic: the daemon seeds the NEXT segment from the last frame, so a blink or a
+ * motion blur there propagates into everything that follows. Start and end alone cannot tell a
+ * steady decay from a clip that held and then dipped -- both produce identical headline numbers
+ * and call for opposite fixes.
+ */
+export function tailVerdict(series: number[]): TailVerdict {
+  const end = series[series.length - 1];
+  const body = series.slice(-TAIL, -2);
+  const bodyMedian = body.length >= 4 ? median(body) : null;
+  const dip = bodyMedian != null ? bodyMedian - end : null;
+  const tail = series.slice(-TAIL);
+  const bestTail = Math.max(...tail);
+  return {
+    end,
+    bodyMedian,
+    dip,
+    isDip: dip != null && dip >= DIP_THRESHOLD,
+    bestTail,
+    bestOffset: tail.length - 1 - tail.lastIndexOf(bestTail),
+  };
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -89,6 +89,7 @@ import type {
 } from "../api/types";
 import StatusChip from "../components/StatusChip";
 import IdentityChip from "../components/IdentityChip";
+import { buildFaceswapFields, resolveFaceswapImage } from "../lib/faceswapPayload";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
 import HologramConfig from "../components/HologramConfig";
 import { QRCodeCanvas } from "qrcode.react";
@@ -2127,23 +2128,20 @@ function SegmentModal({
     setSubmitting(true);
     try {
       let faceswapImageUri: string | null = null;
-      // face is needed for a whole-video swap OR a seed-only re-anchor
+      // face is needed for a whole-video swap OR a seed-only re-anchor.
+      // buildFaceswapFields covers preset and start_frame; only the upload branch needs an
+      // await, and the carry-forward keeps a face the previous segment already resolved.
       if (faceswap.enabled || faceswap.seedFaceswap) {
-        if (faceswap.sourceType === "preset") {
-          faceswapImageUri = faceswap.presetUri;
-        } else if (faceswap.sourceType === "start_frame") {
-          // The JOB's starting image — segment 0's start frame — not the previous segment's
-          // last frame. A continuation's last frame has already drifted; swapping toward it
-          // locks that drift in permanently. Measured: sourcing the swap from the job's start
-          // image scores 0.906 mean identity, sourcing it from a drifted/other face scores
-          // 0.644 and pulls the face away from the reference before a single frame of motion.
-          // It also matches identity_ground_truth, which is what the score is computed against.
-          faceswapImageUri = job.starting_image ?? lastSegment?.last_frame_path ?? null;
-        } else if (faceswap.file) {
-          const result = await uploadFile(faceswap.file, jobId);
-          faceswapImageUri = result.path;
-        } else {
-          faceswapImageUri = lastSegment?.faceswap_image ?? null;
+        faceswapImageUri = resolveFaceswapImage(faceswap, {
+          jobStartingImage: job.starting_image,
+        });
+        if (faceswapImageUri === null) {
+          if (faceswap.file) {
+            const result = await uploadFile(faceswap.file, jobId);
+            faceswapImageUri = result.path;
+          } else {
+            faceswapImageUri = lastSegment?.faceswap_image ?? null;
+          }
         }
       }
 
@@ -2160,15 +2158,9 @@ function SegmentModal({
         duration_seconds: duration,
         speed,
         start_image: startImageUri,
-        faceswap_enabled: faceswap.enabled,
-        faceswap_method: faceswap.enabled || faceswap.seedFaceswap ? faceswap.method : null,
-        faceswap_source_type: faceswap.enabled || faceswap.seedFaceswap ? faceswap.sourceType : null,
+        ...buildFaceswapFields(faceswap, { jobStartingImage: job.starting_image }),
+        // the upload / carry-forward branches above can override what the builder resolved
         faceswap_image: faceswapImageUri,
-        faceswap_faces_index: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesIndex : null,
-        faceswap_model: faceswap.enabled || faceswap.seedFaceswap ? faceswap.model : null,
-        faceswap_pixel_boost: faceswap.enabled || faceswap.seedFaceswap ? faceswap.pixelBoost : null,
-        faceswap_faces_order: faceswap.enabled || faceswap.seedFaceswap ? faceswap.facesOrder : null,
-        seed_faceswap: faceswap.seedFaceswap,
         loras:
           loraSlots.length > 0
             ? loraSlots.map((l) => ({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
@@ -5,5 +6,13 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+  },
+  // Pure-logic tests only: no jsdom, no testing-library, no mocking. Every console bug worth
+  // catching so far has been state -> request-payload logic, which needs none of that.
+  // Node environment also keeps `src/api/client.ts` out of reach — importing it installs axios
+  // interceptors, one of which assigns window.location on a 401.
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Why

`wanly-console` had no tests. CI ran `tsc`, `eslint` and `build` — **all of which passed on every console bug shipped this week**, because all four were pure state → request-payload logic:

- **#274** — a continuation resolved "Start Frame" to the *previous segment's last frame* instead of the job's image. Measured **0.906 → 0.644** identity.
- **#276** — a repo-picked start image (a URI, not a `File`) sent no face at all. The daemon gates on `faceswap_enabled AND faceswap_image`, so the swap silently did not run while the UI still showed it on. **Nine queued jobs affected.**
- **#277** — defaulting the source to Start Frame opened on a disabled toggle.

`CreateJobDialog` and `JobDetail` each built this block and repeated **seven identical lines verbatim**, differing in exactly one field — `faceswap_image` — which is precisely where both bugs lived. The duplication *was* the bug source, so this isn't only "add a runner": it extracts the shared logic and locks it.

## What

- **vitest**, `environment: "node"`, no jsdom / testing-library / mocking — nothing shipped this week needed any of it. Reads the existing `vite.config.ts`, so no second toolchain.
- **`src/lib/faceswapPayload.ts`** — `buildFaceswapFields` / `resolveFaceswapImage` / `shouldAttachStartImageAsFace`, used by both call sites. `FaceswapConfigState` moves here so tests don't drag MUI in; the component re-exports it. Imports nothing from `api/client` (that module installs axios interceptors at import time, one of which assigns `window.location` on a 401).
- **`src/lib/identityHelpers.ts`** — `band`/`totalDrift`/`fmt`/`median`/`tailVerdict` moved out of the `.tsx` files. Exporting them in place wasn't an option: eslint's `react-refresh` rule errors on non-component exports from a component file.
- **29 tests**, named for the bugs they'd have caught.

## Verification

Tests were checked against the *broken* code, not just the fixed code:

```
re-break #276 (guard the URI on the File)      -> 2 failed
re-break #274 (last frame before job image)    -> 2 failed
restored                                        -> 29 passed
```

`tsc -b` clean, `npm run build` clean, eslint identical to baseline (4 errors / 7 warnings before and after — all pre-existing).

## One extra finding

CI's `npx tsc --noEmit` **checks nothing.** The root `tsconfig.json` has `"files": []` and only project references, so `src/` is never type-checked by it — only `tsc -b` walks the references. It passed on a file containing an undefined identifier during this work. Changed to `npx tsc -b --force`.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct