### PR TITLE
Say which reference the trajectory graph is plotting

### DIFF
--- a/src/components/IdentityTrajectory.tsx
+++ b/src/components/IdentityTrajectory.tsx
@@ -24,6 +24,12 @@ export default function IdentityTrajectory({ metrics }: Props) {
 
   const series = (metrics?.series as number[] | undefined) ?? undefined;
   const stride = (metrics?.stride as number | undefined) ?? 1;
+  // Clips scored before 2026-08-06 measured this against the segment's OWN start frame, which
+  // on a continuation is the already-drifted last frame -- so the graph opened near 0.95 while
+  // the trajectory above it read 0.851. New clips declare the reference; old ones have no
+  // field and are all own_start. Say which, rather than letting the two be conflated.
+  const seriesRef = (metrics?.series_ref as string | undefined) ?? "own_start";
+  const vsGroundTruth = seriesRef === "ground_truth";
   if (!series || series.length < 8) return null;
 
   const lo = Math.min(...series);
@@ -56,8 +62,11 @@ export default function IdentityTrajectory({ metrics }: Props) {
     <Box sx={{ mt: 2 }}>
       <Typography variant="subtitle2">Per-frame trajectory</Typography>
       <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
-        Cosine for every scored frame. The next segment is seeded from the <strong>last</strong>{" "}
-        frame, so a dip at the right-hand edge propagates into everything that follows.
+        Cosine for every scored frame, against{" "}
+        <strong>{vsGroundTruth ? "segment 0's start frame" : "this segment's own start frame"}</strong>
+        {!vsGroundTruth && " — so on a continuation it shows drift WITHIN this segment, not since the job began"}
+        . The next segment is seeded from the <strong>last</strong> frame, so a dip at the
+        right-hand edge propagates into everything that follows.
         {stride > 1 && ` Sampled every ${stride} frames.`}
       </Typography>
 


### PR DESCRIPTION
Paired with [wanly-gpu-daemon#103](https://github.com/DavidJBarnes/wanly-gpu-daemon/pull/103), which makes the per-frame series read the job's ground truth.

Clips scored before that measured it against the segment's **own start frame**, so on a continuation the graph opened near 0.95 while the trajectory printed directly above it read 0.851 — two different references in one panel, with nothing saying so.

New clips declare it via `metrics.series_ref`; older ones have no field and are all `own_start`. The caption now names the reference, and on an old continuation adds that it shows drift *within* the segment rather than since the job began.

`tsc -b` clean, build clean, 29 tests pass.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct