### PR TITLE
Discard a segment from Job Detail

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -746,3 +746,14 @@ export async function getQueueHealth(): Promise<QueueHealth> {
   const { data } = await api.get<QueueHealth>("/queue-health");
   return data;
 }
+
+
+/** Take a segment out of the video, keeping its rating, tags and notes.
+ *
+ *  Not a delete: the row survives, and so does the clip. A bad segment is frequently the most
+ *  informative one, so discarding the observation to get it out of the cut is backwards. The
+ *  discarded row keeps its index, so a regenerated segment takes the same position. */
+export async function discardSegment(segmentId: string): Promise<SegmentResponse> {
+  const { data } = await api.post<SegmentResponse>(`/segments/${segmentId}/discard`);
+  return data;
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -162,6 +162,8 @@ export interface SegmentResponse {
   rating?: number | null;
   /** Comma-separated, from the server's controlled vocabulary. */
   observation_tags?: string | null;
+  /** Soft-deleted: kept for its feedback, excluded from the video. */
+  discarded?: boolean;
   prompt: string;
   prompt_template: string | null;
   duration_seconds: number;

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -41,6 +41,7 @@ import {
   Replay,
   StopCircle,
   DeleteOutline,
+  RemoveCircleOutline,
   ClearOutlined,
   Download,
   ExpandMore,
@@ -92,6 +93,7 @@ import type {
 import StatusChip from "../components/StatusChip";
 import IdentityChip from "../components/IdentityChip";
 import SegmentObservationDialog from "../components/SegmentObservationDialog";
+import { discardSegment } from "../api/client";
 import SegmentPromptPopover from "../components/SegmentPromptPopover";
 import { buildFaceswapFields, resolveFaceswapImage } from "../lib/faceswapPayload";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
@@ -1007,7 +1009,7 @@ export default function JobDetail() {
               <TableBody>
                 {videoSegments.flatMap((seg) => {
                   const rows = [
-                  <TableRow key={seg.id}>
+                  <TableRow key={seg.id} sx={seg.discarded ? { opacity: 0.5 } : undefined}>
                     {groups.length > 0 && (
                       <TableCell padding="none" sx={{ width: laneWidth, minWidth: laneWidth, position: "relative" }}>
                         <div style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%" }}>
@@ -1145,6 +1147,11 @@ export default function JobDetail() {
                     <TableCell>
                       <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap" }}>
                         <StatusChip status={seg.status} />
+                        {seg.discarded && (
+                          <Tooltip title="Kept for its feedback, excluded from the video">
+                            <Chip size="small" label="Discarded" variant="outlined" color="warning" />
+                          </Tooltip>
+                        )}
                         <IdentityChip segment={seg} />
                         {(() => {
                           const reviewed =
@@ -1248,8 +1255,34 @@ export default function JobDetail() {
                         )}
                         {job.status !== "finalized" &&
                           (seg.status === "failed" || seg.status === "completed") &&
+                          !seg.discarded &&
+                          job.segments.filter((x) => !x.discarded).length > 1 && (
+                            <Tooltip title="Discard — keeps the rating and notes, removes it from the video">
+                              <IconButton
+                                size="small"
+                                onClick={async () => {
+                                  const updated = await discardSegment(seg.id);
+                                  setJob((prev) =>
+                                    prev
+                                      ? {
+                                          ...prev,
+                                          segments: prev.segments.map((x) =>
+                                            x.id === updated.id ? { ...x, discarded: true } : x,
+                                          ),
+                                        }
+                                      : prev,
+                                  );
+                                }}
+                                disabled={actionLoading === seg.id}
+                              >
+                                <RemoveCircleOutline fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          )}
+                        {job.status !== "finalized" &&
+                          (seg.status === "failed" || seg.status === "completed") &&
                           job.segments.length > 1 && (
-                            <Tooltip title="Delete">
+                            <Tooltip title="Delete — destroys the segment and its feedback">
                               <IconButton
                                 size="small"
                                 color="error"


### PR DESCRIPTION
Pairs with wanly-api#189, now merged.

Takes a segment out of the video and **keeps the rating, tags and notes**.

**Sits before Delete in the row**, because it is almost always the right action — delete destroys the feedback, which is the point of having reviewed the segment at all. Both tooltips now say which is which:

```
Discard — keeps the rating and notes, removes it from the video
Delete  — destroys the segment and its feedback
```

**Discarded rows are dimmed and badged, not hidden.** The segment is still a record and its annotations are still worth reading — hiding it would reproduce the delete this replaces.

The "cannot remove the last segment" guard counts **live** segments only, so a job with one live and three discarded segments still refuses to discard the last one.

Updates the row in place rather than refetching, so the list doesn't jump while you're working down it.

80 tests passing, `tsc -b` and `build` clean.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct