### PR TITLE
Record observations per segment from Job Detail

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -690,3 +690,28 @@ export async function createSmashcut(body: SmashcutBody): Promise<{ id: string; 
   const { data } = await api.post<{ id: string; job_id: string }>("/smashcut", body);
   return data;
 }
+
+
+/** The controlled observation vocabulary, served rather than hardcoded here.
+ *
+ *  One source of truth so a tag written by the UI is the same string later analysis groups on.
+ *  That grouping is the entire value — "mouth-void" and "mouth void" are two labels. */
+export async function getObservationTags(): Promise<string[]> {
+  const { data } = await api.get<string[]>("/segments/observation-tags");
+  return data;
+}
+
+export interface SegmentAnnotation {
+  notes?: string | null;
+  rating?: number | null;
+  observation_tags?: string[];
+}
+
+/** Record what a human saw. Writes nothing generation reads. */
+export async function annotateSegment(
+  segmentId: string,
+  body: SegmentAnnotation,
+): Promise<SegmentResponse> {
+  const { data } = await api.patch<SegmentResponse>(`/segments/${segmentId}/annotation`, body);
+  return data;
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -156,6 +156,12 @@ export interface SegmentResponse {
   id: string;
   job_id: string;
   index: number;
+  /** Human observation. The metrics cannot rank quality — expression rewards the mouth-gape
+   *  artifact it should penalise — so what a person saw is primary evidence, not a footnote. */
+  notes?: string | null;
+  rating?: number | null;
+  /** Comma-separated, from the server's controlled vocabulary. */
+  observation_tags?: string | null;
   prompt: string;
   prompt_template: string | null;
   duration_seconds: number;

--- a/src/components/SegmentObservationDialog.tsx
+++ b/src/components/SegmentObservationDialog.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Rating,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { annotateSegment, getObservationTags } from "../api/client";
+import type { SegmentResponse } from "../api/types";
+
+/**
+ * Recording what a human saw in a segment.
+ *
+ * This exists because the automated metrics cannot rank quality, which we know rather than
+ * suspect: on the one controlled pair where both a measurement and a judgement exist, the
+ * expression score ranked them backwards. A gaping mouth is the largest landmark excursion a
+ * face can make, so the metric scores the very artifact that makes a segment look worse.
+ *
+ * So the rating is the ranking channel and the tags are labelled ground truth — enough of them
+ * turns fixing that metric from guesswork into a fitting problem.
+ *
+ * Tags come from the server rather than a constant here, so a tag written by this dialog is the
+ * same string later analysis groups on.
+ */
+
+interface Props {
+  open: boolean;
+  segment: SegmentResponse | null;
+  onClose: () => void;
+  onSaved: (updated: SegmentResponse) => void;
+}
+
+/** Tags are <location>-<condition>, so the prefix groups them into rows the eye can scan. */
+function groupOf(tag: string): string {
+  const location = tag.split("-")[0];
+  if (["face", "mouth", "teeth", "identity", "eyes", "brows"].includes(location)) return "Face";
+  if (["him", "her"].includes(location)) return "Motion";
+  return "Body";
+}
+
+const GROUP_ORDER = ["Face", "Motion", "Body"];
+
+export default function SegmentObservationDialog({ open, segment, onClose, onSaved }: Props) {
+  const [vocabulary, setVocabulary] = useState<string[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [rating, setRating] = useState<number | null>(null);
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reload from the segment every time it opens. Keeping stale state across openings would let
+  // you overwrite one segment's observations with another's, which is worse than losing them.
+  useEffect(() => {
+    if (!open || !segment) return;
+    setError(null);
+    setRating(segment.rating ?? null);
+    setNotes(segment.notes ?? "");
+    setSelected(new Set((segment.observation_tags ?? "").split(",").filter(Boolean)));
+    getObservationTags()
+      .then(setVocabulary)
+      .catch(() => setError("Could not load the tag vocabulary"));
+  }, [open, segment]);
+
+  const toggle = (tag: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(tag)) next.add(tag);
+      return next;
+    });
+
+  const handleSave = async () => {
+    if (!segment) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await annotateSegment(segment.id, {
+        // Sent explicitly rather than omitted when empty, so clearing a rating or blanking notes
+        // actually clears them — a mistyped observation needs an undo.
+        rating,
+        notes,
+        observation_tags: [...selected],
+      });
+      onSaved(updated);
+      onClose();
+    } catch (e) {
+      const detail = (e as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail;
+      setError(typeof detail === "string" ? detail : "Could not save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const groups = GROUP_ORDER.map((name) => ({
+    name,
+    tags: vocabulary.filter((t) => groupOf(t) === name),
+  })).filter((g) => g.tags.length > 0);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        Observations — segment {segment ? segment.index : ""}
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={2.5} sx={{ mt: 1 }}>
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Overall
+            </Typography>
+            <Rating
+              value={rating}
+              onChange={(_, value) => setRating(value)}
+              size="large"
+            />
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+              One all-in score — enough to rank the arms of a test. The specifics go in tags.
+            </Typography>
+          </Box>
+
+          {groups.map((group) => (
+            <Box key={group.name}>
+              <Typography variant="subtitle2" gutterBottom>
+                {group.name}
+              </Typography>
+              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                {group.tags.map((tag) => (
+                  <Chip
+                    key={tag}
+                    label={tag}
+                    size="small"
+                    onClick={() => toggle(tag)}
+                    color={selected.has(tag) ? "primary" : "default"}
+                    variant={selected.has(tag) ? "filled" : "outlined"}
+                    sx={{ cursor: "pointer" }}
+                  />
+                ))}
+              </Stack>
+            </Box>
+          ))}
+
+          <TextField
+            label="Notes"
+            multiline
+            minRows={3}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="What did you actually see?"
+            fullWidth
+          />
+
+          {error && <Alert severity="error">{error}</Alert>}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={handleSave} disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -51,6 +51,8 @@ import {
   Star,
   StarBorder,
   ViewInAr,
+  RateReview,
+  RateReviewOutlined,
 } from "@mui/icons-material";
 import { useParams, useNavigate, Link as RouterLink } from "react-router";
 import {
@@ -89,6 +91,7 @@ import type {
 } from "../api/types";
 import StatusChip from "../components/StatusChip";
 import IdentityChip from "../components/IdentityChip";
+import SegmentObservationDialog from "../components/SegmentObservationDialog";
 import SegmentPromptPopover from "../components/SegmentPromptPopover";
 import { buildFaceswapFields, resolveFaceswapImage } from "../lib/faceswapPayload";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
@@ -257,6 +260,9 @@ export default function JobDetail() {
   const [error, setError] = useState("");
   const [videoModal, setVideoModal] = useState<{ path: string; v?: string; segIndex?: number } | null>(null);
   const [imageModal, setImageModal] = useState<{ path: string; segIndex: number } | null>(null);
+  // Which segment's observations are open. Holds the segment itself rather than an id so the
+  // dialog can populate without a second lookup.
+  const [observing, setObserving] = useState<SegmentResponse | null>(null);
   const [loopVideo, setLoopVideo] = useState(false);
   const [finalizing, setFinalizing] = useState(false);
   const [segmentModalOpen, setSegmentModalOpen] = useState(false);
@@ -1140,6 +1146,25 @@ export default function JobDetail() {
                       <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap" }}>
                         <StatusChip status={seg.status} />
                         <IdentityChip segment={seg} />
+                        {(() => {
+                          const reviewed =
+                            seg.rating != null || !!seg.notes || !!seg.observation_tags;
+                          return (
+                            <Tooltip title={reviewed ? "Edit observations" : "Add observations"}>
+                              <IconButton
+                                size="small"
+                                onClick={() => setObserving(seg)}
+                                color={reviewed ? "primary" : "default"}
+                              >
+                                {reviewed ? (
+                                  <RateReview fontSize="small" />
+                                ) : (
+                                  <RateReviewOutlined fontSize="small" />
+                                )}
+                              </IconButton>
+                            </Tooltip>
+                          );
+                        })()}
                       </Box>
                     </TableCell>
                     <TableCell>
@@ -1348,6 +1373,25 @@ export default function JobDetail() {
                       </Typography>
                       <StatusChip status={seg.status} />
                       <IdentityChip segment={seg} />
+                      {(() => {
+                        const reviewed =
+                          seg.rating != null || !!seg.notes || !!seg.observation_tags;
+                        return (
+                          <Tooltip title={reviewed ? "Edit observations" : "Add observations"}>
+                            <IconButton
+                              size="small"
+                              onClick={() => setObserving(seg)}
+                              color={reviewed ? "primary" : "default"}
+                            >
+                              {reviewed ? (
+                                <RateReview fontSize="small" />
+                              ) : (
+                                <RateReviewOutlined fontSize="small" />
+                              )}
+                            </IconButton>
+                          </Tooltip>
+                        );
+                      })()}
                       <Box sx={{ ml: "auto", display: "flex", gap: 0.5 }}>
                         {(seg.status === "claimed" || seg.status === "processing") && seg.claimed_at && (
                           <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
@@ -1859,6 +1903,33 @@ export default function JobDetail() {
           </Box>
         </DialogContent>
       </Dialog>
+
+      {/* Human observations. Kept out of the fetch path — saving patches the local segment in
+          place rather than refetching the job, so the row you just rated does not flicker. */}
+      <SegmentObservationDialog
+        open={!!observing}
+        segment={observing}
+        onClose={() => setObserving(null)}
+        onSaved={(updated) =>
+          setJob((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  segments: prev.segments.map((s) =>
+                    s.id === updated.id
+                      ? {
+                          ...s,
+                          rating: updated.rating,
+                          notes: updated.notes,
+                          observation_tags: updated.observation_tags,
+                        }
+                      : s,
+                  ),
+                }
+              : prev,
+          )
+        }
+      />
 
       {/* Frame preview popover */}
       <Popover


### PR DESCRIPTION
Pairs with wanly-api#172.

An icon on each segment row opens a modal with an **overall rating**, the **tag chips**, and **free notes**. The icon is filled when something has been recorded, so a glance down the list shows which segments have been reviewed and which are still to do.

## Why

The automated metrics cannot rank quality — we know this rather than suspect it. On the one controlled pair where both a measurement and a human judgement exist, **the expression score ranked them backwards**. A gaping mouth is the largest landmark excursion a face can make, so the metric scores the exact artifact that makes a segment look worse (daemon#123).

So `rating` is the ranking channel, and the tags are **labelled ground truth** — enough of them turns fixing that metric from guesswork into a fitting problem.

## Vocabulary

`<location>-<condition>` throughout, and the prefix is what groups the chips into rows:

```
Face     face-frozen  face-blurry  face-expressive  mouth-void  teeth-mush  identity-drift
Motion   him-static   her-static   him-strong       her-strong
Body     anatomy-break
```

Motion is split by person because `motion_magnitude` is whole-frame Farneback optical flow — it sums every moving pixel, so a lively woman with a static man scores identically to the reverse. These tags are the only per-person motion data obtainable.

## Details

- Vocabulary is **fetched from the API**, not duplicated here, so a tag written by this dialog is the same string later analysis groups on.
- State reloads from the segment on every open — carrying it across openings would let you overwrite one segment's observations with another's.
- Saving **patches the segment in place** rather than refetching the job, so the row you just rated doesn't flicker.
- Rating and notes are sent explicitly rather than omitted when empty, so clearing actually clears. A mistyped observation needs an undo.

74 tests passing, `tsc -b` and `build` clean. The two lint warnings in `JobDetail.tsx` are pre-existing in untouched code.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct