### PR TITLE
Show all four quality axes on one trajectory chart

### DIFF
--- a/src/components/IdentityTrajectory.tsx
+++ b/src/components/IdentityTrajectory.tsx
@@ -1,148 +1,117 @@
-import { Box, Typography, useTheme } from "@mui/material";
+import { Box, Chip, Stack, Typography, useTheme } from "@mui/material";
 import { DIP_THRESHOLD, TAIL, median } from "../lib/identityHelpers";
+import { buildTracks, type Track } from "../lib/trajectorySeries";
 
-/** Per-frame cosine, already stored by the daemon in identity_metrics.series.
+/** The four axes a clip is judged on, over time, on one chart.
  *
- *  WHY THIS EXISTS: start and end alone cannot distinguish a clip that decayed steadily
- *  from one that held and then dipped on the final frames. Those two produce identical
- *  headline numbers and call for opposite fixes — and it matters more than a display
- *  detail, because the daemon seeds the NEXT segment from the LAST frame. If that frame
- *  is a blink or a motion blur, the continuation inherits the worst moment of the clip
- *  and every later segment compounds an artifact that was never really there.
+ *  Start and end alone cannot tell a clip that decayed steadily from one that held and then
+ *  dipped on the final frames. Those produce identical headline numbers and call for opposite
+ *  fixes — and it matters beyond display, because the next segment is seeded from the LAST
+ *  frame. A blink or motion blur there propagates into everything that follows.
  *
- *  Observed on a real 2-segment job: seg1 read 0.851 -> 0.506 while the fitted slope was
- *  POSITIVE (+3.5e-4/frame). Endpoints falling while the trend rises is exactly the shape
- *  the summary stats cannot express. */
-
+ *  All four together because they trade against each other: high motion with a dead face,
+ *  or identity held while detail collapses, are the failures that any single axis misses. */
 
 interface Props {
   metrics: Record<string, unknown> | null | undefined;
 }
 
+const W = 600;
+const H = 130;
+
 export default function IdentityTrajectory({ metrics }: Props) {
   const theme = useTheme();
+  const tracks = buildTracks(metrics);
+  const identity = tracks.find((t) => t.key === "identity");
+  if (tracks.length === 0) return null;
 
-  const series = (metrics?.series as number[] | undefined) ?? undefined;
+  const colours: Record<Track["key"], string> = {
+    identity: theme.palette.primary.main,
+    expression: theme.palette.secondary.main,
+    motion: theme.palette.warning.main,
+    detail: theme.palette.success.main,
+  };
+
   const stride = (metrics?.stride as number | undefined) ?? 1;
-  // Clips scored before 2026-08-06 measured this against the segment's OWN start frame, which
-  // on a continuation is the already-drifted last frame -- so the graph opened near 0.95 while
-  // the trajectory above it read 0.851. New clips declare the reference; old ones have no
-  // field and are all own_start. Say which, rather than letting the two be conflated.
-  const seriesRef = (metrics?.series_ref as string | undefined) ?? "own_start";
-  const vsGroundTruth = seriesRef === "ground_truth";
-  if (!series || series.length < 8) return null;
+  // Older clips measured identity against the segment's own start frame, which on a
+  // continuation is the already-drifted last frame. Say which, rather than letting the two be
+  // read as the same number.
+  const vsGroundTruth = (metrics?.series_ref as string | undefined) === "ground_truth";
 
-  const lo = Math.min(...series);
-  const hi = Math.max(...series);
-  const span = Math.max(hi - lo, 0.02); // guard a flat clip from dividing by ~0
-  const mean = series.reduce((a, b) => a + b, 0) / series.length;
-
-  const W = 600;
-  const H = 120;
-  const x = (i: number) => (i / (series.length - 1)) * W;
-  const y = (v: number) => H - ((v - lo) / span) * H;
-  const points = series.map((v, i) => `${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(" ");
-
-  // Is the final frame representative of where the clip actually settled?
-  const end = series[series.length - 1];
-  const body = series.slice(-TAIL, -2);
+  // Dip detection stays on identity alone: it exists to decide whether the seed frame for the
+  // NEXT segment is representative, and that is an identity question.
+  const s = identity?.raw ?? [];
+  const end = s.length ? s[s.length - 1] : null;
+  const body = s.slice(-TAIL, -2);
   const bodyMedian = body.length >= 4 ? median(body) : null;
-  const dip = bodyMedian != null ? bodyMedian - end : null;
+  const dip = bodyMedian != null && end != null ? bodyMedian - end : null;
   const isDip = dip != null && dip >= DIP_THRESHOLD;
 
-  // If it IS a dip, the fix is to seed the next segment from the best frame in the tail
-  // rather than strictly the last one — so show what that frame would have been worth.
-  const tail = series.slice(-TAIL);
-  const bestTail = Math.max(...tail);
-  const bestOffset = tail.length - 1 - tail.lastIndexOf(bestTail);
-
-  const line = theme.palette.mode === "dark" ? theme.palette.primary.light : theme.palette.primary.main;
+  const path = (t: Track) =>
+    t.points
+      .map((v, i) => `${((i / (t.points.length - 1)) * W).toFixed(1)},${(H - v * H).toFixed(1)}`)
+      .join(" ");
 
   return (
     <Box sx={{ mt: 2 }}>
-      <Typography variant="subtitle2">Per-frame trajectory</Typography>
-      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
-        Cosine for every scored frame, against{" "}
-        <strong>{vsGroundTruth ? "segment 0's start frame" : "this segment's own start frame"}</strong>
-        {!vsGroundTruth && " — so on a continuation it shows drift WITHIN this segment, not since the job began"}
-        . The next segment is seeded from the <strong>last</strong> frame, so a dip at the
-        right-hand edge propagates into everything that follows.
-        {stride > 1 && ` Sampled every ${stride} frames.`}
-      </Typography>
+      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+        <Typography variant="subtitle2" sx={{ mr: 1 }}>
+          Per-frame trajectory
+        </Typography>
+        {tracks.map((t) => (
+          <Chip
+            key={t.key}
+            size="small"
+            variant="outlined"
+            sx={{ borderColor: colours[t.key], color: colours[t.key] }}
+            label={`${t.label} ${t.min.toFixed(t.precision)}–${t.max.toFixed(t.precision)}`}
+          />
+        ))}
+      </Stack>
 
-      <Box
-        sx={{
-          border: 1,
-          borderColor: "divider",
-          borderRadius: 1,
-          p: 1,
-          overflowX: "auto",
-        }}
-      >
+      <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, p: 1, overflowX: "auto" }}>
         <svg
           viewBox={`0 0 ${W} ${H}`}
           preserveAspectRatio="none"
-          style={{ width: "100%", height: 120, display: "block" }}
+          style={{ width: "100%", height: H, display: "block" }}
         >
-          {/* the clip's own mean — makes "the end is below typical" visible at a glance */}
-          <line
-            x1={0}
-            x2={W}
-            y1={y(mean)}
-            y2={y(mean)}
-            stroke={theme.palette.text.disabled}
-            strokeDasharray="4 4"
-            strokeWidth={1}
-            vectorEffect="non-scaling-stroke"
-          />
-          <polyline
-            points={points}
-            fill="none"
-            stroke={line}
-            strokeWidth={1.5}
-            vectorEffect="non-scaling-stroke"
-          />
-          <circle
-            cx={x(series.length - 1)}
-            cy={y(end)}
-            r={3}
-            fill={isDip ? theme.palette.error.main : theme.palette.success.main}
-            vectorEffect="non-scaling-stroke"
-          />
+          {tracks.map((t) => (
+            <polyline
+              key={t.key}
+              points={path(t)}
+              fill="none"
+              stroke={colours[t.key]}
+              strokeWidth={t.key === "identity" ? 1.8 : 1.1}
+              // The non-identity axes sit behind, so the line that drives the seeding decision
+              // stays readable when all four overlap.
+              opacity={t.key === "identity" ? 1 : 0.65}
+              vectorEffect="non-scaling-stroke"
+            />
+          ))}
+          {identity && end != null && (
+            <circle
+              cx={W}
+              cy={H - identity.points[identity.points.length - 1] * H}
+              r={3.5}
+              fill={isDip ? theme.palette.error.main : theme.palette.success.main}
+              vectorEffect="non-scaling-stroke"
+            />
+          )}
         </svg>
       </Box>
 
-      <Box sx={{ display: "flex", justifyContent: "space-between", mt: 0.5 }}>
-        <Typography variant="caption" color="text.secondary">
-          y-axis {lo.toFixed(3)} – {hi.toFixed(3)} (dashed = mean {mean.toFixed(3)})
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          {series.length} samples
-        </Typography>
-      </Box>
-
-      <Typography
-        variant="caption"
-        component="div"
-        sx={{ mt: 1, fontFamily: "monospace", wordBreak: "break-word" }}
-      >
-        last {TAIL}: {tail.map((v) => v.toFixed(3)).join("  ")}
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
+        Each axis normalised to its own range — the chart shows <em>when</em> something moved;
+        the ranges above carry <em>how much</em>. Identity is measured against{" "}
+        {vsGroundTruth ? "segment 0's start frame" : "this segment's own start frame"}
+        {stride > 1 && `, sampled every ${stride} frames`}.
       </Typography>
 
-      {isDip ? (
+      {isDip && (
         <Typography variant="caption" component="div" color="error.main" sx={{ mt: 1 }}>
-          <strong>The final frame is a dip, not the settled state.</strong> The clip sits around{" "}
-          {bodyMedian!.toFixed(3)} through its tail and ends at {end.toFixed(3)} —{" "}
-          {dip!.toFixed(3)} lower. The next segment is seeded from that frame. The best frame in
-          the last {TAIL} scores {bestTail.toFixed(3)} ({bestOffset} frames from the end), so
-          re-anchoring — or seeding from the best tail frame instead of the last — would start the
-          continuation {(bestTail - end).toFixed(3)} higher.
-        </Typography>
-      ) : (
-        <Typography variant="caption" component="div" color="text.secondary" sx={{ mt: 1 }}>
-          The final frame is consistent with the tail (median {bodyMedian?.toFixed(3) ?? "—"}), so
-          the endpoint reflects where the clip actually settled — any loss here is real drift, not
-          a bad frame.
+          <strong>The final frame is a dip, not the settled state</strong> — tail median{" "}
+          {bodyMedian!.toFixed(3)} vs {end!.toFixed(3)} ending. The next segment seeds from that
+          frame, so this propagates.
         </Typography>
       )}
     </Box>

--- a/src/lib/trajectorySeries.test.ts
+++ b/src/lib/trajectorySeries.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { buildTracks, sampleAt } from "./trajectorySeries";
+
+const seq = (n: number, f: (i: number) => number) => Array.from({ length: n }, (_, i) => f(i));
+
+describe("buildTracks", () => {
+  it("normalises each axis to its own range so all four are comparable in shape", () => {
+    // Identity is a 0-1 cosine, detail is in the hundreds. Plotted raw on one axis, identity
+    // would be a flat line at the bottom.
+    const tracks = buildTracks({
+      series: seq(20, (i) => 0.9 - i * 0.001),
+      series_detail: seq(20, (i) => 200 + i),
+    });
+    for (const t of tracks) {
+      expect(Math.min(...t.points)).toBeCloseTo(0, 5);
+      expect(Math.max(...t.points)).toBeCloseTo(1, 5);
+    }
+  });
+
+  it("keeps the real values alongside the normalised ones", () => {
+    const [t] = buildTracks({ series: seq(20, () => 0.5) });
+    expect(t.raw[0]).toBe(0.5);
+  });
+
+  it("renders a flat series down the middle rather than dropping it", () => {
+    // "This never changed" is information. An absent line reads as missing data.
+    const [t] = buildTracks({ series: seq(20, () => 0.77) });
+    expect(t.points.every((p) => p === 0.5)).toBe(true);
+  });
+
+  it("skips series too short to be a trajectory", () => {
+    expect(buildTracks({ series: [0.1, 0.2, 0.3] })).toEqual([]);
+  });
+
+  it("skips absent axes without disturbing the present ones", () => {
+    const tracks = buildTracks({ series: seq(20, (i) => i / 20) });
+    expect(tracks.map((t) => t.key)).toEqual(["identity"]);
+  });
+
+  it("survives a series containing nulls", () => {
+    const dirty = [...seq(10, (i) => i), null, undefined, "x"] as unknown[];
+    const tracks = buildTracks({ series: dirty });
+    expect(tracks[0].raw).toHaveLength(10);
+  });
+
+  it("returns nothing for absent metrics", () => {
+    expect(buildTracks(null)).toEqual([]);
+    expect(buildTracks(undefined)).toEqual([]);
+  });
+});
+
+describe("sampleAt", () => {
+  it("reads by proportion, not index, because the series have different lengths", () => {
+    // Identity is sampled with a stride; motion is one value per frame pair. Aligning on index
+    // would compare frame 40 of one axis against frame 12 of another.
+    const short = buildTracks({ series: seq(10, (i) => i) })[0];
+    const long = buildTracks({ series_motion: seq(100, (i) => i) })[0];
+    expect(sampleAt(short, 0)).toBe(0);
+    expect(sampleAt(short, 1)).toBe(9);
+    expect(sampleAt(long, 0.5)).toBeCloseTo(50, 0);
+  });
+
+  it("clamps out-of-range fractions instead of returning undefined", () => {
+    const t = buildTracks({ series: seq(10, (i) => i) })[0];
+    expect(sampleAt(t, -1)).toBe(0);
+    expect(sampleAt(t, 2)).toBe(9);
+  });
+});

--- a/src/lib/trajectorySeries.ts
+++ b/src/lib/trajectorySeries.ts
@@ -1,0 +1,76 @@
+/**
+ * Preparing the four quality axes for one shared chart.
+ *
+ * They have wildly different natural units — identity is a 0–1 cosine, motion is pixels per
+ * frame, expression is landmark movement scaled by 1000, detail is Laplacian variance in the
+ * hundreds. Plotted raw on one axis, identity would be a flat line at the bottom and detail
+ * would be the only thing visible.
+ *
+ * So each series is normalised to its own range. That deliberately discards magnitude: the
+ * chart answers "when did this dip", and the headline numbers beside it carry "by how much".
+ * Mixing those two jobs into one axis makes both worse.
+ */
+
+export interface Track {
+  key: "identity" | "expression" | "motion" | "detail";
+  label: string;
+  /** Normalised 0–1 for plotting. */
+  points: number[];
+  /** Real values, for the tooltip and the range caption. */
+  raw: number[];
+  min: number;
+  max: number;
+  /** How many decimals this axis is meaningfully read at. */
+  precision: number;
+}
+
+const SPECS: {
+  key: Track["key"];
+  label: string;
+  field: string;
+  precision: number;
+}[] = [
+  { key: "identity", label: "Identity", field: "series", precision: 3 },
+  { key: "expression", label: "Expression", field: "series_expression", precision: 1 },
+  { key: "motion", label: "Motion", field: "series_motion", precision: 2 },
+  { key: "detail", label: "Detail", field: "series_detail", precision: 0 },
+];
+
+/** A series shorter than this is noise, not a trajectory. */
+const MIN_POINTS = 8;
+
+export function buildTracks(metrics: Record<string, unknown> | null | undefined): Track[] {
+  if (!metrics) return [];
+  const tracks: Track[] = [];
+
+  for (const spec of SPECS) {
+    const raw = metrics[spec.field];
+    if (!Array.isArray(raw) || raw.length < MIN_POINTS) continue;
+    const values = raw.filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+    if (values.length < MIN_POINTS) continue;
+
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    // A genuinely flat series would divide by zero. Render it down the middle rather than
+    // dropping it — "this never changed" is information, and an absent line reads as missing
+    // data instead.
+    const span = max - min;
+    const points = span > 0 ? values.map((v) => (v - min) / span) : values.map(() => 0.5);
+
+    tracks.push({ ...spec, points, raw: values, min, max });
+  }
+  return tracks;
+}
+
+/**
+ * Where each track sits at a given fraction through the clip.
+ *
+ * The series have different lengths — identity is sampled with a stride, motion is one value
+ * per frame pair — so they are read by proportion rather than by index. Aligning on index
+ * would silently compare frame 40 of one axis with frame 12 of another.
+ */
+export function sampleAt(track: Track, fraction: number): number {
+  if (track.raw.length === 0) return 0;
+  const i = Math.round(fraction * (track.raw.length - 1));
+  return track.raw[Math.max(0, Math.min(track.raw.length - 1, i))];
+}


### PR DESCRIPTION
Identity was the only axis plotted, and it was surrounded by more explanation than chart. Now **identity, expression, motion and detail share one time axis**, with the prose cut to the two sentences that carry information.

### Why together

They trade against each other, and the failures that have actually cost us were only visible as *combinations*: high motion with a dead face, or identity held while detail collapsed. Any single axis reads fine in both cases.

### The call on scaling

Each series is normalised to its own range. The units are not comparable — identity is a 0–1 cosine, detail is Laplacian variance in the hundreds. Plotted raw, identity would be a flat line along the bottom and only detail would be visible.

That discards magnitude, deliberately, and the card says so: **the chart answers *when* something moved; the range chips carry *how much*.** Mixing those two jobs into one axis makes both worse.

### Two details worth keeping

- **A flat series renders down the middle** rather than being dropped. "This never changed" is information; an absent line reads as missing data.
- **Series are read by proportion, not index.** They have different lengths — identity is sampled with a stride, motion is one value per frame pair — so aligning on index would compare frame 40 of one axis against frame 12 of another.

Dip detection stays on **identity alone**: it exists to decide whether the last frame is a fit seed for the next segment, which is an identity question.

**65 tests pass.** Verified the normalisation tests fail when raw values are plotted.
