### PR TITLE
Banner when the queue has work and no workers

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -727,3 +727,22 @@ export async function annotateSegment(
   const { data } = await api.patch<SegmentResponse>(`/segments/${segmentId}/annotation`, body);
   return data;
 }
+
+
+/** Queued work versus workers able to take it.
+ *
+ *  `stalled` requires BOTH halves — queued work with a busy worker is a queue doing its job, and
+ *  no workers with an empty queue is a quiet night. The 3090 was down for thirteen hours with
+ *  four segments waiting and nothing said so; every fact was recorded and nothing combined them. */
+export interface QueueHealth {
+  pending_segments: number;
+  live_workers: number;
+  stalled: boolean;
+  last_worker_seen: string | null;
+  summary: string;
+}
+
+export async function getQueueHealth(): Promise<QueueHealth> {
+  const { data } = await api.get<QueueHealth>("/queue-health");
+  return data;
+}

--- a/src/components/StalledQueueBanner.tsx
+++ b/src/components/StalledQueueBanner.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { Alert, AlertTitle } from "@mui/material";
+import { getQueueHealth, type QueueHealth } from "../api/client";
+import { POLL_INTERVAL_SLOW } from "../constants";
+
+/**
+ * Says so when there is work and nobody to do it.
+ *
+ * The 3090's host rebooted and its container had restart=no, so the worker never came back. It
+ * was found thirteen hours later by hand, with four segments queued the whole time. The database
+ * knew: a stale heartbeat, a worker marked offline, segments pending. Nothing combined them, and
+ * an offline worker looked the same whether the queue was empty or not.
+ *
+ * Deliberately silent unless BOTH halves hold. A banner that appears whenever a queue has depth,
+ * or whenever a worker is off, would be present most of the time and stop being read.
+ */
+export default function StalledQueueBanner() {
+  const [health, setHealth] = useState<QueueHealth | null>(null);
+
+  useEffect(() => {
+    const check = () => getQueueHealth().then(setHealth).catch(() => setHealth(null));
+    check();
+    const t = setInterval(check, POLL_INTERVAL_SLOW);
+    return () => clearInterval(t);
+  }, []);
+
+  if (!health?.stalled) return null;
+
+  return (
+    <Alert severity="error" sx={{ mb: 2 }}>
+      <AlertTitle>Nothing is running</AlertTitle>
+      {health.summary}
+      {health.last_worker_seen &&
+        ` — last worker seen ${timeAgo(health.last_worker_seen)}.`}
+      {" Start a worker, or launch a RunPod pod, or this queue will sit."}
+    </Alert>
+  );
+}
+
+function timeAgo(iso: string): string {
+  const mins = Math.floor((Date.now() - new Date(iso).getTime()) / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  return hours < 24 ? `${hours}h ago` : `${Math.floor(hours / 24)}d ago`;
+}

--- a/src/pages/JobQueue.tsx
+++ b/src/pages/JobQueue.tsx
@@ -32,6 +32,7 @@ import type { JobResponse, JobStatus } from "../api/types";
 import StatusChip from "../components/StatusChip";
 import CreateJobDialog from "../components/CreateJobDialog";
 import { POLL_INTERVAL_FAST } from "../constants";
+import StalledQueueBanner from "../components/StalledQueueBanner";
 
 const ALL_STATUSES: JobStatus[] = [
   "awaiting",
@@ -220,6 +221,7 @@ export default function JobQueue() {
 
   return (
     <Box>
+      <StalledQueueBanner />
       <Box
         sx={{
           display: "flex",

--- a/src/pages/Workers.tsx
+++ b/src/pages/Workers.tsx
@@ -52,6 +52,7 @@ import { describeWindow, describePolicy, describeAttempts, describeGpu } from ".
 import LaunchRunPodDialog from "../components/LaunchRunPodDialog";
 import type { WorkerResponse, WorkerStatus } from "../api/types";
 import { POLL_INTERVAL_SLOW } from "../constants";
+import StalledQueueBanner from "../components/StalledQueueBanner";
 
 /** Minutes-and-seconds for a pod's age. Local rather than shared because formatDuration is
  *  already duplicated across three pages; consolidating them is its own change. */
@@ -217,6 +218,8 @@ export default function Workers() {
           Launch RunPod
         </Button>
       </Box>
+
+      <StalledQueueBanner />
 
       {error && (
         <Alert severity="error" sx={{ mb: 2 }}>


### PR DESCRIPTION
Pairs with wanly-api#184.

The 3090 was down for **thirteen hours with four segments queued** and nothing said so. The state was all recorded — stale heartbeat, worker marked offline, segments pending — and an offline worker looked identical whether the queue was empty or not.

Shown on both the **Job Queue** and **Workers** pages, since those are where someone already looks when they suspect nothing is happening.

**Silent unless both halves hold.** A banner that appeared whenever a queue had depth, or whenever a worker was off, would be present most of the time and stop being read — which is precisely the failure mode of the thing it replaces.

80 tests passing, `tsc -b` and `build` clean.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct