### PR TITLE
Archive video presets from the console instead of deleting them

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -315,8 +315,20 @@ export async function deleteLora(id: string): Promise<void> {
   await api.delete(`/loras/${id}`);
 }
 
-export async function getVideoPresets(): Promise<VideoSettingsPreset[]> {
-  const { data } = await api.get<VideoSettingsPreset[]>("/video-presets");
+export async function getVideoPresets(includeArchived = false): Promise<VideoSettingsPreset[]> {
+  const { data } = await api.get<VideoSettingsPreset[]>("/video-presets", {
+    params: includeArchived ? { include_archived: true } : undefined,
+  });
+  return data;
+}
+
+/** Archiving hides a preset from the picker without breaking the jobs that used it —
+ *  they resolve it by id, which still works. Deleting would lose that record. */
+export async function setVideoPresetArchived(
+  id: string,
+  archived: boolean,
+): Promise<VideoSettingsPreset> {
+  const { data } = await api.patch<VideoSettingsPreset>(`/video-presets/${id}`, { archived });
   return data;
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -409,6 +409,9 @@ export interface VideoSettingsPreset {
   notes: string | null;
   created_at: string;
   updated_at: string;
+  /** Hidden from the picker but still resolvable by id, so historical jobs keep
+   *  their config. Presets accumulate fast during experiments. */
+  archived?: boolean;
 }
 
 export interface VideoSettingsPresetCreate {

--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -181,7 +181,8 @@ export default function CreateJobDialog({
   }, [open, initialImageTags, titleTags1, titleTags2]);
 
   // Preset state
-  const { presets: videoPresets, fetchPresets: fetchVideoPresets } = useVideoPresetStore();
+  const { presets: videoPresets, allPresets: allVideoPresets, fetchPresets: fetchVideoPresets } =
+    useVideoPresetStore();
 
   // LoRA state
   const { loras: loraLibrary, fetchLoras } = useLoraStore();
@@ -328,7 +329,7 @@ export default function CreateJobDialog({
   // Select a user-defined video-settings preset (live link). "" = Custom (raw fields below).
   const applyVideoPreset = (id: string) => {
     setVideoPresetId(id);
-    const p = videoPresets.find((v) => v.id === id);
+    const p = allVideoPresets.find((v) => v.id === id);
     if (!p) return;
     const s = (v: number | null) => (v == null ? "" : String(v));
     setLightx2vHigh(s(p.lightx2v_strength_high));
@@ -730,7 +731,7 @@ export default function CreateJobDialog({
             </Box>
             <Box sx={{ mt: 1.5 }}>
               {(() => {
-                const p = videoPresets.find((v) => v.id === videoPresetId);
+                const p = allVideoPresets.find((v) => v.id === videoPresetId);
                 return p ? (
                   <SettingsSignature values={p} />
                 ) : (

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -250,7 +250,7 @@ function BranchLane({ groups, laneWidth, activeFilename, segIndex }: { groups: B
 export default function JobDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { presets: videoPresets, fetchPresets: fetchVideoPresets } = useVideoPresetStore();
+  const { allPresets: allVideoPresets, fetchPresets: fetchVideoPresets } = useVideoPresetStore();
   const { loras: loraLibrary, fetchLoras } = useLoraStore();
   const [job, setJob] = useState<JobDetailResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -341,7 +341,8 @@ export default function JobDetail() {
     loras: { name: string; high_weight: number; low_weight: number }[];
   } => {
     const presetId = seg.video_preset_id ?? job?.video_preset_id ?? null;
-    const preset = presetId ? videoPresets.find((p) => p.id === presetId) ?? null : null;
+    // allPresets, not presets: a job whose preset was archived must still show what it ran with.
+    const preset = presetId ? allVideoPresets.find((p) => p.id === presetId) ?? null : null;
     const src = preset ?? job;
     const rawLoras =
       preset?.loras && preset.loras.length > 0 ? preset.loras : seg.loras ?? [];
@@ -1990,7 +1991,8 @@ function SegmentModal({
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const { loras: loraLibrary, fetchLoras } = useLoraStore();
-  const { presets: segVideoPresets, fetchPresets: fetchSegVideoPresets } = useVideoPresetStore();
+  const { presets: segVideoPresets, allPresets: allSegVideoPresets, fetchPresets: fetchSegVideoPresets } =
+    useVideoPresetStore();
   const [segVideoPresetId, setSegVideoPresetId] = useState("");
   const { negativePrompt: defaultNegativePrompt, fetchSettings } = useSettingsStore();
   const [prompt, setPrompt] = useState("");
@@ -2120,7 +2122,7 @@ function SegmentModal({
   // prompt from the preset's default (a snapshot you can still edit before submitting).
   const applySegVideoPreset = (id: string) => {
     setSegVideoPresetId(id);
-    const p = segVideoPresets.find((v) => v.id === id);
+    const p = allSegVideoPresets.find((v) => v.id === id);
     if (!p) return;
     if (p.prompt) setPrompt(p.prompt);
     if (p.loras && p.loras.length > 0) setLoraSlots(lorasToSlots(p.loras, loraLibrary));
@@ -2540,7 +2542,7 @@ function SegmentModal({
               ))}
             </TextField>
             {(() => {
-              const p = segVideoPresets.find((v) => v.id === segVideoPresetId);
+              const p = allSegVideoPresets.find((v) => v.id === segVideoPresetId);
               return p ? (
                 <Box sx={{ mb: 2 }}>
                   <SettingsSignature values={p} />

--- a/src/pages/VideoPresetLibrary.tsx
+++ b/src/pages/VideoPresetLibrary.tsx
@@ -16,11 +16,13 @@ import {
   Autocomplete,
   MenuItem,
   Tooltip,
+  FormControlLabel,
+  Switch,
 } from "@mui/material";
-import { Add, Edit, DeleteOutline, ContentCopy } from "@mui/icons-material";
+import { Add, Edit, DeleteOutline, ContentCopy, Archive, Unarchive } from "@mui/icons-material";
 import { useVideoPresetStore } from "../stores/videoPresetStore";
 import { useLoraStore } from "../stores/loraStore";
-import { createVideoPreset, updateVideoPreset, deleteVideoPreset, getFileUrl } from "../api/client";
+import { createVideoPreset, updateVideoPreset, deleteVideoPreset, setVideoPresetArchived, getFileUrl } from "../api/client";
 import type { VideoSettingsPreset, VideoSettingsPresetCreate, LoraListItem } from "../api/types";
 import { MAX_LORAS } from "../constants";
 import SettingsSignature, { parseSignature, SIG_COLS } from "../components/SettingsSignature";
@@ -65,7 +67,7 @@ function presetToForm(p: VideoSettingsPreset): FormState {
 }
 
 export default function VideoPresetLibrary() {
-  const { presets, loading, error, fetchPresets } = useVideoPresetStore();
+  const { presets, allPresets, loading, error, fetchPresets } = useVideoPresetStore();
   const { loras: loraLibrary, fetchLoras } = useLoraStore();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editing, setEditing] = useState<VideoSettingsPreset | null>(null);
@@ -76,6 +78,7 @@ export default function VideoPresetLibrary() {
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<VideoSettingsPreset | null>(null);
+  const [showArchived, setShowArchived] = useState(false);
 
   useEffect(() => {
     fetchPresets();
@@ -180,13 +183,32 @@ export default function VideoPresetLibrary() {
     await fetchPresets();
   };
 
+  const toggleArchived = async (p: VideoSettingsPreset) => {
+    await setVideoPresetArchived(p.id, !p.archived);
+    // With "show archived" off the card vanishes, which is the intended feedback: the list
+    // it disappears from is the same list the pickers offer.
+    await fetchPresets();
+  };
+
   return (
     <Box sx={{ p: 3 }}>
       <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1 }}>
         <Typography variant="h5">Video Presets</Typography>
-        <Button variant="contained" startIcon={<Add />} onClick={openNew}>
-          New Preset
-        </Button>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={showArchived}
+                onChange={(e) => setShowArchived(e.target.checked)}
+              />
+            }
+            label={<Typography variant="body2">Show archived</Typography>}
+          />
+          <Button variant="contained" startIcon={<Add />} onClick={openNew}>
+            New Preset
+          </Button>
+        </Box>
       </Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
         Named bundles of sampler settings. Choose one per-job (default) or per-segment (override) —
@@ -197,8 +219,8 @@ export default function VideoPresetLibrary() {
         <CircularProgress />
       ) : (
         <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-          {presets.map((p) => (
-            <Card key={p.id} sx={{ width: 340 }}>
+          {(showArchived ? allPresets : presets).map((p) => (
+            <Card key={p.id} sx={{ width: 340, opacity: p.archived ? 0.55 : 1 }}>
               <CardContent>
                 <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
                   <Typography variant="subtitle1" fontWeight={600}>{p.name}</Typography>
@@ -211,9 +233,19 @@ export default function VideoPresetLibrary() {
                     <IconButton size="small" onClick={() => openEdit(p)}>
                       <Edit fontSize="small" />
                     </IconButton>
-                    <IconButton size="small" onClick={() => setDeleteConfirm(p)}>
-                      <DeleteOutline fontSize="small" />
-                    </IconButton>
+                    {/* Archive, not delete, is the right default here: jobs reference a preset
+                        by id, so deleting destroys the record of which config produced which
+                        result. Archiving only hides it from the picker. */}
+                    <Tooltip title={p.archived ? "Restore to the picker" : "Archive — hides it from the picker, keeps it resolvable by past jobs"} arrow>
+                      <IconButton size="small" onClick={() => toggleArchived(p)}>
+                        {p.archived ? <Unarchive fontSize="small" /> : <Archive fontSize="small" />}
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete permanently — past jobs lose their config" arrow>
+                      <IconButton size="small" onClick={() => setDeleteConfirm(p)}>
+                        <DeleteOutline fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
                   </Box>
                 </Box>
                 <Box sx={{ mt: 1 }}>

--- a/src/stores/videoPresetStore.test.ts
+++ b/src/stores/videoPresetStore.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { VideoSettingsPreset } from "../api/types";
+
+// Mocked, not imported: api/client installs axios interceptors at import time, one of which
+// assigns window.location on a 401. vi.mock keeps the real module from ever loading.
+const getVideoPresets = vi.fn();
+vi.mock("../api/client", () => ({ getVideoPresets: (...a: unknown[]) => getVideoPresets(...a) }));
+
+const { useVideoPresetStore } = await import("./videoPresetStore");
+
+const preset = (name: string, archived: boolean): VideoSettingsPreset =>
+  ({ id: `id-${name}`, name, archived }) as VideoSettingsPreset;
+
+describe("videoPresetStore — the picker/history split", () => {
+  beforeEach(() => {
+    getVideoPresets.mockReset();
+    useVideoPresetStore.setState({ presets: [], allPresets: [], loading: false, error: null });
+  });
+
+  it("keeps archived presets out of the picker list but resolvable by id", async () => {
+    // The whole point of archiving over deleting: a job that ran on 'old' must still be able
+    // to show what it ran with, while nobody can pick it for a new job.
+    getVideoPresets.mockResolvedValue([preset("old", true), preset("current", false)]);
+
+    await useVideoPresetStore.getState().fetchPresets();
+    const { presets, allPresets } = useVideoPresetStore.getState();
+
+    expect(presets.map((p) => p.name)).toEqual(["current"]);
+    expect(allPresets.map((p) => p.name)).toEqual(["current", "old"]);
+    expect(allPresets.find((p) => p.id === "id-old")).toBeDefined();
+  });
+
+  it("asks the API for archived presets — filtering happens here, not server-side", () => {
+    getVideoPresets.mockResolvedValue([]);
+    useVideoPresetStore.getState().fetchPresets();
+    expect(getVideoPresets).toHaveBeenCalledWith(true);
+  });
+
+  it("sorts by name", async () => {
+    getVideoPresets.mockResolvedValue([preset("b", false), preset("a", false)]);
+    await useVideoPresetStore.getState().fetchPresets();
+    expect(useVideoPresetStore.getState().presets.map((p) => p.name)).toEqual(["a", "b"]);
+  });
+
+  it("surfaces a fetch failure instead of leaving an empty picker looking correct", async () => {
+    getVideoPresets.mockRejectedValue(new Error("boom"));
+    await useVideoPresetStore.getState().fetchPresets();
+    expect(useVideoPresetStore.getState().error).toBe("boom");
+    expect(useVideoPresetStore.getState().loading).toBe(false);
+  });
+});

--- a/src/stores/videoPresetStore.ts
+++ b/src/stores/videoPresetStore.ts
@@ -3,7 +3,14 @@ import { getVideoPresets } from "../api/client";
 import type { VideoSettingsPreset } from "../api/types";
 
 interface VideoPresetState {
+  /** Active presets — the list every picker offers. Archiving is only meaningful if it
+   *  takes a preset out of here. */
   presets: VideoSettingsPreset[];
+  /** Every preset including archived ones, for resolving a preset BY ID. A job holds the id of
+   *  whatever preset it ran with; if that preset was later archived and we looked it up in
+   *  `presets`, the job would silently render its raw sampler values instead of the preset's —
+   *  which is exactly the history that archiving (rather than deleting) exists to keep. */
+  allPresets: VideoSettingsPreset[];
   loading: boolean;
   error: string | null;
   fetchPresets: () => Promise<void>;
@@ -11,15 +18,22 @@ interface VideoPresetState {
 
 export const useVideoPresetStore = create<VideoPresetState>((set) => ({
   presets: [],
+  allPresets: [],
   loading: false,
   error: null,
 
   fetchPresets: async () => {
     set({ loading: true, error: null });
     try {
-      const presets = await getVideoPresets();
-      presets.sort((a, b) => a.name.localeCompare(b.name));
-      set({ presets, loading: false });
+      // One fetch, two views. Asking for everything and splitting here keeps the two concerns
+      // from racing each other through a single shared store.
+      const all = await getVideoPresets(true);
+      all.sort((a, b) => a.name.localeCompare(b.name));
+      set({
+        allPresets: all,
+        presets: all.filter((p) => !p.archived),
+        loading: false,
+      });
     } catch (e) {
       set({
         loading: false,


### PR DESCRIPTION
The API for this shipped in #145 but nothing in the UI used it — archiving a preset meant running a script.

**What's here**
- Archive / Unarchive on each preset card, next to Delete. Archived cards render dimmed.
- A "Show archived" switch on the library page.
- `setVideoPresetArchived()` in the API client.

**The non-obvious part**

The preset store now derives two lists from one fetch:

- `presets` — active only. What every picker offers.
- `allPresets` — includes archived. What resolves a preset **by id**.

`JobDetail.segVideoSettings()` resolves a job's preset by id to show its name and sampler signature. Looked up in the active list, a since-archived preset resolves to `null` and the row silently falls back to the job's raw sampler values — losing exactly the history that archiving (rather than deleting) exists to keep. The id lookups in `JobDetail` and `CreateJobDialog` now use `allPresets`.

**Verification**
- `tsc -b`, `npm run lint` (same 11 pre-existing problems before and after), `npm run build`, `npm test` — 33 tests, 3 files.
- Removed the `!p.archived` filter and confirmed the picker/history-split test fails; restored and it passes.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct