### PR TITLE
fix(ar): the dom-overlay was buried under the WebGL canvas

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -32,9 +32,19 @@ server {
         client_max_body_size 1G;
     }
 
-    # Cache static assets
+    # index.html must always revalidate. It is the only file that knows which content-hashed
+    # bundle is current, so letting a browser cache it pins that browser to a stale app across
+    # every future deploy — the assets update, the pointer to them does not. Exact-match wins over
+    # `location /`, and the SPA fallback above re-runs location matching on its internal redirect,
+    # so deep routes get this header too.
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
+    # Cache static assets. Vite content-hashes these filenames, so a changed file is a changed URL
+    # and immutable is safe. One header, not two: `expires` emits its own Cache-Control and the
+    # add_header appended a second, conflicting one.
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
+        add_header Cache-Control "public, max-age=31536000, immutable";
     }
 }

--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -519,11 +519,17 @@ function TuningPanel({
 
   return (
     <div
+      // Top-left, not bottom-left: the WebXR emulator's "Controller [L]" inspector occupies the
+      // bottom-left corner, and that extension is exactly where this gets iterated on. Its UI is
+      // injected at document level so it cannot be out-stacked from in here — the only fix is to
+      // not be underneath it. Sits below the tier chip, which is clear in the headset too.
       style={{
         position: "absolute",
         left: 20,
-        bottom: 20,
+        top: 64,
         width: open ? 300 : "auto",
+        maxHeight: "calc(100vh - 88px)",
+        overflowY: "auto",
         pointerEvents: "auto",
         background: "rgba(0,0,0,0.72)",
         color: "#fff",
@@ -545,7 +551,12 @@ function TuningPanel({
           padding: 0,
         }}
       >
-        {open ? "▾ Tuning" : "▸ Tuning"}
+        {open ? "▾" : "▸"} Tuning
+        {/* Names the context. The panel is otherwise identical in AR and preview but silently
+            carries fewer controls in preview, which reads as "the modes are missing". */}
+        <span style={{ opacity: 0.55, fontWeight: 400, marginLeft: 6 }}>
+          {showLock ? "AR session" : "preview"}
+        </span>
       </button>
 
       {open && (
@@ -820,7 +831,15 @@ export default function HologramPlayer() {
   return (
     <div ref={containerRef} style={{ position: "fixed", inset: 0 }}>
       {/* dom-overlay content (transport UI could live here during AR) */}
-      <div ref={overlayRef} style={{ position: "fixed", inset: 0, pointerEvents: "none" }}>
+      {/* zIndex is load-bearing: startArSession appends the WebGL canvas as a later sibling of
+          this div, so with both at z-index auto the canvas paints over the whole overlay and
+          every control here vanishes. A real headset masks it — the UA promotes the dom-overlay
+          root into the XR compositor — but under the WebXR emulator plain CSS stacking applies
+          and the overlay is simply buried. */}
+      <div
+        ref={overlayRef}
+        style={{ position: "fixed", inset: 0, pointerEvents: "none", zIndex: 10 }}
+      >
         {inAr && (
           <>
             {tierLabel && (


### PR DESCRIPTION
Follow-up to #318. The tuning panel shipped but was invisible in an AR session.

## Root cause

`startArSession` appends `renderer.domElement` as a **later sibling** of the dom-overlay root,
inside the same container:

```
<div ref={containerRef}>          position: fixed
  <div ref={overlayRef}>          position: fixed, z-index: auto   <- overlay
  <canvas>                        appended at runtime, z-index: auto <- paints on top
```

Both at `z-index: auto`, so paint order falls back to DOM order and **the canvas covers the entire
overlay**. The panel's own `zIndex: 3` cannot rescue it: `position: fixed` on the overlay root
creates a stacking context, which traps any child z-index inside it.

This hid **everything** in the overlay — the new panel, and the pre-existing **Exit AR** button,
tier chip and hint text.

### Why it was never noticed, and why preview worked

A real headset masks it. When `dom-overlay` is granted the UA promotes the overlay root into the
XR compositor, so CSS stacking never decides the outcome. Under the WebXR emulator the session
renders into an ordinary canvas, plain stacking applies, and the overlay is buried.

And the *identical* panel rendered fine in 3D preview because the preview controls are direct
children of the container — their `z-index: 2` competes with the canvas and wins. Same component,
two different stacking contexts, opposite outcomes.

## Also in here

**Panel moved bottom-left → top-left.** The emulator's "Controller [L]" inspector sits in the
bottom-left corner (roughly x 10–280, y 545–935, against the panel's x 20–320, y 536–936 — near
total overlap). That extension is exactly where this gets iterated on, and its UI is injected at
document level, so it cannot be out-stacked from inside the page. The only fix is to not be under
it. Top-left is clear in both the emulator and the headset.

**Panel header names its context** — `Tuning · AR session` vs `Tuning · preview`. It was otherwise
identical in both places while silently carrying fewer controls in preview, which reads as the
mode buttons being broken rather than deliberately absent.

**`nginx.conf`: `index.html` now sends `Cache-Control: no-cache`.** It had no cache directive at
all, so browsers applied heuristic caching to the one file that knows which content-hashed bundle
is current. Caching it pins a browser to a stale app across every future deploy — the assets
update, the pointer to them does not. Assets stay `immutable`, correctly, since Vite hashes their
filenames.

Also collapses the asset rule to a **single** `Cache-Control`. `expires 1y` emits one and the
`add_header` appended a second, so responses carried two conflicting headers:

```
Cache-Control: max-age=31536000
Cache-Control: public, immutable
```

## Verification

`tsc --noEmit` clean · `eslint` clean · `vitest` 101/101 · `nginx -t` passes against `nginx:alpine`
with a stub cert (the config previously failed to test only on the absent Let's Encrypt files).

**Not verified:** how any of this looks in a real Quest 3S. The stacking bug is masked there by
design, so the headset cannot confirm the fix — the emulator is the thing that proves it.
