### PR TITLE
Make the reservation card say what is actually happening

### DIFF
--- a/src/lib/reservationDisplay.test.ts
+++ b/src/lib/reservationDisplay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { minutesLeft, describeWindow, describePolicy } from "./reservationDisplay";
+import { minutesLeft, describeWindow, describePolicy, describeAttempts, describeGpu } from "./reservationDisplay";
 import type { GpuReservation } from "../api/client";
 
 const NOW = new Date("2026-08-07T12:00:00Z");
@@ -36,7 +36,8 @@ describe("describeWindow", () => {
     expect(describeWindow(res({ expires_at: "2026-08-07T12:30:00Z" }), NOW)).toBe("30m left");
     expect(describeWindow(res({ expires_at: "2026-08-07T14:00:00Z" }), NOW)).toBe("2h left");
     expect(describeWindow(res({ expires_at: "2026-08-07T13:20:00Z" }), NOW)).toBe("1h 20m left");
-    expect(describeWindow(res({ expires_at: "2026-08-07T12:00:00Z" }), NOW)).toBe("expiring");
+    // Was "expiring" -- a bare word with no timeframe, sitting under a status chip.
+    expect(describeWindow(res({ expires_at: "2026-08-07T12:00:00Z" }), NOW)).toBe("under a minute left");
   });
 });
 
@@ -49,5 +50,43 @@ describe("describePolicy", () => {
   it("reads naturally at one and many", () => {
     expect(describePolicy(res({ drain_after_jobs: 1 }))).toBe("drains after 1 job");
     expect(describePolicy(res({ drain_after_jobs: 3 }))).toBe("drains after 3 jobs");
+  });
+});
+
+describe("describeAttempts", () => {
+  it("says plainly when nothing has been tried", () => {
+    // The case that matters. A live 3090 reservation sat through its whole window at attempts=0
+    // -- never calling RunPod once -- while the card read "Waiting for a GPU". The bug was found
+    // by querying the database, because the one number that would have shown it was not on
+    // screen. Silence here is what made a loud failure quiet.
+    expect(describeAttempts(res({ attempts: 0 }))).toBe("no launch attempted yet");
+  });
+
+  it("does not pluralise a single attempt", () => {
+    expect(describeAttempts(res({ attempts: 1 }))).toBe("1 launch attempted");
+  });
+
+  it("counts repeated attempts", () => {
+    expect(describeAttempts(res({ attempts: 7 }))).toBe("7 launches attempted");
+  });
+});
+
+describe("describeGpu", () => {
+  it("strips the vendor prefix that makes every option look alike", () => {
+    expect(describeGpu(res({ gpu_type_id: "NVIDIA GeForce RTX 3090" }))).toBe("RTX 3090");
+  });
+
+  it("names the fallback rather than showing nothing", () => {
+    // NULL means "the server default" -- which is what every reservation made before the column
+    // existed is waiting for. Blank would read as "no GPU", which is a different claim.
+    expect(describeGpu(res({ gpu_type_id: null }))).toBe("default GPU");
+  });
+});
+
+describe("describeWindow near expiry", () => {
+  it("still states a timeframe in the last minute", () => {
+    // "expiring" alone dangled with no timeframe next to a status chip.
+    const r = res({ expires_at: "2026-08-07T12:00:30Z" });
+    expect(describeWindow(r, NOW)).toBe("under a minute left");
   });
 });

--- a/src/lib/reservationDisplay.ts
+++ b/src/lib/reservationDisplay.ts
@@ -16,11 +16,37 @@ export function minutesLeft(reservation: GpuReservation, now: Date = new Date())
 
 export function describeWindow(reservation: GpuReservation, now: Date = new Date()): string {
   const mins = minutesLeft(reservation, now);
-  if (mins <= 0) return "expiring";
+  if (mins <= 0) return "under a minute left";
   if (mins < 60) return `${mins}m left`;
   const hours = Math.floor(mins / 60);
   const rest = mins % 60;
   return rest ? `${hours}h ${rest}m left` : `${hours}h left`;
+}
+
+/**
+ * How hard this reservation has actually tried.
+ *
+ * `attempts` existed on the model and was never displayed, and that omission hid a real bug: a
+ * 3090 reservation sat through its entire window at attempts=0, never calling RunPod once,
+ * because decide() gated on a price check that reports nothing for a GPU that places fine. The
+ * card said "Waiting for a GPU", which described an activity that was not happening, and the
+ * failure was only found by querying the database directly.
+ *
+ * A reservation that is not attempting is indistinguishable from one that is, unless this is on
+ * screen. It is the difference between a silent failure and an obvious one.
+ */
+export function describeAttempts(reservation: GpuReservation): string {
+  const n = reservation.attempts ?? 0;
+  if (n === 0) return "no launch attempted yet";
+  return n === 1 ? "1 launch attempted" : `${n} launches attempted`;
+}
+
+/** Which GPU this reservation is holding out for. Selectable since wanly-api#169, so a card that
+ *  omits it cannot be read — "3090-1" is a name someone typed, not a fact about the request. */
+export function describeGpu(reservation: GpuReservation): string {
+  const gpu = reservation.gpu_type_id;
+  if (!gpu) return "default GPU";
+  return gpu.replace("NVIDIA GeForce ", "").replace("NVIDIA ", "");
 }
 
 /** What this reservation will do to the worker it eventually launches. */

--- a/src/pages/Workers.tsx
+++ b/src/pages/Workers.tsx
@@ -46,7 +46,7 @@ import {
   type GpuReservation,
 } from "../api/client";
 import { findBootingPods, costForWorker } from "../lib/bootingPods";
-import { describeWindow, describePolicy } from "../lib/reservationDisplay";
+import { describeWindow, describePolicy, describeAttempts, describeGpu } from "../lib/reservationDisplay";
 import LaunchRunPodDialog from "../components/LaunchRunPodDialog";
 import type { WorkerResponse, WorkerStatus } from "../api/types";
 import { POLL_INTERVAL_SLOW } from "../constants";
@@ -234,7 +234,16 @@ export default function Workers() {
                   </Typography>
                 </Box>
                 <Typography variant="body2" color="text.secondary">
-                  Waiting for a GPU · {describeWindow(r)}
+                  {describeGpu(r)} · {describeWindow(r)}
+                </Typography>
+                {/* Attempts, prominently. A reservation showing "no launch attempted yet" as its
+                    window drains is broken, and that must be visible without a database query. */}
+                <Typography
+                  variant="body2"
+                  sx={{ mt: 0.25 }}
+                  color={(r.attempts ?? 0) === 0 ? "warning.main" : "text.secondary"}
+                >
+                  {describeAttempts(r)}
                 </Typography>
                 <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
                   When it launches: {describePolicy(r)}


### PR DESCRIPTION
The card read:

```
3090-1                                    Reserved
Waiting for a GPU · expiring
When it launches: runs until you stop it
```

Every part of that was doing less work than it looked like.

**"Waiting for a GPU" described an activity that was not happening.** A live 3090 reservation sat through its entire window and never called RunPod once — `decide()` gated on a price check that reports nothing for a GPU that places fine (fixed in wanly-api#170). It was waiting for a *quote*, not asking for a GPU.

**`attempts` was on the model and never displayed.** That is the omission that mattered. "no launch attempted yet" as a window drains is self-evidently wrong and would have been caught at a glance; instead the bug was found by querying the database. It is now shown in warning colour while zero, because a reservation that is not attempting is otherwise indistinguishable from one that is.

**The GPU was not shown.** It became selectable in wanly-api#169, so `3090-1` is a name someone typed, not a fact about the request.

**"expiring"** dangled with no timeframe beside a status chip.

After:

```
3090-1                                    Reserved
RTX 3090 · 12m left
no launch attempted yet          <- warning colour
When it launches: runs until you stop it
```

74 tests passing (6 new), `tsc -b` and `build` clean.