### PR TITLE
Show RunPod pods while they are still booting, and what they cost

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -530,6 +530,14 @@ export async function getRunPodAvailability(): Promise<RunPodAvailability> {
   return data;
 }
 
+/** Pods RunPod knows about — including ones that have not registered as workers yet.
+ *  The gap between "pod RUNNING" and "worker registered" is the boot: model staging, ComfyUI
+ *  start, node checks. Without this the Workers page shows nothing during that window. */
+export async function getRunPodWorkers(): Promise<RunPodWorker[]> {
+  const { data } = await api.get<RunPodWorker[]>("/runpod/workers");
+  return data;
+}
+
 export async function launchRunPodWorker(name: string): Promise<RunPodWorker> {
   const { data } = await api.post<RunPodWorker>("/runpod/workers", { name });
   return data;

--- a/src/lib/bootingPods.test.ts
+++ b/src/lib/bootingPods.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { findBootingPods, costForWorker } from "./bootingPods";
+import type { RunPodWorker } from "../api/client";
+import type { WorkerResponse } from "../api/types";
+
+const pod = (name: string, status = "RUNNING", cost = 0.74): RunPodWorker =>
+  ({ id: `pod-${name}`, name, status, cost_per_hr: cost, gpu_type_id: null });
+
+const worker = (friendly_name: string): WorkerResponse =>
+  ({ friendly_name } as WorkerResponse);
+
+describe("findBootingPods", () => {
+  it("shows a pod that has not registered yet — the whole point", () => {
+    // Between RunPod saying RUNNING and the daemon registering there is model staging,
+    // ComfyUI start and node checks. That window showed nothing before.
+    const out = findBootingPods([pod("new-worker")], []);
+    expect(out.map((p) => p.name)).toEqual(["new-worker"]);
+  });
+
+  it("hides a pod once its worker registers, so it never appears twice", () => {
+    const out = findBootingPods([pod("w1")], [worker("w1")]);
+    expect(out).toEqual([]);
+  });
+
+  it("ignores pods that are not RUNNING", () => {
+    // An EXITED pod is shutting down. Showing it as "starting" would be worse than nothing.
+    expect(findBootingPods([pod("gone", "EXITED")], [])).toEqual([]);
+    expect(findBootingPods([pod("stopping", "TERMINATED")], [])).toEqual([]);
+  });
+
+  it("handles a mix", () => {
+    const out = findBootingPods(
+      [pod("registered"), pod("booting"), pod("dead", "EXITED")],
+      [worker("registered"), worker("3090.zero")],
+    );
+    expect(out.map((p) => p.name)).toEqual(["booting"]);
+  });
+
+  it("carries the cost through so the card can show what it is burning", () => {
+    expect(findBootingPods([pod("x", "RUNNING", 0.74)], [])[0].costPerHr).toBe(0.74);
+  });
+});
+
+describe("costForWorker", () => {
+  it("returns the pod's actual rate, not the launch-dialog quote", () => {
+    expect(costForWorker("w1", [pod("w1", "RUNNING", 0.69)])).toBe(0.69);
+  });
+
+  it("returns null for a worker with no pod behind it", () => {
+    // The 3090 is not a RunPod pod; it must not render a cost.
+    expect(costForWorker("3090.zero", [pod("w1")])).toBeNull();
+  });
+});

--- a/src/lib/bootingPods.ts
+++ b/src/lib/bootingPods.ts
@@ -1,0 +1,55 @@
+import type { RunPodWorker } from "../api/client";
+import type { WorkerResponse } from "../api/types";
+
+/**
+ * Which RunPod pods are up but have not registered as workers yet.
+ *
+ * There is a real gap between "RunPod says RUNNING" and "the worker appears on this page":
+ * the container stages models, starts ComfyUI, verifies nodes and validates models before the
+ * daemon registers. On a warm network volume that is ~90s; on a cold one it is 12+ minutes of
+ * downloading. During that window the Workers page showed nothing at all, so a launch looked
+ * like it had failed.
+ *
+ * Joined on name, because the launcher sets the pod name and the worker's FRIENDLY_NAME to the
+ * same value — so a pod that has registered appears once, as a worker, not twice.
+ */
+
+export interface BootingPod {
+  id: string;
+  name: string;
+  status: string | null;
+  costPerHr: number | null;
+}
+
+export function findBootingPods(
+  pods: RunPodWorker[],
+  workers: WorkerResponse[],
+): BootingPod[] {
+  const registered = new Set(workers.map((w) => w.friendly_name));
+  return pods
+    // A pod RunPod is deliberately shutting down is not "booting". Showing EXITED pods as
+    // starting would be worse than showing nothing.
+    .filter((p) => p.status === "RUNNING")
+    .filter((p) => !!p.name && !registered.has(p.name))
+    .map((p) => ({
+      id: p.id,
+      name: p.name as string,
+      status: p.status,
+      costPerHr: p.cost_per_hr,
+    }));
+}
+
+/**
+ * The hourly cost of a pod backing an already-registered worker, or null if this worker is not
+ * a RunPod pod.
+ *
+ * This is the pod's ACTUAL rate as RunPod reports it, not the pre-launch quote shown in the
+ * launch dialog — they are different numbers and only this one is what gets billed.
+ */
+export function costForWorker(
+  workerName: string,
+  pods: RunPodWorker[],
+): number | null {
+  const pod = pods.find((p) => p.name === workerName);
+  return pod?.cost_per_hr ?? null;
+}

--- a/src/pages/Workers.tsx
+++ b/src/pages/Workers.tsx
@@ -33,7 +33,16 @@ import {
   Cancel,
 } from "@mui/icons-material";
 import { useNavigate } from "react-router";
-import { getWorkers, deleteWorker, drainWorker, cancelDrain, renameWorker } from "../api/client";
+import {
+  getWorkers,
+  deleteWorker,
+  drainWorker,
+  cancelDrain,
+  renameWorker,
+  getRunPodWorkers,
+  type RunPodWorker,
+} from "../api/client";
+import { findBootingPods, costForWorker } from "../lib/bootingPods";
 import LaunchRunPodDialog from "../components/LaunchRunPodDialog";
 import type { WorkerResponse, WorkerStatus } from "../api/types";
 import { POLL_INTERVAL_SLOW } from "../constants";
@@ -76,6 +85,7 @@ export default function Workers() {
   const [deleting, setDeleting] = useState(false);
   const [drainConfirm, setDrainConfirm] = useState<WorkerResponse | null>(null);
   const [launchOpen, setLaunchOpen] = useState(false);
+  const [pods, setPods] = useState<RunPodWorker[]>([]);
   const [draining, setDraining] = useState(false);
   const [drainMode, setDrainMode] = useState<"immediate" | "after">("immediate");
   const [drainCount, setDrainCount] = useState(3);
@@ -89,6 +99,13 @@ export default function Workers() {
       setError("Failed to load workers");
     } finally {
       setLoading(false);
+    }
+    // Separate and non-fatal: RunPod being unreachable, or simply not configured on this
+    // server, must not blank the worker list. The 3090 does not depend on it at all.
+    try {
+      setPods(await getRunPodWorkers());
+    } catch {
+      setPods([]);
     }
   }, []);
 
@@ -149,6 +166,11 @@ export default function Workers() {
     (w) => w.status !== "offline",
   ).length;
 
+  const booting = findBootingPods(pods, workers);
+  const hourlySpend = pods
+    .filter((p) => p.status === "RUNNING")
+    .reduce((sum, p) => sum + (p.cost_per_hr ?? 0), 0);
+
   return (
     <Box>
       <Box sx={{ display: "flex", alignItems: "baseline", gap: 2, mb: 3 }}>
@@ -156,6 +178,15 @@ export default function Workers() {
         <Typography variant="body2" color="text.secondary">
           {onlineCount} online / {workers.length} total
         </Typography>
+        {hourlySpend > 0 && (
+          <Chip
+            size="small"
+            color="warning"
+            variant="outlined"
+            label={`$${hourlySpend.toFixed(2)}/hr`}
+            title="Combined hourly cost of running RunPod pods"
+          />
+        )}
         <Box sx={{ flexGrow: 1 }} />
         <Button
           variant="contained"
@@ -180,10 +211,36 @@ export default function Workers() {
       )}
 
       <Grid container spacing={2}>
+        {booting.map((p) => (
+          <Grid key={p.id} size={{ xs: 12, sm: 6, md: 4 }}>
+            <Card sx={{ opacity: 0.85 }}>
+              <CardContent>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
+                  <Typography variant="h6" sx={{ flexGrow: 1 }}>
+                    {p.name}
+                  </Typography>
+                  <CircularProgress size={16} />
+                  <Typography variant="body2" sx={{ color: "#0288d1", fontWeight: 600 }}>
+                    Starting
+                  </Typography>
+                </Box>
+                <Typography variant="body2" color="text.secondary">
+                  Pod is running; the worker has not registered yet. It stages models, starts
+                  ComfyUI and validates before appearing as online.
+                </Typography>
+                <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1 }}>
+                  {p.id}
+                  {p.costPerHr != null && ` · $${p.costPerHr}/hr`}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
         {sorted.map((worker) => (
           <Grid key={worker.id} size={{ xs: 12, sm: 6, md: 4 }}>
             <WorkerCard
               worker={worker}
+              costPerHr={costForWorker(worker.friendly_name, pods)}
               onDelete={setDeleteConfirm}
               onDrain={setDrainConfirm}
               onCancelDrain={handleCancelDrain}
@@ -293,6 +350,7 @@ export default function Workers() {
 
 function WorkerCard({
   worker,
+  costPerHr,
   onDelete,
   onDrain,
   onCancelDrain,
@@ -300,6 +358,9 @@ function WorkerCard({
   onClick,
 }: {
   worker: WorkerResponse;
+  /** The pod's actual hourly rate as RunPod reports it, or null when this worker is not a pod.
+   *  Distinct from the launch dialog's pre-launch quote — this is what is being billed. */
+  costPerHr: number | null;
   onDelete: (w: WorkerResponse) => void;
   onDrain: (w: WorkerResponse) => void;
   onCancelDrain: (w: WorkerResponse) => void;
@@ -536,6 +597,7 @@ function WorkerCard({
           sx={{ mt: 1.5, pt: 1, borderTop: "1px solid", borderColor: "divider" }}
         >
           Registered {formatDate(worker.registered_at)}
+          {costPerHr != null && ` · $${costPerHr}/hr`}
         </Typography>
       </CardContent>
     </Card>


### PR DESCRIPTION
Closes #291.

There is a real gap between RunPod reporting `RUNNING` and the worker appearing on this page — the container stages models, starts ComfyUI, verifies nodes and validates models before the daemon registers. **Warm volume ~90s; cold volume 12+ minutes.** The page showed nothing during that window, so a launch looked like it had failed and the obvious response was to launch another one.

Pods that are RUNNING but unregistered now show as **Starting** cards, joined on name (the launcher sets pod name and `FRIENDLY_NAME` to the same value, so a registered pod appears once — as a worker — not twice). `EXITED`/`TERMINATED` pods are not shown; calling a shutting-down pod "starting" would be worse than nothing.

### Also: cost, which is the other half of the same problem

- Each RunPod-backed worker card shows its rate.
- The header shows **combined hourly spend** across running pods.

This is the pod's **actual** `costPerHr` from RunPod, not the pre-launch quote in the launch dialog — different numbers, and only this one is billed. Two forgotten pods were found burning $0.74/hr each earlier today with nothing on screen to suggest it.

The pod fetch is **non-fatal**: RunPod being unreachable, or not configured on this server, must not blank the worker list. The 3090 does not depend on it.

**48 tests pass.** Verified the RUNNING-filter test fails when the filter is removed.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct