### PR TITLE
Show a segment's prompt in the timeline, on demand

### DIFF
--- a/src/components/SegmentPromptPopover.tsx
+++ b/src/components/SegmentPromptPopover.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import {
+  Box,
+  Divider,
+  IconButton,
+  Popover,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import NotesIcon from "@mui/icons-material/Notes";
+
+/**
+ * The prompt behind a segment, on demand.
+ *
+ * The timeline had no way to see it at all, and showing every prompt inline would drown the
+ * table -- they run to several sentences each. So: one small button per row.
+ *
+ * It also shows the TEMPLATE when wildcards were resolved. That is not a detail: the <face>
+ * wildcard holds four variants that fire at random on every job, and they are the deformation
+ * text that costs roughly 0.13 identity. Without this there is no way to tell after the fact
+ * which variant a given segment drew, so two segments of the "same" job can differ for reasons
+ * invisible in the UI.
+ */
+
+interface Props {
+  index: number;
+  prompt: string;
+  promptTemplate?: string | null;
+  negativePrompt?: string | null;
+}
+
+export default function SegmentPromptPopover({
+  index,
+  prompt,
+  promptTemplate,
+  negativePrompt,
+}: Props) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  // Only interesting when the template actually differs — the API stores it unconditionally,
+  // so an equal value just means "no wildcards in this prompt".
+  const resolvedFromTemplate = !!promptTemplate && promptTemplate !== prompt;
+
+  return (
+    <>
+      <Tooltip title={resolvedFromTemplate ? "Prompt (wildcards resolved)" : "Prompt"}>
+        <IconButton size="small" onClick={(e) => setAnchorEl(e.currentTarget)}>
+          <NotesIcon
+            fontSize="small"
+            // A quiet hint that this row drew from a wildcard, without opening the popover.
+            color={resolvedFromTemplate ? "primary" : "inherit"}
+          />
+        </IconButton>
+      </Tooltip>
+
+      <Popover
+        open={!!anchorEl}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        slotProps={{ paper: { sx: { maxWidth: 560, p: 2 } } }}
+      >
+        <Typography variant="subtitle2" gutterBottom>
+          Segment {index} prompt
+        </Typography>
+        <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+          {prompt || <em>(empty)</em>}
+        </Typography>
+
+        {resolvedFromTemplate && (
+          <>
+            <Divider sx={{ my: 1.5 }} />
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 0.5 }}>
+              Template — one of the wildcard's options was chosen at random for this segment
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ whiteSpace: "pre-wrap", color: "text.secondary", fontStyle: "italic" }}
+            >
+              {promptTemplate}
+            </Typography>
+          </>
+        )}
+
+        {negativePrompt && (
+          <>
+            <Divider sx={{ my: 1.5 }} />
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 0.5 }}>
+              Negative
+            </Typography>
+            <Box component={Typography} variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+              {negativePrompt}
+            </Box>
+          </>
+        )}
+      </Popover>
+    </>
+  );
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -89,6 +89,7 @@ import type {
 } from "../api/types";
 import StatusChip from "../components/StatusChip";
 import IdentityChip from "../components/IdentityChip";
+import SegmentPromptPopover from "../components/SegmentPromptPopover";
 import { buildFaceswapFields, resolveFaceswapImage } from "../lib/faceswapPayload";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
 import HologramConfig from "../components/HologramConfig";
@@ -986,6 +987,7 @@ export default function JobDetail() {
                     <TableCell padding="none" sx={{ width: laneWidth, minWidth: laneWidth }} />
                   )}
                   <TableCell sx={{ width: 120, ...(groups.length > 0 ? { pl: 0 } : {}) }}>Start Image</TableCell>
+                  <TableCell sx={{ width: 48 }} align="center">Prompt</TableCell>
                   <TableCell sx={{ width: 300 }}>Video Settings</TableCell>
                   <TableCell sx={{ width: 120 }}>Output</TableCell>
                   <TableCell sx={{ width: 100 }}>Status</TableCell>
@@ -1042,6 +1044,14 @@ export default function JobDetail() {
                           </Typography>
                         );
                       })()}
+                    </TableCell>
+                    <TableCell align="center" padding="none">
+                      <SegmentPromptPopover
+                        index={seg.index}
+                        prompt={seg.prompt}
+                        promptTemplate={seg.prompt_template}
+                        negativePrompt={seg.negative_prompt}
+                      />
                     </TableCell>
                     <TableCell>
                       {(() => {
@@ -1242,7 +1252,9 @@ export default function JobDetail() {
                           </div>
                         </TableCell>
                       )}
-                      <TableCell colSpan={8} sx={{ py: 0.5 }}>
+                      {/* 9 non-lane columns: Start Image, Prompt, Video Settings, Output,
+                          Status, Worker, Created, Run Time, actions */}
+                      <TableCell colSpan={9} sx={{ py: 0.5 }}>
                         <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 2 }}>
                           <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
                             <Typography variant="caption" color="text.secondary">Trim #{seg.index} Start:</Typography>


### PR DESCRIPTION
## Why

The timeline had no way to see a segment's prompt. Inline would drown the table — they run to several sentences each — so it's one small button per row opening a popover.

## The part that actually matters

It also shows the **template** when wildcards were resolved. The `<face>` wildcard holds four options that fire at random, and they're the deformation text measured to cost **~0.13 identity**.

Real data, job `02013c48` — three segments, one template, three different resolved prompts:

```
template  <face> c0wg1rl the young k3llydw woman bounces...
seg       "Her forehead furrows and relaxes, her eyebrows..."
seg       "Her forehead bunches, her eyes squint and wide..."
seg       "Her brow tightens then slackens with each thru..."
```

Nothing in the UI showed that, so two segments of the "same" job could differ for reasons that were completely invisible. The popover surfaces both the resolved prompt and the template it came from, and the icon tints when a row drew from a template — so a wildcard-driven segment is identifiable without opening anything.

`prompt_template` was already on `SegmentResponse`; this is console-only, no API change.

## Note

Adds a column, so the transition row's `colSpan` goes 8 → 9 (header column count verified at 9).

`tsc -b` clean, build clean, 29 tests pass, eslint identical to baseline.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct