### PR TITLE
Say what is holding an image when a delete is refused

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -423,8 +423,10 @@ export async function getUntaggedImages(): Promise<ImageFile[]> {
   return data;
 }
 
-export async function deleteImage(path: string): Promise<void> {
-  await api.delete("/images", { params: { path } });
+/** Delete an image. Refused with 409 when a job or segment still references it; pass
+ *  force to delete anyway and accept the dangling reference. */
+export async function deleteImage(path: string, force = false): Promise<void> {
+  await api.delete("/images", { params: force ? { path, force: true } : { path } });
 }
 
 export async function createImageFolder(name: string): Promise<{ name: string }> {

--- a/src/lib/imageDeleteConflict.test.ts
+++ b/src/lib/imageDeleteConflict.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { parseImageInUse, describeHolders } from "./imageDeleteConflict";
+
+const conflict = (overrides = {}) => ({
+  response: {
+    status: 409,
+    data: {
+      detail: {
+        message: "Image is still referenced; pass force=true to delete anyway",
+        path: "s3://wanly-images/2026-07-09/x.png",
+        job_ids: ["job-1"],
+        segment_ids: ["seg-1", "seg-2"],
+        ...overrides,
+      },
+    },
+  },
+});
+
+describe("parseImageInUse", () => {
+  it("extracts the holders so the user can go look at them", () => {
+    const out = parseImageInUse(conflict())!;
+    expect(out.jobIds).toEqual(["job-1"]);
+    expect(out.segmentIds).toEqual(["seg-1", "seg-2"]);
+    expect(out.path).toBe("s3://wanly-images/2026-07-09/x.png");
+  });
+
+  it("returns null for anything that is not a 409", () => {
+    // A network failure must never be reported to the user as "image in use".
+    expect(parseImageInUse({ response: { status: 500, data: {} } })).toBeNull();
+    expect(parseImageInUse({ message: "Network Error" })).toBeNull();
+    expect(parseImageInUse(undefined)).toBeNull();
+  });
+
+  it("returns null when a 409 names no holders", () => {
+    // The API contradicting itself. Better to fall back to ordinary error handling than to
+    // render "still used by 0 things".
+    expect(parseImageInUse(conflict({ job_ids: [], segment_ids: [] }))).toBeNull();
+  });
+
+  it("survives a malformed detail without throwing", () => {
+    expect(parseImageInUse({ response: { status: 409, data: { detail: "oops" } } })).toBeNull();
+    expect(parseImageInUse({ response: { status: 409, data: {} } })).toBeNull();
+    expect(
+      parseImageInUse({ response: { status: 409, data: { detail: { job_ids: "nope" } } } }),
+    ).toBeNull();
+  });
+});
+
+describe("describeHolders", () => {
+  it("reads naturally at one and at many", () => {
+    expect(describeHolders({ path: "", jobIds: ["a"], segmentIds: [] })).toBe("1 job");
+    expect(describeHolders({ path: "", jobIds: ["a", "b"], segmentIds: [] })).toBe("2 jobs");
+    expect(describeHolders({ path: "", jobIds: [], segmentIds: ["s"] })).toBe("1 segment");
+    expect(describeHolders({ path: "", jobIds: ["a"], segmentIds: ["s", "t"] })).toBe(
+      "1 job and 2 segments",
+    );
+  });
+});

--- a/src/lib/imageDeleteConflict.ts
+++ b/src/lib/imageDeleteConflict.ts
@@ -1,0 +1,62 @@
+/**
+ * Reading the 409 that `DELETE /images` returns when something still points at the image.
+ *
+ * The API refuses rather than deleting, because a deleted-but-referenced image fails silently:
+ * nothing breaks until a worker claims the segment and S3 returns 404, which costs a pickup and
+ * surfaces as a red segment nowhere near the cause (wanly-api#156).
+ *
+ * The refusal is only useful if the UI says *what* is holding the image. Before this, the
+ * handler silently ignored it - the delete correctly did not happen and the user was
+ * told nothing at all, which teaches people to distrust the button rather than go look at the
+ * job.
+ */
+
+export interface ImageInUse {
+  path: string;
+  jobIds: string[];
+  segmentIds: string[];
+}
+
+/**
+ * Pull the conflict out of an axios error, or null if this was not a 409-in-use.
+ *
+ * Anything that is not a well-formed 409 returns null so the caller falls back to ordinary
+ * error handling — a network failure must not be reported as "image in use".
+ */
+export function parseImageInUse(error: unknown): ImageInUse | null {
+  const response = (error as { response?: { status?: number; data?: unknown } })?.response;
+  if (response?.status !== 409) return null;
+
+  const detail = (response.data as { detail?: unknown })?.detail;
+  if (!detail || typeof detail !== "object") return null;
+
+  const d = detail as { path?: unknown; job_ids?: unknown; segment_ids?: unknown };
+  const jobIds = Array.isArray(d.job_ids) ? d.job_ids.filter((x): x is string => typeof x === "string") : [];
+  const segmentIds = Array.isArray(d.segment_ids)
+    ? d.segment_ids.filter((x): x is string => typeof x === "string")
+    : [];
+
+  // A 409 with no holders at all would be the API contradicting itself. Treat it as an ordinary
+  // error rather than rendering "still used by 0 things".
+  if (jobIds.length === 0 && segmentIds.length === 0) return null;
+
+  return {
+    path: typeof d.path === "string" ? d.path : "",
+    jobIds,
+    segmentIds,
+  };
+}
+
+/** "2 jobs and 1 segment" — for a sentence, so it has to read naturally at 1 and at 0. */
+export function describeHolders(conflict: ImageInUse): string {
+  const parts: string[] = [];
+  if (conflict.jobIds.length) {
+    parts.push(`${conflict.jobIds.length} job${conflict.jobIds.length === 1 ? "" : "s"}`);
+  }
+  if (conflict.segmentIds.length) {
+    parts.push(
+      `${conflict.segmentIds.length} segment${conflict.segmentIds.length === 1 ? "" : "s"}`,
+    );
+  }
+  return parts.join(" and ");
+}

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -23,6 +23,7 @@ import {
   ListItemText,
   useMediaQuery,
   useTheme,
+  Snackbar,
 } from "@mui/material";
 import {
   ArrowBack,
@@ -43,6 +44,11 @@ import {
   Search,
 } from "@mui/icons-material";
 import { useNavigate } from "react-router";
+import {
+  parseImageInUse,
+  describeHolders,
+  type ImageInUse,
+} from "../lib/imageDeleteConflict";
 import {
   getImageFolders,
   getImageFolder,
@@ -92,6 +98,8 @@ export default function ImageRepo() {
   const [loading, setLoading] = useState(true);
   const [lightboxImage, setLightboxImage] = useState<ImageFile | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<ImageFile | null>(null);
+  const [inUse, setInUse] = useState<{ image: ImageFile; conflict: ImageInUse } | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [jobDialogOpen, setJobDialogOpen] = useState(false);
   const [jobDialogImageUri, setJobDialogImageUri] = useState<string | null>(null);
   const [jobDialogImageTags, setJobDialogImageTags] = useState<string | null>(null);
@@ -323,16 +331,28 @@ export default function ImageRepo() {
     setImages([]);
   };
 
-  const handleDeleteConfirm = async () => {
-    if (!deleteConfirm) return;
+  const removeFromView = (key: string) => {
+    setImages((prev) => prev.filter((img) => img.key !== key));
+    if (lightboxImage?.key === key) setLightboxImage(null);
+  };
+
+  const handleDeleteConfirm = async (force = false) => {
+    const target = deleteConfirm ?? inUse?.image ?? null;
+    if (!target) return;
     try {
-      await deleteImage(deleteConfirm.path);
-      setImages((prev) => prev.filter((img) => img.key !== deleteConfirm.key));
-      if (lightboxImage?.key === deleteConfirm.key) {
-        setLightboxImage(null);
+      await deleteImage(target.path, force);
+      removeFromView(target.key);
+      setInUse(null);
+    } catch (e) {
+      // A refusal is not a failure — the API declined because something still points at this
+      // image. Say what, instead of the previous silent swallow, which taught people to
+      // distrust the button rather than go look at the job.
+      const conflict = parseImageInUse(e);
+      if (conflict) {
+        setInUse({ image: target, conflict });
+      } else {
+        setError("Could not delete image");
       }
-    } catch {
-      // ignore
     }
     setDeleteConfirm(null);
   };
@@ -444,21 +464,38 @@ export default function ImageRepo() {
   const handleBulkDeleteConfirm = async () => {
     if (bulkDeleteKeys.length === 0) return;
     setBulkDeleting(true);
+    // Each image is attempted independently. Previously one failure aborted the loop and was
+    // swallowed, so images that HAD been deleted stayed on screen, the rest were never tried,
+    // and nothing was reported — the view and the bucket silently disagreed.
+    const deleted: string[] = [];
+    let refused = 0;
+    let failed = 0;
     try {
       for (const key of bulkDeleteKeys) {
         const img = images.find((i) => i.key === key);
-        if (img) await deleteImage(img.path);
+        if (!img) continue;
+        try {
+          await deleteImage(img.path);
+          deleted.push(key);
+        } catch (e) {
+          if (parseImageInUse(e)) refused += 1;
+          else failed += 1;
+        }
       }
-      setImages((prev) => prev.filter((img) => !bulkDeleteKeys.includes(img.key)));
-      if (lightboxImage && bulkDeleteKeys.includes(lightboxImage.key)) {
+      setImages((prev) => prev.filter((img) => !deleted.includes(img.key)));
+      if (lightboxImage && deleted.includes(lightboxImage.key)) {
         setLightboxImage(null);
       }
       setSelectedKeys(new Set());
       setSelectMode(false);
       setBulkDeleteOpen(false);
       setBulkDeleteKeys([]);
-    } catch {
-      // ignore
+      if (refused || failed) {
+        const parts = [`Deleted ${deleted.length}`];
+        if (refused) parts.push(`${refused} still in use`);
+        if (failed) parts.push(`${failed} failed`);
+        setError(parts.join(" · "));
+      }
     } finally {
       setBulkDeleting(false);
     }
@@ -731,11 +768,61 @@ export default function ImageRepo() {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setDeleteConfirm(null)}>Cancel</Button>
-          <Button color="error" variant="contained" onClick={handleDeleteConfirm}>
+          <Button color="error" variant="contained" onClick={() => handleDeleteConfirm()}>
             Delete
           </Button>
         </DialogActions>
       </Dialog>
+
+      {/* Refused: something still points at this image (wanly-api#156). */}
+      <Dialog open={!!inUse} onClose={() => setInUse(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Image is still in use</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" gutterBottom>
+            <strong>{inUse?.image.filename}</strong> is referenced by{" "}
+            <strong>{inUse ? describeHolders(inUse.conflict) : ""}</strong>.
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            Deleting it anyway leaves those pointing at a file that no longer exists. They will
+            fail when a worker picks them up, which is how images went missing before.
+          </Typography>
+          {!!inUse?.conflict.jobIds.length && (
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="caption" color="text.secondary">
+                Jobs
+              </Typography>
+              {inUse.conflict.jobIds.slice(0, 5).map((id) => (
+                <Typography
+                  key={id}
+                  variant="body2"
+                  sx={{ cursor: "pointer", color: "primary.main", wordBreak: "break-all" }}
+                  onClick={() => navigate(`/jobs/${id}`)}
+                >
+                  {id}
+                </Typography>
+              ))}
+              {inUse.conflict.jobIds.length > 5 && (
+                <Typography variant="caption" color="text.secondary">
+                  …and {inUse.conflict.jobIds.length - 5} more
+                </Typography>
+              )}
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setInUse(null)}>Keep it</Button>
+          <Button color="error" onClick={() => handleDeleteConfirm(true)}>
+            Delete anyway
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={!!error}
+        autoHideDuration={6000}
+        onClose={() => setError(null)}
+        message={error ?? ""}
+      />
 
       {/* Bulk Delete Confirmation */}
       <Dialog


### PR DESCRIPTION
Closes #289.

wanly-api#157 made `DELETE /images` return 409 when a job or segment still points at the image. The console's handler was literally:

```ts
} catch {
  // ignore
}
```

So the refusal was **completely silent** — the delete correctly did not happen and the user was told nothing at all. The habit that grows from that is to distrust the button, not to go look at the job.

### Now

A refusal opens a dialog naming what holds it — *"referenced by 1 job and 2 segments"* — lists the job ids as links into those jobs, and offers **Delete anyway**, which re-issues with `force=true`. The dangling reference then happens deliberately rather than by accident.

### The bulk path had a worse bug in the same shape

One failure aborted the loop and was swallowed, so images that **had** been deleted stayed on screen, the remaining ones were never attempted, and nothing was reported — the view and the bucket silently disagreed. Each image is now attempted independently, only the ones that actually deleted are removed from view, and the outcome is summarised (`Deleted 4 · 2 still in use`).

### Parsing

In `src/lib` so it is testable without MUI. Returns `null` for anything that is not a well-formed 409, so a **network failure is never reported as "image in use"**, and a 409 naming no holders falls back to ordinary error handling rather than rendering "still used by 0 things".

**41 tests pass.** Verified the parser test fails when the 409 check is removed.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct