### PR TITLE
Launch a RunPod worker from the Workers page

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -505,6 +505,34 @@ export async function deleteWorker(id: string): Promise<void> {
   await api.delete(`/workers/${id}`);
 }
 
+export interface RunPodAvailability {
+  gpu_type_id: string;
+  datacenter_id: string;
+  available: boolean;
+  price_per_hr: number | null;
+  stock: string | null;
+}
+
+export interface RunPodWorker {
+  id: string;
+  name: string | null;
+  status: string | null;
+  cost_per_hr: number | null;
+  gpu_type_id: string | null;
+}
+
+/** Is the configured GPU purchasable right now? Point-in-time — availability genuinely flaps,
+ *  so a launch can still fail after this returns available. */
+export async function getRunPodAvailability(): Promise<RunPodAvailability> {
+  const { data } = await api.get<RunPodAvailability>("/runpod/availability");
+  return data;
+}
+
+export async function launchRunPodWorker(name: string): Promise<RunPodWorker> {
+  const { data } = await api.post<RunPodWorker>("/runpod/workers", { name });
+  return data;
+}
+
 export async function drainWorker(id: string, afterJobs?: number): Promise<void> {
   const body = afterJobs && afterJobs > 0 ? { after_jobs: afterJobs } : undefined;
   await api.post(`/workers/${id}/drain`, body);

--- a/src/components/LaunchRunPodDialog.tsx
+++ b/src/components/LaunchRunPodDialog.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import {
+  getRunPodAvailability,
+  launchRunPodWorker,
+  type RunPodAvailability,
+} from "../api/client";
+
+/**
+ * Launch a RunPod worker.
+ *
+ * Availability is checked on open and shown before the button is usable, because launching
+ * costs money per hour and "no 4090s right now" is a common, temporary answer — it should be
+ * visible up front rather than discovered as a failure.
+ *
+ * The GPU and datacenter are not choices. The network volume holding the ~39GB model set is
+ * region-locked, so the pod must launch beside it; and 3090 inventory there is transient, so
+ * offering it would produce launches that cannot be honoured.
+ */
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onLaunched: () => void;
+}
+
+export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props) {
+  const [name, setName] = useState("");
+  const [availability, setAvailability] = useState<RunPodAvailability | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [launching, setLaunching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setAvailability(null);
+    setChecking(true);
+    getRunPodAvailability()
+      .then(setAvailability)
+      .catch((e) => setError(detail(e) ?? "Could not check RunPod availability"))
+      .finally(() => setChecking(false));
+  }, [open]);
+
+  const handleLaunch = async () => {
+    setLaunching(true);
+    setError(null);
+    try {
+      await launchRunPodWorker(name.trim());
+      onLaunched();
+      onClose();
+      setName("");
+    } catch (e) {
+      // The API forwards RunPod's own wording for capacity failures — it distinguishes
+      // no-stock from a bad spec better than anything we would write here.
+      setError(detail(e) ?? "Launch failed");
+    } finally {
+      setLaunching(false);
+    }
+  };
+
+  const nameOk = /^[a-zA-Z0-9][a-zA-Z0-9 ._-]{0,48}$/.test(name.trim());
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Launch RunPod worker</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          {checking && (
+            <Stack direction="row" spacing={1} alignItems="center">
+              <CircularProgress size={16} />
+              <Typography variant="body2" color="text.secondary">
+                Checking availability…
+              </Typography>
+            </Stack>
+          )}
+
+          {availability && (
+            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+              <Chip
+                size="small"
+                color={availability.available ? "success" : "default"}
+                label={availability.available ? `Available${availability.stock ? ` · ${availability.stock}` : ""}` : "No capacity"}
+              />
+              {availability.price_per_hr != null && (
+                <Chip size="small" variant="outlined" label={`$${availability.price_per_hr}/hr`} />
+              )}
+              <Typography variant="caption" color="text.secondary">
+                {availability.gpu_type_id.replace("NVIDIA GeForce ", "")} · {availability.datacenter_id}
+              </Typography>
+            </Stack>
+          )}
+
+          {availability && !availability.available && (
+            <Alert severity="info">
+              No capacity right now. The datacenter is fixed because the network volume holding
+              the models is region-locked to it — availability changes minute to minute, so
+              trying again shortly usually works.
+            </Alert>
+          )}
+
+          <TextField
+            label="Worker name"
+            size="small"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. runpod-1"
+            helperText="Shown on this page and in the worker's logs"
+            error={name.length > 0 && !nameOk}
+            fullWidth
+          />
+
+          <Typography variant="caption" color="text.secondary">
+            The worker starts claiming jobs as soon as it boots. Set a drain policy from its
+            card when you want it to stop.
+          </Typography>
+
+          {error && <Alert severity="error">{error}</Alert>}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={launching}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleLaunch}
+          disabled={launching || checking || !nameOk || !availability?.available}
+        >
+          {launching ? "Launching…" : "Launch"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/** Pull the API's `detail` out of an axios error without dragging axios types in here. */
+function detail(e: unknown): string | null {
+  const d = (e as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail;
+  return typeof d === "string" ? d : null;
+}

--- a/src/pages/Workers.tsx
+++ b/src/pages/Workers.tsx
@@ -27,12 +27,14 @@ import {
   Timer,
   DeleteOutline,
   PowerSettingsNew,
+  CloudUpload,
   Edit,
   Memory,
   Cancel,
 } from "@mui/icons-material";
 import { useNavigate } from "react-router";
 import { getWorkers, deleteWorker, drainWorker, cancelDrain, renameWorker } from "../api/client";
+import LaunchRunPodDialog from "../components/LaunchRunPodDialog";
 import type { WorkerResponse, WorkerStatus } from "../api/types";
 import { POLL_INTERVAL_SLOW } from "../constants";
 
@@ -73,6 +75,7 @@ export default function Workers() {
   const [deleteConfirm, setDeleteConfirm] = useState<WorkerResponse | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [drainConfirm, setDrainConfirm] = useState<WorkerResponse | null>(null);
+  const [launchOpen, setLaunchOpen] = useState(false);
   const [draining, setDraining] = useState(false);
   const [drainMode, setDrainMode] = useState<"immediate" | "after">("immediate");
   const [drainCount, setDrainCount] = useState(3);
@@ -153,6 +156,15 @@ export default function Workers() {
         <Typography variant="body2" color="text.secondary">
           {onlineCount} online / {workers.length} total
         </Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<CloudUpload />}
+          onClick={() => setLaunchOpen(true)}
+        >
+          Launch RunPod
+        </Button>
       </Box>
 
       {error && (
@@ -270,6 +282,11 @@ export default function Workers() {
           </Button>
         </DialogActions>
       </Dialog>
+      <LaunchRunPodDialog
+        open={launchOpen}
+        onClose={() => setLaunchOpen(false)}
+        onLaunched={fetchWorkers}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
Closes #288. Pairs with wanly-api#159.

A **Launch RunPod** button on the Workers page opens a dialog that checks availability on open and shows stock and price before the launch button becomes usable. Launching costs money per hour, and "no 4090s right now" is a common and temporary answer — better seen up front than discovered as a failure.

### What is deliberately not a choice

**GPU and datacenter.** The network volume holding the ~39GB model set is region-locked, so the pod must launch beside it; and 3090 inventory there is transient (present in one sample, gone the next five). Offering a choice the system cannot honour is worse than offering none — so the dialog states what it is launching rather than asking.

**Drain policy.** Set per worker from its card, where the rest of the lifecycle already lives.

### Failure handling

Capacity failures show the API's message verbatim, which forwards RunPod's own wording — theirs distinguishes no-stock from a bad spec better than ours would. When unavailable, the dialog also explains *why* the datacenter is fixed, so "no capacity" doesn't read as a bug.

, 
> wanly-console@0.1.0 build
> tsc -b && vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 11809 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                    0.60 kB │ gzip:   0.35 kB
dist/assets/index-DKjcCkGF.js  1,538.16 kB │ gzip: 445.06 kB
✓ built in 9.96s clean; 36 tests pass; lint unchanged at the same 4 pre-existing errors.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct