### PR TITLE
Serialise console deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,20 @@ env:
   ECR_REPOSITORY: wanly-console
   CONTAINER_NAME: wanly-console
 
+# One deploy at a time. The steps stop and remove the container before starting it, which is
+# idempotent alone but not against a concurrent run: both remove, both start, and the second gets
+# "the container name /wanly-console is already in use". The API repo hit exactly this on
+# 2026-08-08 with two merges nineteen seconds apart. The failure is worse than a red build --
+# whichever run loses is arbitrary, so a close pair can leave the OLDER image serving while CI
+# reports success on the newer commit.
+#
+# cancel-in-progress is false deliberately: cancelling mid-flight can leave the host with no
+# container, having already removed the previous one. Queueing still converges on the newest
+# commit, because a third run supersedes the one waiting.
+concurrency:
+  group: deploy-console
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
Pairs with wanly-api#182, which hit this for real today.

The deploy stops and removes the container before starting it — idempotent alone, but not against a concurrent run: both remove, both start, and the second fails with `the container name /wanly-console is already in use`. The API repo hit exactly this with two merges nineteen seconds apart.

**The red build is the least of it.** Whichever run loses the race is arbitrary, so a close pair can leave the OLDER image serving while CI reports success on the newer commit — stale code with no signal.

Several console PRs merged in quick succession today; this repo has simply not been unlucky yet.

`cancel-in-progress: false` deliberately — cancelling mid-flight can leave the host with no container, having already removed the previous one. Queueing still converges on the newest commit, because a third run supersedes the one waiting.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct