### PR TITLE
Choose the GPU when launching a RunPod worker

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -513,6 +513,27 @@ export interface RunPodAvailability {
   available: boolean;
   price_per_hr: number | null;
   stock: string | null;
+  cloud_type?: string | null;
+}
+
+/** One selectable GPU with its live price and stock.
+ *
+ *  `available` means RunPod quotes a price for this GPU here — NOT that a pod can be placed on
+ *  it. Measured 2026-08-08: community 4090 read available/"Low" for an hour while every create
+ *  failed with "this machine does not have the resources", because the hosts existed but were
+ *  all partially committed. So a false here is a reliable no; a true is not a yes. */
+export interface RunPodGpuOption {
+  gpu_type_id: string;
+  is_default: boolean;
+  available: boolean;
+  price_per_hr: number | null;
+  stock: string | null;
+  error?: string | null;
+}
+
+export async function getRunPodGpuOptions(): Promise<RunPodGpuOption[]> {
+  const { data } = await api.get<RunPodGpuOption[]>("/runpod/gpu-options");
+  return data;
 }
 
 export interface RunPodWorker {
@@ -546,8 +567,10 @@ export async function getSegmentRuntimes(minSamples = 1): Promise<SegmentRuntime
   return data;
 }
 
-export async function getRunPodAvailability(): Promise<RunPodAvailability> {
-  const { data } = await api.get<RunPodAvailability>("/runpod/availability");
+export async function getRunPodAvailability(gpuTypeId?: string): Promise<RunPodAvailability> {
+  const { data } = await api.get<RunPodAvailability>("/runpod/availability", {
+    params: gpuTypeId ? { gpu_type_id: gpuTypeId } : undefined,
+  });
   return data;
 }
 
@@ -560,6 +583,7 @@ export interface GpuReservation {
   status: string;
   expires_at: string;
   drain_after_jobs: number | null;
+  gpu_type_id: string | null;
   pod_id: string | null;
   error: string | null;
   attempts: number;
@@ -577,11 +601,13 @@ export async function createReservation(
   name: string,
   minutes: number,
   drainAfterJobs?: number,
+  gpuTypeId?: string,
 ): Promise<GpuReservation> {
   const { data } = await api.post<GpuReservation>("/runpod/reservations", {
     name,
     minutes,
     drain_after_jobs: drainAfterJobs ?? null,
+    gpu_type_id: gpuTypeId ?? null,
   });
   return data;
 }
@@ -595,8 +621,14 @@ export async function getRunPodWorkers(): Promise<RunPodWorker[]> {
   return data;
 }
 
-export async function launchRunPodWorker(name: string): Promise<RunPodWorker> {
-  const { data } = await api.post<RunPodWorker>("/runpod/workers", { name });
+export async function launchRunPodWorker(
+  name: string,
+  gpuTypeId?: string,
+): Promise<RunPodWorker> {
+  const { data } = await api.post<RunPodWorker>("/runpod/workers", {
+    name,
+    gpu_type_id: gpuTypeId ?? null,
+  });
   return data;
 }
 

--- a/src/components/LaunchRunPodDialog.tsx
+++ b/src/components/LaunchRunPodDialog.tsx
@@ -13,22 +13,28 @@ import {
   Typography,
 } from "@mui/material";
 import {
-  getRunPodAvailability,
+  getRunPodGpuOptions,
   launchRunPodWorker,
   createReservation,
-  type RunPodAvailability,
+  type RunPodGpuOption,
 } from "../api/client";
 
 /**
  * Launch a RunPod worker.
  *
- * Availability is checked on open and shown before the button is usable, because launching
- * costs money per hour and "no 4090s right now" is a common, temporary answer — it should be
- * visible up front rather than discovered as a failure.
+ * Price and stock are fetched per GPU on open, because launching costs money per hour and that
+ * should be visible before the button is, not after.
  *
- * The GPU and datacenter are not choices. The network volume holding the ~39GB model set is
- * region-locked, so the pod must launch beside it; and 3090 inventory there is transient, so
- * offering it would produce launches that cannot be honoured.
+ * The GPU IS a choice, and has to be. Community 4090s are frequently unplaceable — RunPod
+ * matches a host and answers "this machine does not have the resources", a fit failure rather
+ * than an empty fleet — while a 3090 places immediately at roughly two thirds the price. With no
+ * choice offered, that state is a dead end.
+ *
+ * Launch is NOT gated on `available`. That flag means "RunPod prices this GPU here", which is a
+ * weaker claim than "a pod can be placed": community 4090 read available/"Low" continuously
+ * through an hour of failed creates. Gating on it would block launches that would have worked,
+ * and — worse — a green flag never made a doomed one succeed. The launch attempt itself is the
+ * only honest test, and its error message is far more specific than anything shown up front.
  */
 
 interface Props {
@@ -39,7 +45,8 @@ interface Props {
 
 export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props) {
   const [name, setName] = useState("");
-  const [availability, setAvailability] = useState<RunPodAvailability | null>(null);
+  const [gpus, setGpus] = useState<RunPodGpuOption[]>([]);
+  const [gpu, setGpu] = useState<string>("");
   const [checking, setChecking] = useState(false);
   const [launching, setLaunching] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -51,10 +58,17 @@ export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props)
   useEffect(() => {
     if (!open) return;
     setError(null);
-    setAvailability(null);
+    setGpus([]);
     setChecking(true);
-    getRunPodAvailability()
-      .then(setAvailability)
+    getRunPodGpuOptions()
+      .then((options) => {
+        setGpus(options);
+        // Prefer a GPU that is actually priced; fall back to the server default. Opening on an
+        // option we already know is unsellable would make the first click a guaranteed failure.
+        const priced = options.find((o) => o.available);
+        const fallback = options.find((o) => o.is_default) ?? options[0];
+        setGpu((priced ?? fallback)?.gpu_type_id ?? "");
+      })
       .catch((e) => setError(detail(e) ?? "Could not check RunPod availability"))
       .finally(() => setChecking(false));
   }, [open]);
@@ -63,7 +77,7 @@ export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props)
     setLaunching(true);
     setError(null);
     try {
-      await launchRunPodWorker(name.trim());
+      await launchRunPodWorker(name.trim(), gpu || undefined);
       onLaunched();
       onClose();
       setName("");
@@ -81,7 +95,7 @@ export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props)
     setError(null);
     try {
       const drain = drainAfter ? Number(drainAfter) : undefined;
-      await createReservation(name.trim(), minutes, drain);
+      await createReservation(name.trim(), minutes, drain, gpu || undefined);
       onLaunched();
       onClose();
       setName("");
@@ -93,7 +107,10 @@ export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props)
   };
 
   const nameOk = /^[a-zA-Z0-9][a-zA-Z0-9 ._-]{0,48}$/.test(name.trim());
-  const noCapacity = !!availability && !availability.available;
+  const selected = gpus.find((g) => g.gpu_type_id === gpu) ?? null;
+  // Only "RunPod does not sell this GPU here" switches the dialog to reserve-instead. A priced
+  // GPU always gets a real launch attempt, because pricing does not predict placement.
+  const noCapacity = !!selected && !selected.available;
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
@@ -109,26 +126,62 @@ export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props)
             </Stack>
           )}
 
-          {availability && (
+          {gpus.length > 0 && (
+            <TextField
+              label="GPU"
+              size="small"
+              select
+              value={gpu}
+              onChange={(e) => setGpu(e.target.value)}
+              SelectProps={{ native: true }}
+              helperText="Price and stock are live. Stock is a band, not a guarantee of placement."
+              fullWidth
+            >
+              {gpus.map((g) => (
+                <option key={g.gpu_type_id} value={g.gpu_type_id}>
+                  {short(g.gpu_type_id)}
+                  {g.price_per_hr != null ? ` — $${g.price_per_hr}/hr` : ""}
+                  {g.stock ? ` · ${g.stock}` : g.available ? "" : " · not sold here"}
+                </option>
+              ))}
+            </TextField>
+          )}
+
+          {selected && (
             <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
               <Chip
                 size="small"
-                color={availability.available ? "success" : "default"}
-                label={availability.available ? `Available${availability.stock ? ` · ${availability.stock}` : ""}` : "No capacity"}
+                color={selected.available ? "success" : "default"}
+                label={
+                  selected.available
+                    ? `Priced${selected.stock ? ` · ${selected.stock}` : ""}`
+                    : "Not sold here"
+                }
               />
-              {availability.price_per_hr != null && (
-                <Chip size="small" variant="outlined" label={`$${availability.price_per_hr}/hr`} />
+              {selected.price_per_hr != null && (
+                <Chip size="small" variant="outlined" label={`$${selected.price_per_hr}/hr`} />
               )}
-              <Typography variant="caption" color="text.secondary">
-                {availability.gpu_type_id.replace("NVIDIA GeForce ", "")} · {availability.datacenter_id}
-              </Typography>
+              {selected.error && (
+                <Typography variant="caption" color="warning.main">
+                  price lookup failed
+                </Typography>
+              )}
             </Stack>
           )}
 
+          {selected?.available && (
+            <Alert severity="info" sx={{ py: 0 }}>
+              Stock is a price band, not a promise. In-demand GPUs can be priced here and still
+              refuse to place — if that happens, the error says so and another GPU usually works.
+            </Alert>
+          )}
+
           {noCapacity && (
-            <Alert severity="info">
-              No capacity right now. Availability changes minute to minute — a reservation keeps
-              checking and launches the moment one frees up.
+            <Alert severity="warning">
+              RunPod is not quoting a price for this GPU right now. That usually means no stock —
+              but it is not reliable: a 3090 pod placed on the first attempt minutes after this
+              same check reported nothing. Launching anyway is worth a try; a reservation keeps
+              retrying if you would rather walk away.
             </Alert>
           )}
 
@@ -188,22 +241,30 @@ export default function LaunchRunPodDialog({ open, onClose, onLaunched }: Props)
         <Button onClick={onClose} disabled={launching}>
           Cancel
         </Button>
-        {noCapacity ? (
-          <Button variant="contained" onClick={handleReserve} disabled={launching || !nameOk}>
+        {noCapacity && (
+          <Button onClick={handleReserve} disabled={launching || !nameOk}>
             {launching ? "Reserving…" : `Reserve for ${minutes < 60 ? `${minutes}m` : `${minutes / 60}h`}`}
           </Button>
-        ) : (
-          <Button
-            variant="contained"
-            onClick={handleLaunch}
-            disabled={launching || checking || !nameOk || !availability?.available}
-          >
-            {launching ? "Launching…" : "Launch"}
-          </Button>
         )}
+        {/* Launch is ALWAYS offered. Pricing predicts placement in neither direction: measured
+            2026-08-08, community 4090 read priced/"Low" through an hour of failures, and minutes
+            after a 3090 pod placed on the first try the 3090 reported no price at all. Disabling
+            the button on that flag blocked launches that would have worked. */}
+        <Button
+          variant="contained"
+          onClick={handleLaunch}
+          disabled={launching || checking || !nameOk || !gpu}
+        >
+          {launching ? "Launching…" : noCapacity ? "Launch anyway" : "Launch"}
+        </Button>
       </DialogActions>
     </Dialog>
   );
+}
+
+/** RunPod's own ids are long and repetitive in a dropdown. */
+function short(gpuTypeId: string): string {
+  return gpuTypeId.replace("NVIDIA GeForce ", "").replace("NVIDIA ", "");
 }
 
 /** Pull the API's `detail` out of an axios error without dragging axios types in here. */

--- a/src/lib/reservationDisplay.test.ts
+++ b/src/lib/reservationDisplay.test.ts
@@ -10,6 +10,9 @@ const res = (overrides: Partial<GpuReservation> = {}): GpuReservation =>
     status: "pending",
     expires_at: "2026-08-07T12:30:00Z",
     drain_after_jobs: null,
+    // null means "the server default GPU", which is what every reservation made before the
+    // field existed was waiting for.
+    gpu_type_id: null,
     pod_id: null,
     error: null,
     attempts: 0,


### PR DESCRIPTION
Pairs with wanly-api#169.

Community 4090s frequently can't be placed — RunPod matches a host and answers "this machine does not have the resources", which is a *fit* failure, not an empty fleet — while a 3090 places immediately at roughly two thirds the price. The dialog offered no choice, so that state was a dead end.

**GPU is now a dropdown** with live price and stock per option, from the new `/runpod/gpu-options`. It opens on a GPU that's actually priced rather than blindly on the default, so the first click isn't a guaranteed failure.

**Launch is no longer gated on availability.** That flag means "RunPod prices this GPU here", and it predicts placement in **neither direction**:

- The 4090 read priced/`Low` through an hour of failed creates.
- Minutes after a 3090 pod placed on the first attempt, the 3090 reported **no price at all**.

Disabling the button on that flag blocked launches that would have worked, and a green flag never made a doomed one succeed. So Launch is always offered; when nothing is priced it reads **"Launch anyway"** and a reservation is offered *alongside* it rather than instead of it. The launch attempt is the only honest test, and its error message is far more specific than anything shown up front.

Wording follows the evidence: the chip now says **"Priced"**, not "Available", because that's the claim the number actually supports. The info alert says stock is a band, not a promise.

`npm test` 68 passed, `tsc -b` and `build` clean.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct