### PR TITLE
Show segment run times by GPU and shape on the dashboard

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -525,6 +525,27 @@ export interface RunPodWorker {
 
 /** Is the configured GPU purchasable right now? Point-in-time — availability genuinely flaps,
  *  so a launch can still fail after this returns available. */
+export interface SegmentRuntimeGroup {
+  gpu_name: string;
+  width: number;
+  height: number;
+  clip_seconds: number;
+  samples: number;
+  avg_seconds: number;
+  median_seconds: number;
+  min_seconds: number;
+  max_seconds: number;
+}
+
+/** Run times grouped by GPU AND job shape. Never by GPU alone — the same card runs 480p/3s in
+ *  ~330s and 720x1056/5s in ~1780s, so a combined figure describes nothing. */
+export async function getSegmentRuntimes(minSamples = 1): Promise<SegmentRuntimeGroup[]> {
+  const { data } = await api.get<SegmentRuntimeGroup[]>("/stats/segment-runtimes", {
+    params: { min_samples: minSamples },
+  });
+  return data;
+}
+
 export async function getRunPodAvailability(): Promise<RunPodAvailability> {
   const { data } = await api.get<RunPodAvailability>("/runpod/availability");
   return data;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -20,7 +20,7 @@ import {
   Timer,
   Schedule,
 } from "@mui/icons-material";
-import { getStats, getWorkers } from "../api/client";
+import { getStats, getWorkers, getSegmentRuntimes, type SegmentRuntimeGroup } from "../api/client";
 import type { StatsResponse, WorkerResponse } from "../api/types";
 import { POLL_INTERVAL_SLOW } from "../constants";
 
@@ -96,6 +96,7 @@ function StatCard({ label, value, color, icon }: StatCardProps) {
 export default function Dashboard() {
   const [stats, setStats] = useState<StatsResponse | null>(null);
   const [workers, setWorkers] = useState<WorkerResponse[]>([]);
+  const [runtimes, setRuntimes] = useState<SegmentRuntimeGroup[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -106,6 +107,12 @@ export default function Dashboard() {
       })
       .catch(() => {})
       .finally(() => setLoading(false));
+
+    // Separate from the main load: this is supplementary, and it should never be able to blank
+    // the dashboard if the query is slow or the endpoint is unavailable.
+    getSegmentRuntimes()
+      .then(setRuntimes)
+      .catch(() => setRuntimes([]));
 
     const interval = setInterval(() => {
       Promise.all([getStats(), getWorkers()])
@@ -211,6 +218,56 @@ export default function Dashboard() {
                 <TableRow>
                   <TableCell colSpan={4} sx={{ textAlign: "center", color: "text.secondary" }}>
                     No worker data yet
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Card>
+
+      <Card sx={{ mt: 3 }}>
+        <CardContent sx={{ pb: 1 }}>
+          <Typography variant="h6">Run time by GPU and shape</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Grouped by shape as well as GPU — the same card runs 480p/3s in ~5 minutes and
+            720&times;1056/5s in ~30, so a combined average would describe nothing.
+          </Typography>
+        </CardContent>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>GPU</TableCell>
+                <TableCell>Shape</TableCell>
+                <TableCell align="right">Runs</TableCell>
+                <TableCell align="right">Median</TableCell>
+                <TableCell align="right">Avg</TableCell>
+                <TableCell align="right">Range</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {runtimes.length > 0 ? (
+                runtimes.map((r) => (
+                  <TableRow key={`${r.gpu_name}-${r.width}x${r.height}-${r.clip_seconds}`}>
+                    <TableCell>{r.gpu_name.replace("NVIDIA GeForce ", "")}</TableCell>
+                    <TableCell>
+                      {r.width}&times;{r.height} · {r.clip_seconds}s
+                    </TableCell>
+                    <TableCell align="right">{r.samples}</TableCell>
+                    <TableCell align="right">{formatRunTime(r.median_seconds)}</TableCell>
+                    <TableCell align="right" sx={{ color: "text.secondary" }}>
+                      {formatRunTime(r.avg_seconds)}
+                    </TableCell>
+                    <TableCell align="right" sx={{ color: "text.secondary" }}>
+                      {formatRunTime(r.min_seconds)}–{formatRunTime(r.max_seconds)}
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={6} sx={{ textAlign: "center", color: "text.secondary" }}>
+                    No completed segments recorded yet
                   </TableCell>
                 </TableRow>
               )}


### PR DESCRIPTION
Closes #287. Pairs with wanly-api#160.

A table of median, mean and range per GPU + job shape, with sample count beside it.

**Grouped by shape as well as GPU, because the spread within one card is larger than the spread between cards.** Measured in a single day:

| shape | run time |
|---|---|
| 704x480 / 3s | 329s |
| 704x480 / 5s | ~570s |
| 720x1056 / 5s | ~1780s |

An average over those would look authoritative and mean nothing — worse than showing no number.

**Median is the headline, mean greyed beside it**, so one pathological run cannot quietly move the figure people plan against. Sample count shown for the same reason: a group built from one run should not read like one built from fifty.

The fetch is separate from the main dashboard load and swallows its own errors — this is supplementary, and a slow query must never blank the page.

48 tests pass.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct