### PR TITLE
Archiving a preset no longer reloads the whole library

### DIFF
--- a/src/pages/VideoPresetLibrary.tsx
+++ b/src/pages/VideoPresetLibrary.tsx
@@ -67,7 +67,7 @@ function presetToForm(p: VideoSettingsPreset): FormState {
 }
 
 export default function VideoPresetLibrary() {
-  const { presets, allPresets, loading, error, fetchPresets } = useVideoPresetStore();
+  const { presets, allPresets, loading, error, fetchPresets, applyPreset } = useVideoPresetStore();
   const { loras: loraLibrary, fetchLoras } = useLoraStore();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editing, setEditing] = useState<VideoSettingsPreset | null>(null);
@@ -79,6 +79,7 @@ export default function VideoPresetLibrary() {
   const [formError, setFormError] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<VideoSettingsPreset | null>(null);
   const [showArchived, setShowArchived] = useState(false);
+  const [rowError, setRowError] = useState<string | null>(null);
 
   useEffect(() => {
     fetchPresets();
@@ -184,10 +185,25 @@ export default function VideoPresetLibrary() {
   };
 
   const toggleArchived = async (p: VideoSettingsPreset) => {
-    await setVideoPresetArchived(p.id, !p.archived);
-    // With "show archived" off the card vanishes, which is the intended feedback: the list
-    // it disappears from is the same list the pickers offer.
-    await fetchPresets();
+    // No refetch. fetchPresets() flips `loading`, which replaces the whole grid with a spinner
+    // and remounts every card — a full-postback flicker for a one-field change. The PATCH
+    // response is the updated preset, so fold it straight into the store.
+    //
+    // With "show archived" off the card still vanishes, which is the intended feedback: the
+    // list it disappears from is the list the pickers offer.
+    setRowError(null);
+    try {
+      const updated = await setVideoPresetArchived(p.id, !p.archived);
+      applyPreset(updated);
+    } catch (e) {
+      // Previously unhandled, so a failed archive looked identical to a successful one that
+      // simply had not refreshed yet.
+      setRowError(
+        `Could not ${p.archived ? "restore" : "archive"} "${p.name}": ${
+          e instanceof Error ? e.message : "request failed"
+        }`,
+      );
+    }
   };
 
   return (
@@ -215,6 +231,11 @@ export default function VideoPresetLibrary() {
         edits apply to future runs of anything using the preset.
       </Typography>
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      {rowError && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setRowError(null)}>
+          {rowError}
+        </Alert>
+      )}
       {loading ? (
         <CircularProgress />
       ) : (

--- a/src/stores/videoPresetStore.test.ts
+++ b/src/stores/videoPresetStore.test.ts
@@ -48,4 +48,44 @@ describe("videoPresetStore — the picker/history split", () => {
     expect(useVideoPresetStore.getState().error).toBe("boom");
     expect(useVideoPresetStore.getState().loading).toBe(false);
   });
+
+  it("applyPreset updates both lists without a refetch — the postback fix", async () => {
+    // Archiving used to call fetchPresets(), which flips `loading` and makes the library swap
+    // its whole grid for a spinner. Folding the PATCH response in directly avoids that, so the
+    // network must NOT be touched.
+    getVideoPresets.mockResolvedValue([preset("keep", false), preset("target", false)]);
+    await useVideoPresetStore.getState().fetchPresets();
+    getVideoPresets.mockClear();
+
+    useVideoPresetStore.getState().applyPreset(preset("target", true));
+
+    const { presets, allPresets } = useVideoPresetStore.getState();
+    expect(getVideoPresets).not.toHaveBeenCalled();
+    expect(presets.map((p) => p.name)).toEqual(["keep"]);
+    expect(allPresets.map((p) => p.name)).toEqual(["keep", "target"]);
+    expect(allPresets.find((p) => p.id === "id-target")!.archived).toBe(true);
+  });
+
+  it("applyPreset does not disturb the order of the other presets", async () => {
+    // Same keys in the same order is what lets React leave the other cards mounted.
+    getVideoPresets.mockResolvedValue([preset("a", false), preset("b", false), preset("c", false)]);
+    await useVideoPresetStore.getState().fetchPresets();
+
+    useVideoPresetStore.getState().applyPreset(preset("b", true));
+
+    expect(useVideoPresetStore.getState().allPresets.map((p) => p.id)).toEqual([
+      "id-a",
+      "id-b",
+      "id-c",
+    ]);
+  });
+
+  it("restoring puts a preset back in the picker list", async () => {
+    getVideoPresets.mockResolvedValue([preset("old", true)]);
+    await useVideoPresetStore.getState().fetchPresets();
+    expect(useVideoPresetStore.getState().presets).toHaveLength(0);
+
+    useVideoPresetStore.getState().applyPreset(preset("old", false));
+    expect(useVideoPresetStore.getState().presets.map((p) => p.name)).toEqual(["old"]);
+  });
 });

--- a/src/stores/videoPresetStore.ts
+++ b/src/stores/videoPresetStore.ts
@@ -14,6 +14,13 @@ interface VideoPresetState {
   loading: boolean;
   error: string | null;
   fetchPresets: () => Promise<void>;
+  /** Fold a single already-persisted preset back into both lists.
+   *
+   *  Mutating one preset used to be followed by fetchPresets(), which flips `loading` and makes
+   *  the library swap its whole grid for a spinner — every card unmounts and remounts, which
+   *  reads as a full page postback for what is a one-field change. The PATCH response already
+   *  contains the updated preset, so there is nothing to go back to the server for. */
+  applyPreset: (updated: VideoSettingsPreset) => void;
 }
 
 export const useVideoPresetStore = create<VideoPresetState>((set) => ({
@@ -41,4 +48,12 @@ export const useVideoPresetStore = create<VideoPresetState>((set) => ({
       });
     }
   },
+
+  applyPreset: (updated) =>
+    set((state) => {
+      // Replace in place so the existing sort order is preserved without re-sorting, and so
+      // React sees the same keys for every other card and leaves them mounted.
+      const allPresets = state.allPresets.map((p) => (p.id === updated.id ? updated : p));
+      return { allPresets, presets: allPresets.filter((p) => !p.archived) };
+    }),
 }));


### PR DESCRIPTION
Closes #283.

Archiving *felt* like a full page postback because it effectively was one:

```ts
const toggleArchived = async (p) => {
  await setVideoPresetArchived(p.id, !p.archived);
  await fetchPresets();          // <- sets loading: true
};
```

and the library renders

```tsx
{loading ? <CircularProgress /> : <Box>…every card…</Box>}
```

So a one-field change on one preset unmounted and remounted the entire grid, with a spinner in between.

**There was never a reason to go back to the server.** The PATCH response *is* the updated preset. It now folds straight into the store:

```ts
applyPreset: (updated) => set((state) => {
  const allPresets = state.allPresets.map((p) => (p.id === updated.id ? updated : p));
  return { allPresets, presets: allPresets.filter((p) => !p.archived) };
}),
```

Replaced in place, so the other cards keep their React keys and stay mounted, the sort order is untouched, and **no request is made at all**. The archived card still disappears when "Show archived" is off — that feedback is intentional and preserved.

**Also fixed, same handler:** there was no error handling, so a failed archive looked identical to a successful one that hadn't refreshed yet. Failures now surface in a dismissible alert naming the preset.

### Verification
- 36 tests pass (3 new), covering the invariants that matter: `applyPreset` touches **neither the network nor the order** of the other presets, and restoring puts a preset back in the picker list.
- Confirmed the key test **fails** when the `!archived` filter is removed.
- `tsc -b`, `npm run build` clean; lint unchanged at the same 11 pre-existing problems.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct