### PR TITLE
Remove deleted images from every view's grid (#315)

### DIFF
--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -332,7 +332,18 @@ export default function ImageRepo() {
   };
 
   const removeFromView = (key: string) => {
+    // A deleted image must vanish from EVERY cached list, not just `images`. The folder,
+    // untagged, favorites and search views each render their own array, so filtering only
+    // `images` left the deleted image on screen until a refetch — the reported bug (#315),
+    // which reproduced on the untagged and folder views.
     setImages((prev) => prev.filter((img) => img.key !== key));
+    setUntaggedImages((prev) => prev.filter((img) => img.key !== key));
+    setFavImages((prev) => prev.filter((img) => img.key !== key));
+    setSearchResults((prev) => {
+      const next = prev.filter((img) => img.key !== key);
+      if (next.length !== prev.length) setSearchTotal((t) => Math.max(0, t - 1));
+      return next;
+    });
     if (lightboxImage?.key === key) setLightboxImage(null);
   };
 
@@ -470,9 +481,17 @@ export default function ImageRepo() {
     const deleted: string[] = [];
     let refused = 0;
     let failed = 0;
+    // Look the image up across every view's array, not just `images`. Selection is possible in
+    // the untagged and favorites views too, whose items are NOT in `images` — so the old
+    // `images.find` skipped them entirely, deleting nothing and updating nothing (#315).
+    const findImage = (key: string) =>
+      images.find((i) => i.key === key) ??
+      untaggedImages.find((i) => i.key === key) ??
+      favImages.find((i) => i.key === key) ??
+      searchResults.find((i) => i.key === key);
     try {
       for (const key of bulkDeleteKeys) {
-        const img = images.find((i) => i.key === key);
+        const img = findImage(key);
         if (!img) continue;
         try {
           await deleteImage(img.path);
@@ -482,7 +501,15 @@ export default function ImageRepo() {
           else failed += 1;
         }
       }
-      setImages((prev) => prev.filter((img) => !deleted.includes(img.key)));
+      const wasDeleted = (img: ImageFile) => deleted.includes(img.key);
+      setImages((prev) => prev.filter((img) => !wasDeleted(img)));
+      setUntaggedImages((prev) => prev.filter((img) => !wasDeleted(img)));
+      setFavImages((prev) => prev.filter((img) => !wasDeleted(img)));
+      setSearchResults((prev) => {
+        const next = prev.filter((img) => !wasDeleted(img));
+        setSearchTotal((t) => Math.max(0, t - (prev.length - next.length)));
+        return next;
+      });
       if (lightboxImage && deleted.includes(lightboxImage.key)) {
         setLightboxImage(null);
       }


### PR DESCRIPTION
Fixes #315 — deleting an image left it in the grid until a page refresh, on both the folder-dir page and the untagged view.

## Cause

`ImageRepo` keeps a **separate array per view** — `images` (folder), `untaggedImages`, `favImages`, `searchResults` — and each view renders its own. Deletion only ever maintained `images`:

- **Single delete** (`removeFromView`) filtered only `images`, so in the untagged/favorites/search views the deleted image stayed on screen.
- **Bulk delete** was worse — it looked images up with `images.find((i) => i.key === key)`, so a selected *untagged* or *favorite* image (not present in `images`) was skipped entirely: deleted nothing **and** updated nothing.

## Fix

- `removeFromView` now purges the key from all four arrays and decrements `searchTotal` when it removes a search hit.
- Bulk delete resolves each key across all four arrays before deleting, and filters all four afterward.

No behavior change for the happy path in the folder view; the other views now stay in sync without a refetch.

## Verification

`npx tsc --noEmit`, `npm run lint`, and `npm run build` all clean.

The change is component state-array maintenance — *which* array each view renders is JSX, not a pure function — so it isn't covered by the pure-logic vitest suite, and I didn't add a component-test harness (out of scope for this repo's current test setup). Worth a manual pass before merge: delete a single image and bulk-delete a selection from **both** the untagged view and a folder page, and confirm each disappears immediately.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct