### PR TITLE
Restrict Claude review workflow to trusted actors

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,14 @@ permissions:
 
 jobs:
   claude-review:
+    # Only trusted actors may trigger this job. Without this, any GitHub user
+    # commenting on an issue starts a run holding contents/id-token write and
+    # the repo secrets. claude-code-action checks actor permissions itself, but
+    # this keeps the gate in our own config rather than a third-party dependency.
+    if: >-
+      github.event.comment.author_association == 'OWNER' ||
+      github.event.comment.author_association == 'MEMBER' ||
+      github.event.comment.author_association == 'COLLABORATOR'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

`.github/workflows/claude.yml` fires on `issue_comment` with **no `if:` guard**. On a public repo that means any GitHub user commenting on any issue starts a job that holds:

- `contents: write`
- `id-token: write` (OIDC path to AWS via `AWS_ROLE_ARN`)
- `issues: write`, `pull-requests: write`
- `secrets.ANTHROPIC_API_KEY`

## Was this exploitable?

**No — not currently.** `anthropics/claude-code-action` runs its own actor check and refuses with *"Actor does not have write permissions to the repository"* (`src/entrypoints/prepare.ts:44`, `src/entrypoints/run.ts:194`).

The issue is that this was the *only* barrier, and it lives inside a third-party dependency. An upstream regression would turn an unguarded trigger into repo write access plus an AWS OIDC path.

## Change

Add an `author_association` guard so the job only runs for OWNER / MEMBER / COLLABORATOR. Both triggers (`issue_comment`, `pull_request_review_comment`) populate `github.event.comment`, so one expression covers both.

Defense in depth — the action still does its own check. No behavior change for you or any collaborator.

Found during an audit of public-repo exposure.