### PR TITLE
Reserve a GPU from the Workers page when none are available

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -554,6 +554,42 @@ export async function getRunPodAvailability(): Promise<RunPodAvailability> {
 /** Pods RunPod knows about — including ones that have not registered as workers yet.
  *  The gap between "pod RUNNING" and "worker registered" is the boot: model staging, ComfyUI
  *  start, node checks. Without this the Workers page shows nothing during that window. */
+export interface GpuReservation {
+  id: string;
+  name: string;
+  status: string;
+  expires_at: string;
+  drain_after_jobs: number | null;
+  pod_id: string | null;
+  error: string | null;
+  attempts: number;
+  created_at: string;
+}
+
+/** Reservations still waiting. Terminal ones are not returned — the point of the list is
+ *  "what is still going to spend money". */
+export async function getReservations(): Promise<GpuReservation[]> {
+  const { data } = await api.get<GpuReservation[]>("/runpod/reservations");
+  return data;
+}
+
+export async function createReservation(
+  name: string,
+  minutes: number,
+  drainAfterJobs?: number,
+): Promise<GpuReservation> {
+  const { data } = await api.post<GpuReservation>("/runpod/reservations", {
+    name,
+    minutes,
+    drain_after_jobs: drainAfterJobs ?? null,
+  });
+  return data;
+}
+
+export async function cancelReservation(id: string): Promise<void> {
+  await api.delete(`/runpod/reservations/${id}`);
+}
+
 export async function getRunPodWorkers(): Promise<RunPodWorker[]> {
   const { data } = await api.get<RunPodWorker[]>("/runpod/workers");
   return data;

--- a/src/components/LaunchRunPodDialog.tsx
+++ b/src/components/LaunchRunPodDialog.tsx
@@ -15,6 +15,7 @@ import {
 import {
   getRunPodAvailability,
   launchRunPodWorker,
+  createReservation,
   type RunPodAvailability,
 } from "../api/client";
 
@@ -42,6 +43,10 @@ export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props)
   const [checking, setChecking] = useState(false);
   const [launching, setLaunching] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Reservation options only appear when there is no capacity — offering them alongside a
+  // working Launch button would be a choice nobody needs to make.
+  const [minutes, setMinutes] = useState(30);
+  const [drainAfter, setDrainAfter] = useState<string>("");
 
   useEffect(() => {
     if (!open) return;
@@ -71,7 +76,24 @@ export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props)
     }
   };
 
+  const handleReserve = async () => {
+    setLaunching(true);
+    setError(null);
+    try {
+      const drain = drainAfter ? Number(drainAfter) : undefined;
+      await createReservation(name.trim(), minutes, drain);
+      onLaunched();
+      onClose();
+      setName("");
+    } catch (e) {
+      setError(detail(e) ?? "Could not create the reservation");
+    } finally {
+      setLaunching(false);
+    }
+  };
+
   const nameOk = /^[a-zA-Z0-9][a-zA-Z0-9 ._-]{0,48}$/.test(name.trim());
+  const noCapacity = !!availability && !availability.available;
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
@@ -103,11 +125,10 @@ export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props)
             </Stack>
           )}
 
-          {availability && !availability.available && (
+          {noCapacity && (
             <Alert severity="info">
-              No capacity right now. The datacenter is fixed because the network volume holding
-              the models is region-locked to it — availability changes minute to minute, so
-              trying again shortly usually works.
+              No capacity right now. Availability changes minute to minute — a reservation keeps
+              checking and launches the moment one frees up.
             </Alert>
           )}
 
@@ -122,10 +143,43 @@ export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props)
             fullWidth
           />
 
-          <Typography variant="caption" color="text.secondary">
-            The worker starts claiming jobs as soon as it boots. Set a drain policy from its
-            card when you want it to stop.
-          </Typography>
+          {noCapacity && (
+            <>
+              <TextField
+                label="Keep trying for"
+                size="small"
+                select
+                value={minutes}
+                onChange={(e) => setMinutes(Number(e.target.value))}
+                SelectProps={{ native: true }}
+                fullWidth
+              >
+                {[15, 30, 60, 120, 240].map((m) => (
+                  <option key={m} value={m}>
+                    {m < 60 ? `${m} minutes` : `${m / 60} hour${m > 60 ? "s" : ""}`}
+                  </option>
+                ))}
+              </TextField>
+
+              <TextField
+                label="Drain after N jobs (optional)"
+                size="small"
+                type="number"
+                value={drainAfter}
+                onChange={(e) => setDrainAfter(e.target.value)}
+                placeholder="e.g. 3"
+                helperText="A reservation can fire while you are away. This bounds what it costs."
+                fullWidth
+              />
+            </>
+          )}
+
+          {!noCapacity && (
+            <Typography variant="caption" color="text.secondary">
+              The worker starts claiming jobs as soon as it boots. Set a drain policy from its
+              card when you want it to stop.
+            </Typography>
+          )}
 
           {error && <Alert severity="error">{error}</Alert>}
         </Stack>
@@ -134,13 +188,19 @@ export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props)
         <Button onClick={onClose} disabled={launching}>
           Cancel
         </Button>
-        <Button
-          variant="contained"
-          onClick={handleLaunch}
-          disabled={launching || checking || !nameOk || !availability?.available}
-        >
-          {launching ? "Launching…" : "Launch"}
-        </Button>
+        {noCapacity ? (
+          <Button variant="contained" onClick={handleReserve} disabled={launching || !nameOk}>
+            {launching ? "Reserving…" : `Reserve for ${minutes < 60 ? `${minutes}m` : `${minutes / 60}h`}`}
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            onClick={handleLaunch}
+            disabled={launching || checking || !nameOk || !availability?.available}
+          >
+            {launching ? "Launching…" : "Launch"}
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/src/lib/reservationDisplay.test.ts
+++ b/src/lib/reservationDisplay.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { minutesLeft, describeWindow, describePolicy } from "./reservationDisplay";
+import type { GpuReservation } from "../api/client";
+
+const NOW = new Date("2026-08-07T12:00:00Z");
+const res = (overrides: Partial<GpuReservation> = {}): GpuReservation =>
+  ({
+    id: "r1",
+    name: "res",
+    status: "pending",
+    expires_at: "2026-08-07T12:30:00Z",
+    drain_after_jobs: null,
+    pod_id: null,
+    error: null,
+    attempts: 0,
+    created_at: "2026-08-07T12:00:00Z",
+    ...overrides,
+  });
+
+describe("minutesLeft", () => {
+  it("counts down in whole minutes", () => {
+    expect(minutesLeft(res(), NOW)).toBe(30);
+  });
+
+  it("never goes negative", () => {
+    // An expired row not yet swept must not render "-3m left".
+    expect(minutesLeft(res({ expires_at: "2026-08-07T11:57:00Z" }), NOW)).toBe(0);
+  });
+});
+
+describe("describeWindow", () => {
+  it("reads naturally across the ranges", () => {
+    expect(describeWindow(res({ expires_at: "2026-08-07T12:30:00Z" }), NOW)).toBe("30m left");
+    expect(describeWindow(res({ expires_at: "2026-08-07T14:00:00Z" }), NOW)).toBe("2h left");
+    expect(describeWindow(res({ expires_at: "2026-08-07T13:20:00Z" }), NOW)).toBe("1h 20m left");
+    expect(describeWindow(res({ expires_at: "2026-08-07T12:00:00Z" }), NOW)).toBe("expiring");
+  });
+});
+
+describe("describePolicy", () => {
+  it("is explicit that no policy means unbounded", () => {
+    // The user should see the open-ended case stated, not implied by absence.
+    expect(describePolicy(res())).toBe("runs until you stop it");
+  });
+
+  it("reads naturally at one and many", () => {
+    expect(describePolicy(res({ drain_after_jobs: 1 }))).toBe("drains after 1 job");
+    expect(describePolicy(res({ drain_after_jobs: 3 }))).toBe("drains after 3 jobs");
+  });
+});

--- a/src/lib/reservationDisplay.ts
+++ b/src/lib/reservationDisplay.ts
@@ -1,0 +1,31 @@
+import type { GpuReservation } from "../api/client";
+
+/**
+ * Presenting a pending reservation.
+ *
+ * A reservation spends money unattended once it fires, so it has to be visible while it waits
+ * and cancellable from where it is visible. The countdown is the part that matters: "waiting"
+ * says nothing about whether this is about to give up or about to run for another four hours.
+ */
+
+/** Whole minutes left, floored at 0 — an expired-but-not-yet-swept row must not show negative. */
+export function minutesLeft(reservation: GpuReservation, now: Date = new Date()): number {
+  const ms = new Date(reservation.expires_at).getTime() - now.getTime();
+  return Math.max(0, Math.floor(ms / 60000));
+}
+
+export function describeWindow(reservation: GpuReservation, now: Date = new Date()): string {
+  const mins = minutesLeft(reservation, now);
+  if (mins <= 0) return "expiring";
+  if (mins < 60) return `${mins}m left`;
+  const hours = Math.floor(mins / 60);
+  const rest = mins % 60;
+  return rest ? `${hours}h ${rest}m left` : `${hours}h left`;
+}
+
+/** What this reservation will do to the worker it eventually launches. */
+export function describePolicy(reservation: GpuReservation): string {
+  if (reservation.drain_after_jobs == null) return "runs until you stop it";
+  const n = reservation.drain_after_jobs;
+  return `drains after ${n} job${n === 1 ? "" : "s"}`;
+}

--- a/src/pages/Workers.tsx
+++ b/src/pages/Workers.tsx
@@ -40,9 +40,13 @@ import {
   cancelDrain,
   renameWorker,
   getRunPodWorkers,
+  getReservations,
+  cancelReservation,
   type RunPodWorker,
+  type GpuReservation,
 } from "../api/client";
 import { findBootingPods, costForWorker } from "../lib/bootingPods";
+import { describeWindow, describePolicy } from "../lib/reservationDisplay";
 import LaunchRunPodDialog from "../components/LaunchRunPodDialog";
 import type { WorkerResponse, WorkerStatus } from "../api/types";
 import { POLL_INTERVAL_SLOW } from "../constants";
@@ -86,6 +90,7 @@ export default function Workers() {
   const [drainConfirm, setDrainConfirm] = useState<WorkerResponse | null>(null);
   const [launchOpen, setLaunchOpen] = useState(false);
   const [pods, setPods] = useState<RunPodWorker[]>([]);
+  const [reservations, setReservations] = useState<GpuReservation[]>([]);
   const [draining, setDraining] = useState(false);
   const [drainMode, setDrainMode] = useState<"immediate" | "after">("immediate");
   const [drainCount, setDrainCount] = useState(3);
@@ -106,6 +111,11 @@ export default function Workers() {
       setPods(await getRunPodWorkers());
     } catch {
       setPods([]);
+    }
+    try {
+      setReservations(await getReservations());
+    } catch {
+      setReservations([]);
     }
   }, []);
 
@@ -211,6 +221,43 @@ export default function Workers() {
       )}
 
       <Grid container spacing={2}>
+        {reservations.map((r) => (
+          <Grid key={r.id} size={{ xs: 12, sm: 6, md: 4 }}>
+            <Card sx={{ opacity: 0.85, borderLeft: "3px solid", borderColor: "#f57f17" }}>
+              <CardContent>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
+                  <Typography variant="h6" sx={{ flexGrow: 1 }}>
+                    {r.name}
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: "#f57f17", fontWeight: 600 }}>
+                    Reserved
+                  </Typography>
+                </Box>
+                <Typography variant="body2" color="text.secondary">
+                  Waiting for a GPU · {describeWindow(r)}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
+                  When it launches: {describePolicy(r)}
+                </Typography>
+                {r.error && (
+                  <Typography variant="caption" sx={{ display: "block", mt: 1, color: "warning.main" }}>
+                    Last attempt: {r.error}
+                  </Typography>
+                )}
+                <Button
+                  size="small"
+                  sx={{ mt: 1 }}
+                  onClick={async () => {
+                    await cancelReservation(r.id);
+                    fetchWorkers();
+                  }}
+                >
+                  Cancel
+                </Button>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
         {booting.map((p) => (
           <Grid key={p.id} size={{ xs: 12, sm: 6, md: 4 }}>
             <Card sx={{ opacity: 0.85 }}>


### PR DESCRIPTION
Closes #296. Pairs with wanly-api#165.

When the launch dialog finds no capacity it now offers a **reservation** instead of just explaining the problem: pick a window, optionally set a drain policy, and it launches the moment a GPU frees up.

### Choices made

**The reservation controls only appear when capacity is unavailable.** Offering them next to a working Launch button would be a decision nobody needs to make.

**The drain policy is offered here and deliberately not on a normal launch.** A manual launch happens with you watching, and the worker card is where you would set it. A reservation can fire at 11:47pm with nobody there — *"get me a 4090 and drain it after 3 jobs"* is bounded; *"get me a 4090"* is open-ended spend. The helper text says that outright rather than leaving you to infer why the field exists.

**Pending reservations appear on the Workers page ahead of booting pods**, since waiting is the earliest state a worker can be in. Each shows:

- its countdown (`1h 20m left`, `expiring`)
- what it will do when it launches — including **"runs until you stop it"** stated explicitly, rather than implied by an empty field
- the last failed attempt, if there was one
- a Cancel button

A reservation nobody can see is one nobody can stop.

### Tests

53 pass. Verified the countdown test **fails** when the floor at zero is removed — that floor is what stops an expired-but-unswept row rendering `-3m left`.
