### PR TITLE
Mirror the bodies-locked/bodies-inout exclusivity

### DIFF
--- a/src/components/SegmentObservationDialog.tsx
+++ b/src/components/SegmentObservationDialog.tsx
@@ -65,6 +65,7 @@ const EXCLUSIVE_GROUPS: string[][] = [
   ["pace-slow", "pace-right", "pace-fast"],
   ["him-static", "him-strong"],
   ["her-static", "her-strong"],
+  ["bodies-locked", "bodies-inout"],
 ];
 
 export default function SegmentObservationDialog({ open, segment, onClose, onSaved }: Props) {


### PR DESCRIPTION
Pairs with wanly-api#178.

The body-mechanics tags now name the travel axis — he withdraws and re-enters, so the bodies separate and rejoin; the failure is that they stay joined. Both ends name travel rather than one naming how the failure looks and the other naming the collision at the end of a stroke.

Client-side exclusivity mirrors the API so the second click replaces the first, rather than Save returning "contradictory tags".

74 tests passing, `tsc -b` and `build` clean.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct