### PR TITLE
Smooth the trajectory lines so a flat clip reads as flat

### DIFF
--- a/src/components/IdentityTrajectory.tsx
+++ b/src/components/IdentityTrajectory.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Box, Chip, Stack, Typography, useTheme } from "@mui/material";
 import { DIP_THRESHOLD, TAIL, median } from "../lib/identityHelpers";
 import { buildTracks, type Track } from "../lib/trajectorySeries";
@@ -21,9 +22,20 @@ const H = 130;
 
 export default function IdentityTrajectory({ metrics }: Props) {
   const theme = useTheme();
+  // Four overlaid lines answer "did these move together"; one line answers "what did this do".
+  // Both are worth asking, so the chips toggle. Hiding never rescales — each axis keeps its own
+  // normalisation, so a line sits in exactly the same place alone as it does in company.
+  const [hidden, setHidden] = useState<ReadonlySet<Track["key"]>>(new Set());
   const tracks = buildTracks(metrics);
   const identity = tracks.find((t) => t.key === "identity");
   if (tracks.length === 0) return null;
+
+  const toggle = (key: Track["key"]) =>
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(key)) next.add(key);
+      return next;
+    });
 
   const colours: Record<Track["key"], string> = {
     identity: theme.palette.primary.main,
@@ -58,15 +70,25 @@ export default function IdentityTrajectory({ metrics }: Props) {
         <Typography variant="subtitle2" sx={{ mr: 1 }}>
           Per-frame trajectory
         </Typography>
-        {tracks.map((t) => (
-          <Chip
-            key={t.key}
-            size="small"
-            variant="outlined"
-            sx={{ borderColor: colours[t.key], color: colours[t.key] }}
-            label={`${t.label} ${t.min.toFixed(t.precision)}–${t.max.toFixed(t.precision)}`}
-          />
-        ))}
+        {tracks.map((t) => {
+          const off = hidden.has(t.key);
+          return (
+            <Chip
+              key={t.key}
+              size="small"
+              variant="outlined"
+              onClick={() => toggle(t.key)}
+              aria-pressed={!off}
+              sx={{
+                cursor: "pointer",
+                borderColor: off ? "divider" : colours[t.key],
+                color: off ? "text.disabled" : colours[t.key],
+                textDecoration: off ? "line-through" : "none",
+              }}
+              label={`${t.label} ${t.min.toFixed(t.precision)}–${t.max.toFixed(t.precision)}`}
+            />
+          );
+        })}
       </Stack>
 
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, p: 1, overflowX: "auto" }}>
@@ -75,7 +97,7 @@ export default function IdentityTrajectory({ metrics }: Props) {
           preserveAspectRatio="none"
           style={{ width: "100%", height: H, display: "block" }}
         >
-          {tracks.map((t) => (
+          {tracks.filter((t) => !hidden.has(t.key)).map((t) => (
             <polyline
               key={t.key}
               points={path(t)}
@@ -88,7 +110,7 @@ export default function IdentityTrajectory({ metrics }: Props) {
               vectorEffect="non-scaling-stroke"
             />
           ))}
-          {identity && end != null && (
+          {identity && !hidden.has("identity") && end != null && (
             <circle
               cx={W}
               cy={H - identity.points[identity.points.length - 1] * H}
@@ -101,9 +123,9 @@ export default function IdentityTrajectory({ metrics }: Props) {
       </Box>
 
       <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
-        Lines are rolling means, each normalised to its own range — the chart shows <em>when</em>{" "}
-        something moved; the ranges above are the raw per-frame extremes and carry{" "}
-        <em>how much</em>. Identity is measured against{" "}
+        Click a chip to hide or isolate an axis. Lines are rolling means, each normalised to its
+        own range — the chart shows <em>when</em> something moved; the chip ranges are the raw
+        per-frame extremes and carry <em>how much</em>. Identity is measured against{" "}
         {vsGroundTruth ? "segment 0's start frame" : "this segment's own start frame"}
         {stride > 1 && `, sampled every ${stride} frames`}.
       </Typography>

--- a/src/components/IdentityTrajectory.tsx
+++ b/src/components/IdentityTrajectory.tsx
@@ -101,8 +101,9 @@ export default function IdentityTrajectory({ metrics }: Props) {
       </Box>
 
       <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
-        Each axis normalised to its own range — the chart shows <em>when</em> something moved;
-        the ranges above carry <em>how much</em>. Identity is measured against{" "}
+        Lines are rolling means, each normalised to its own range — the chart shows <em>when</em>{" "}
+        something moved; the ranges above are the raw per-frame extremes and carry{" "}
+        <em>how much</em>. Identity is measured against{" "}
         {vsGroundTruth ? "segment 0's start frame" : "this segment's own start frame"}
         {stride > 1 && `, sampled every ${stride} frames`}.
       </Typography>

--- a/src/lib/trajectorySeries.test.ts
+++ b/src/lib/trajectorySeries.test.ts
@@ -7,14 +7,23 @@ describe("buildTracks", () => {
   it("normalises each axis to its own range so all four are comparable in shape", () => {
     // Identity is a 0-1 cosine, detail is in the hundreds. Plotted raw on one axis, identity
     // would be a flat line at the bottom.
-    const tracks = buildTracks({
+    const [identity, detail] = buildTracks({
       series: seq(20, (i) => 0.9 - i * 0.001),
       series_detail: seq(20, (i) => 200 + i),
     });
-    for (const t of tracks) {
-      expect(Math.min(...t.points)).toBeCloseTo(0, 5);
-      expect(Math.max(...t.points)).toBeCloseTo(1, 5);
+
+    // One falls, one rises, and their units differ by five orders of magnitude — but after
+    // normalisation they are the same shape reflected, which is what makes them plottable
+    // together. Asserted as a mirror rather than as exact 0-1 endpoints because the line is a
+    // rolling mean: it approaches the extremes without landing on them.
+    for (let i = 0; i < identity.points.length; i++) {
+      expect(identity.points[i] + detail.points[i]).toBeCloseTo(1, 5);
     }
+    expect(Math.min(...identity.points)).toBeGreaterThanOrEqual(0);
+    expect(Math.max(...identity.points)).toBeLessThanOrEqual(1);
+    // Not the full 0-1: averaging pulls the endpoints of a monotone ramp inward, more so on a
+    // short series like this one. A real trend still has to travel most of the plot.
+    expect(Math.max(...identity.points) - Math.min(...identity.points)).toBeGreaterThan(0.85);
   });
 
   it("keeps the real values alongside the normalised ones", () => {
@@ -41,6 +50,29 @@ describe("buildTracks", () => {
     const dirty = [...seq(10, (i) => i), null, undefined, "x"] as unknown[];
     const tracks = buildTracks({ series: dirty });
     expect(tracks[0].raw).toHaveLength(10);
+  });
+
+  it("smooths the plotted line but reports the raw extremes", () => {
+    // The real case (job 9c7243a7): motion swung 0.13-1.06 per frame around a mean that was
+    // flat at ~0.62 for the whole clip. Drawn raw it read as chaos. The chips must still say
+    // how extreme it actually got, or smoothing has hidden the thing worth knowing.
+    const spiky = seq(200, (i) => (i % 2 === 0 ? 0.2 : 1.0));
+    const [t] = buildTracks({ series_motion: spiky });
+
+    // The chips must still say how extreme it actually got.
+    expect(t.min).toBeCloseTo(0.2, 5);
+    expect(t.max).toBeCloseTo(1.0, 5);
+    // ...while the line stays near the middle, because nothing actually trended.
+    expect(t.points.every((p) => p > 0.35 && p < 0.65)).toBe(true);
+  });
+
+  it("still shows a sustained trend after smoothing", () => {
+    // Smoothing that flattened a genuine decay would defeat the panel entirely. This is the
+    // case the "stationary stays flat" test above must not be bought at the expense of.
+    const decay = seq(200, (i) => 0.95 - i * 0.001);
+    const [t] = buildTracks({ series: decay });
+    expect(t.points[0]).toBeGreaterThan(0.9);
+    expect(t.points[t.points.length - 1]).toBeLessThan(0.1);
   });
 
   it("returns nothing for absent metrics", () => {

--- a/src/lib/trajectorySeries.ts
+++ b/src/lib/trajectorySeries.ts
@@ -39,6 +39,36 @@ const SPECS: {
 /** A series shorter than this is noise, not a trajectory. */
 const MIN_POINTS = 8;
 
+/**
+ * Frame-to-frame values are far noisier than the trend inside them.
+ *
+ * Measured on job 9c7243a7: motion ranged 0.13–1.06 per frame while its eighth-by-eighth means
+ * sat between 0.57 and 0.67 — flat. Every axis behaved the same way. Drawn raw, four such series
+ * overlap into solid hatching that reads as chaos when the clip is in fact stationary, which is
+ * the opposite of what the chart is for.
+ *
+ * Two things make the raw signal noisier than the thing being measured. The video is scored
+ * after RIFE interpolation, so most frames are interpolated rather than generated; and the
+ * delta-based axes difference adjacent frames, which amplifies whatever jitter is left.
+ *
+ * So the LINE is smoothed and the RANGE CHIPS stay raw — the trend and the true extremes are
+ * different questions, and one series cannot answer both. Dip detection also stays on raw
+ * values: it asks about one specific frame, which a rolling mean would blur into its neighbours.
+ */
+function smooth(values: number[]): number[] {
+  // ~7% of the clip each side. On a 289-frame series that is about 0.35s of source footage:
+  // wide enough to clear the interpolation jitter, narrow enough that sub-second structure
+  // survives. Dip detection reads raw values, so this only has to serve the trend.
+  const half = Math.max(2, Math.round(values.length / 28));
+  return values.map((_, i) => {
+    const lo = Math.max(0, i - half);
+    const hi = Math.min(values.length, i + half + 1);
+    let sum = 0;
+    for (let j = lo; j < hi; j++) sum += values[j];
+    return sum / (hi - lo);
+  });
+}
+
 export function buildTracks(metrics: Record<string, unknown> | null | undefined): Track[] {
   if (!metrics) return [];
   const tracks: Track[] = [];
@@ -49,13 +79,23 @@ export function buildTracks(metrics: Record<string, unknown> | null | undefined)
     const values = raw.filter((v): v is number => typeof v === "number" && Number.isFinite(v));
     if (values.length < MIN_POINTS) continue;
 
+    // Ranges come from the raw values: the chips answer "how extreme did this get", and
+    // smoothing would quietly shrink both ends of that answer.
     const min = Math.min(...values);
     const max = Math.max(...values);
+
+    // The smoothed line is normalised against the RAW range, deliberately. Rescaling it to its
+    // own range instead would stretch whatever ripple survived smoothing back to full plot
+    // height, so a stationary clip would look identical to a collapsing one and the chart could
+    // never say "flat". Against the raw range, a series that only jitters stays near the middle
+    // and one that genuinely trends travels — which is the distinction being drawn.
+    //
     // A genuinely flat series would divide by zero. Render it down the middle rather than
     // dropping it — "this never changed" is information, and an absent line reads as missing
     // data instead.
     const span = max - min;
-    const points = span > 0 ? values.map((v) => (v - min) / span) : values.map(() => 0.5);
+    const line = smooth(values);
+    const points = span > 0 ? line.map((v) => (v - min) / span) : line.map(() => 0.5);
 
     tracks.push({ ...spec, points, raw: values, min, max });
   }


### PR DESCRIPTION
The first four-axis clip (job `9c7243a7`, Zeta - doggystyle) rendered as solid hatching. Smoothed into eighths the data is stationary on every axis:

```
motion     0.57 0.57 0.62 0.63 0.67 0.64 0.62 0.60
expr       3.38 4.65 5.05 5.04 4.37 4.51 4.58 4.96
detail      150  114  141  141  126  128  142  140
identity   0.94 0.93 0.91 0.91 0.91 0.91 0.92 0.91
```

No trend anywhere — the chart was drawing noise around four constants.

Two reasons the raw signal is noisier than what's being measured: scoring runs on the post-RIFE output (289 frames measured, 75 generated, so most are interpolated), and the delta axes difference adjacent frames.

**Fix:** the line is a rolling mean; the range chips stay raw. Dip detection also stays raw, since it asks about one specific frame.

**The subtle part:** the smoothed line is normalised against the *raw* range, not its own. Rescaling to its own range stretches surviving ripple back to full plot height — a stationary clip would then look identical to a collapsing one, defeating the panel. A first attempt got this backwards and the new test caught it.

Verified against zeta1's real series — lines now occupy 20-47%, 25-60%, 36-69%, 44-95% of the plot instead of all four spanning it end to end.

Tests: two new cases — a spiky-but-stationary series must stay near the middle while its chips report the true extremes, and a genuine decay must still travel the plot. The existing "normalises to its own range" test asserted the line touches exactly 0 and 1, which a rolling mean deliberately no longer does; rewritten to assert unit-independent shape instead.

`npm test` 67 passed, `tsc --noEmit` and `build` clean. The 4 lint errors are pre-existing in untouched files.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct