### PR TITLE
Pair pods with workers by pod id, not by name

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -362,6 +362,9 @@ export interface A1111 {
 }
 
 export interface WorkerResponse {
+  /** Set only by workers running on RunPod. The reliable way to pair a worker with its pod —
+   *  names diverge when a pod is launched from the template rather than the console. */
+  runpod_pod_id?: string | null;
   id: string;
   friendly_name: string;
   hostname: string;

--- a/src/lib/bootingPods.test.ts
+++ b/src/lib/bootingPods.test.ts
@@ -6,8 +6,8 @@ import type { WorkerResponse } from "../api/types";
 const pod = (name: string, status = "RUNNING", cost = 0.74): RunPodWorker =>
   ({ id: `pod-${name}`, name, status, cost_per_hr: cost, gpu_type_id: null });
 
-const worker = (friendly_name: string): WorkerResponse =>
-  ({ friendly_name } as WorkerResponse);
+const worker = (friendly_name: string, runpod_pod_id?: string): WorkerResponse =>
+  ({ friendly_name, runpod_pod_id } as WorkerResponse);
 
 describe("findBootingPods", () => {
   it("shows a pod that has not registered yet — the whole point", () => {
@@ -20,6 +20,20 @@ describe("findBootingPods", () => {
   it("hides a pod once its worker registers, so it never appears twice", () => {
     const out = findBootingPods([pod("w1")], [worker("w1")]);
     expect(out).toEqual([]);
+  });
+
+  it("pairs by pod id when the names differ — the bug this fixes", () => {
+    // Launched from the RunPod template: RunPod auto-names the pod, start.sh defaults
+    // FRIENDLY_NAME to runpod-<pod id>. Matching on name alone left this showing as
+    // "Starting" forever beside the worker it had already become.
+    const p = { ...pod("valid_chocolate_cockroach"), id: "iihtdha72899sn" };
+    const w = worker("runpod-iihtdha72899sn", "iihtdha72899sn");
+    expect(findBootingPods([p], [w])).toEqual([]);
+  });
+
+  it("still shows a template-launched pod before its worker registers", () => {
+    const p = { ...pod("valid_chocolate_cockroach"), id: "iihtdha72899sn" };
+    expect(findBootingPods([p], []).map((x) => x.name)).toEqual(["valid_chocolate_cockroach"]);
   });
 
   it("ignores pods that are not RUNNING", () => {
@@ -43,11 +57,18 @@ describe("findBootingPods", () => {
 
 describe("costForWorker", () => {
   it("returns the pod's actual rate, not the launch-dialog quote", () => {
-    expect(costForWorker("w1", [pod("w1", "RUNNING", 0.69)])).toBe(0.69);
+    expect(costForWorker(worker("w1"), [pod("w1", "RUNNING", 0.69)])).toBe(0.69);
+  });
+
+  it("matches by pod id even when the names differ", () => {
+    // A template-launched pod is auto-named while its worker is runpod-<id>.
+    const w = worker("runpod-abc", "pod-valid_chocolate_cockroach");
+    const p = { ...pod("valid_chocolate_cockroach", "RUNNING", 0.74), id: "pod-valid_chocolate_cockroach" };
+    expect(costForWorker(w, [p])).toBe(0.74);
   });
 
   it("returns null for a worker with no pod behind it", () => {
     // The 3090 is not a RunPod pod; it must not render a cost.
-    expect(costForWorker("3090.zero", [pod("w1")])).toBeNull();
+    expect(costForWorker(worker("3090.zero"), [pod("w1")])).toBeNull();
   });
 });

--- a/src/lib/bootingPods.ts
+++ b/src/lib/bootingPods.ts
@@ -21,16 +21,31 @@ export interface BootingPod {
   costPerHr: number | null;
 }
 
+/** Has this pod already become a registered worker?
+ *
+ *  By pod id first, because that is the only identifier both sides agree on. Names diverge:
+ *  a pod launched from the RunPod template is auto-named (valid_chocolate_cockroach) while its
+ *  worker registers as runpod-<pod id>. Matching on name alone left such a pod showing as
+ *  "Starting" forever, beside the worker it had already become.
+ *
+ *  Name is kept as a fallback for workers whose daemon predates reporting the pod id. */
+function isRegistered(pod: RunPodWorker, workers: WorkerResponse[]): boolean {
+  return workers.some(
+    (w) =>
+      (w.runpod_pod_id && w.runpod_pod_id === pod.id) ||
+      (!!pod.name && w.friendly_name === pod.name),
+  );
+}
+
 export function findBootingPods(
   pods: RunPodWorker[],
   workers: WorkerResponse[],
 ): BootingPod[] {
-  const registered = new Set(workers.map((w) => w.friendly_name));
   return pods
     // A pod RunPod is deliberately shutting down is not "booting". Showing EXITED pods as
     // starting would be worse than showing nothing.
     .filter((p) => p.status === "RUNNING")
-    .filter((p) => !!p.name && !registered.has(p.name))
+    .filter((p) => !isRegistered(p, workers))
     .map((p) => ({
       id: p.id,
       name: p.name as string,
@@ -47,9 +62,13 @@ export function findBootingPods(
  * launch dialog — they are different numbers and only this one is what gets billed.
  */
 export function costForWorker(
-  workerName: string,
+  worker: WorkerResponse,
   pods: RunPodWorker[],
 ): number | null {
-  const pod = pods.find((p) => p.name === workerName);
+  const pod = pods.find(
+    (p) =>
+      (worker.runpod_pod_id && p.id === worker.runpod_pod_id) ||
+      p.name === worker.friendly_name,
+  );
   return pod?.cost_per_hr ?? null;
 }

--- a/src/pages/Workers.tsx
+++ b/src/pages/Workers.tsx
@@ -287,7 +287,7 @@ export default function Workers() {
           <Grid key={worker.id} size={{ xs: 12, sm: 6, md: 4 }}>
             <WorkerCard
               worker={worker}
-              costPerHr={costForWorker(worker.friendly_name, pods)}
+              costPerHr={costForWorker(worker, pods)}
               onDelete={setDeleteConfirm}
               onDrain={setDrainConfirm}
               onCancelDrain={handleCancelDrain}


### PR DESCRIPTION
Fixes a bug I introduced in #291: a pod launched from the RunPod template shows as **Starting** indefinitely, alongside the worker it has already become.

The pairing was on **name**, which only holds for pods the console launcher created — it sets the pod name and `FRIENDLY_NAME` to the same value. A template-launched pod is auto-named by RunPod while its worker registers as `runpod-<pod id>`:

| | |
|---|---|
| pod name | `valid_chocolate_cockroach` |
| worker name | `runpod-iihtdha72899sn` |

Now matched on `runpod_pod_id`, which wanly-api#167 and wanly-gpu-daemon#119 make the worker report. **Name is kept as a fallback** for workers whose daemon predates that, so nothing regresses while the fleet catches up.

`costForWorker` now takes the whole worker rather than its name, for the same reason — it was matching on name and would have failed to show the cost of exactly these pods.

**56 tests pass.** Verified the new pairing test fails when the id match is removed.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct