### PR TITLE
Lead the trajectory chips with the mean, not just the range

### DIFF
--- a/src/components/IdentityTrajectory.tsx
+++ b/src/components/IdentityTrajectory.tsx
@@ -85,7 +85,13 @@ export default function IdentityTrajectory({ metrics }: Props) {
                 color: off ? "text.disabled" : colours[t.key],
                 textDecoration: off ? "line-through" : "none",
               }}
-              label={`${t.label} ${t.min.toFixed(t.precision)}–${t.max.toFixed(t.precision)}`}
+              // Mean first, extremes bracketed. "0.10-1.08" alone sat directly under the
+              // "0.919 -> 0.828" trajectory row and got read as start-to-end, which it never
+              // was: these are the lowest and highest single frames, in no particular order.
+              label={
+                `${t.label} ${t.mean.toFixed(t.precision)} ` +
+                `(${t.min.toFixed(t.precision)}–${t.max.toFixed(t.precision)})`
+              }
             />
           );
         })}

--- a/src/lib/trajectorySeries.test.ts
+++ b/src/lib/trajectorySeries.test.ts
@@ -98,3 +98,18 @@ describe("sampleAt", () => {
     expect(sampleAt(t, 2)).toBe(9);
   });
 });
+
+describe("chip figures", () => {
+  it("reports the mean alongside the true extremes, not the endpoints", () => {
+    // "0.10-1.08" alone sat under the "0.919 -> 0.828" trajectory row and was read as
+    // start-to-end. It never was: these are the lowest and highest single frames, in no
+    // particular order. A series that ENDS at its minimum proves the distinction.
+    const s = [...Array(40).fill(1.0), ...Array(40).fill(0.2), 0.05];
+    const [t] = buildTracks({ series_motion: s });
+    expect(t.min).toBeCloseTo(0.05, 5);
+    expect(t.max).toBeCloseTo(1.0, 5);
+    expect(t.mean).toBeCloseTo((40 * 1.0 + 40 * 0.2 + 0.05) / 81, 5);
+    // The endpoints are 1.0 and 0.05 — neither is the mean, and max is not the start.
+    expect(t.mean).not.toBeCloseTo(t.raw[0], 2);
+  });
+});

--- a/src/lib/trajectorySeries.ts
+++ b/src/lib/trajectorySeries.ts
@@ -18,6 +18,8 @@ export interface Track {
   points: number[];
   /** Real values, for the tooltip and the range caption. */
   raw: number[];
+  /** Average over the clip — the number worth comparing between runs. */
+  mean: number;
   min: number;
   max: number;
   /** How many decimals this axis is meaningfully read at. */
@@ -83,6 +85,7 @@ export function buildTracks(metrics: Record<string, unknown> | null | undefined)
     // smoothing would quietly shrink both ends of that answer.
     const min = Math.min(...values);
     const max = Math.max(...values);
+    const mean = values.reduce((a, b) => a + b, 0) / values.length;
 
     // The smoothed line is normalised against the RAW range, deliberately. Rescaling it to its
     // own range instead would stretch whatever ripple survived smoothing back to full plot
@@ -97,7 +100,7 @@ export function buildTracks(metrics: Record<string, unknown> | null | undefined)
     const line = smooth(values);
     const points = span > 0 ? line.map((v) => (v - min) / span) : line.map(() => 0.5);
 
-    tracks.push({ ...spec, points, raw: values, min, max });
+    tracks.push({ ...spec, points, raw: values, mean, min, max });
   }
   return tracks;
 }


### PR DESCRIPTION
`Motion 0.10–1.08` was read as "starts at 0.10, ends at 1.08". It never meant that — those are the **lowest and highest single frames**, in no particular order. A clip that was flat all the way through with two outlier frames produces exactly that label.

The ambiguity is structural: the chip sits directly under the `0.919 → 0.828` trajectory row, so an en-dash range beneath an arrow reads as the same kind of thing.

Leading with the mean removes the ambiguity and surfaces the more useful number besides — the mean is what you'd compare between two runs, and it wasn't displayed anywhere. Extremes stay, bracketed, because they still tell you how spiky the clip was.

```
before   Motion 0.10–1.08
after    Motion 0.30 (0.10–1.08)
```

Test uses a series that *ends at its minimum*, so mean, min, max and endpoints are all distinct — a label that confused any two of them fails.

`npm test` 68 passed, `tsc --noEmit` and `build` clean.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct