### PR TITLE
fix(ar): landing screen could not scroll, stranding Enter AR off-viewport

### DIFF
--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -508,6 +508,7 @@ function TuningPanel({
   onToggle,
   showLock,
   edgeDefaults,
+  inline,
 }: {
   settings: ArSettings;
   onChange: (patch: Partial<ArSettings>) => void;

--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -832,19 +832,33 @@ export default function HologramPlayer() {
   const edgeDefaults = isDepth ? EDGE_DEFAULTS.depth : EDGE_DEFAULTS.flat;
   const patch = (p: Partial<ArSettings>) => setSettings((s) => ({ ...s, ...p }));
 
+  // Scrolls. `justify-content: center` on a fixed, viewport-height flex column silently clips
+  // anything taller than the viewport AND makes the overflow unreachable — which stranded the
+  // Enter AR button below the fold once the tuning panel was added to this screen. Auto margins
+  // on the inner column centre it while it fits and yield to scrolling when it does not;
+  // `justify-content: center` does not, so it is deliberately absent here.
   const wrap: React.CSSProperties = {
     position: "fixed",
     inset: 0,
+    overflowY: "auto",
     background: "#0b0b0f",
     color: "#eee",
     fontFamily: "system-ui, sans-serif",
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    justifyContent: "center",
-    gap: 16,
     textAlign: "center",
     padding: 24,
+  };
+
+  const wrapInner: React.CSSProperties = {
+    margin: "auto 0",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: 16,
+    width: "100%",
+    maxWidth: 480,
   };
 
   return (
@@ -980,6 +994,7 @@ export default function HologramPlayer() {
 
       {!inAr && !inPreview && (
         <div style={wrap}>
+          <div style={wrapInner}>
           {error && <div style={{ color: "#ff6b6b" }}>⚠ {error}</div>}
           {posterUrl && (
             <img
@@ -1000,26 +1015,6 @@ export default function HologramPlayer() {
               }}
             >
               {tierLabel}
-            </div>
-          )}
-          {/* Chosen here, before entering. The in-session panel needs dom-overlay, which is an
-              optional feature the UA can refuse — under the WebXR emulator it does. This page is
-              ordinary DOM, so the mode is always reachable; the render loop reads it live. */}
-          {manifest && (
-            <TuningPanel
-              settings={settings}
-              onChange={patch}
-              open={panelOpen}
-              onToggle={() => setPanelOpen((o) => !o)}
-              showLock
-              inline
-              edgeDefaults={edgeDefaults}
-            />
-          )}
-          {overlayType === null && sessionRan && (
-            <div style={{ maxWidth: 360, fontSize: 13, color: "#ffb86b", lineHeight: 1.5 }}>
-              That session did not grant <code>dom-overlay</code>, so the in-AR panel could not be
-              shown. Set the mode here instead — it applies as soon as you enter.
             </div>
           )}
           {arSupported === true && manifest && (
@@ -1056,6 +1051,27 @@ export default function HologramPlayer() {
               3D Preview
             </button>
           )}
+          {/* Below the buttons on purpose. The in-session panel needs dom-overlay, an optional
+              feature a UA may refuse, so the mode has to be selectable from ordinary DOM here —
+              but it is tall, and above the buttons it pushed Enter AR off a headset viewport.
+              Primary action first; the render loop reads these live either way. */}
+          {manifest && (
+            <TuningPanel
+              settings={settings}
+              onChange={patch}
+              open={panelOpen}
+              onToggle={() => setPanelOpen((o) => !o)}
+              showLock
+              inline
+              edgeDefaults={edgeDefaults}
+            />
+          )}
+          {overlayType === null && sessionRan && (
+            <div style={{ maxWidth: 360, fontSize: 13, color: "#ffb86b", lineHeight: 1.5 }}>
+              That session did not grant <code>dom-overlay</code>, so the in-AR panel could not be
+              shown. Set the mode here instead — it applies as soon as you enter.
+            </div>
+          )}
           {arSupported === false && (
             <div style={{ maxWidth: 420, lineHeight: 1.5 }}>
               <p style={{ fontWeight: 600 }}>Open this on a Quest 3 (or WebXR headset) to place it in your room.</p>
@@ -1080,6 +1096,7 @@ export default function HologramPlayer() {
             </div>
           )}
           {arSupported === null && !error && <div style={{ opacity: 0.6 }}>Checking AR support…</div>}
+          </div>
         </div>
       )}
     </div>

--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -296,6 +296,7 @@ async function startArSession(
   onEnd: () => void,
   onSession: (s: XRSession) => void,
   settingsRef: { current: ArSettings },
+  onOverlayState: (type: string | null) => void,
 ): Promise<void> {
   const xr = (navigator as unknown as { xr: XRSystem }).xr;
 
@@ -333,6 +334,12 @@ async function startArSession(
   } as XRSessionInit);
   await renderer.xr.setSession(session);
   onSession(session);
+  // dom-overlay is an OPTIONAL feature — a UA is free to start the session without it, in which
+  // case the overlay root is never composited and every in-session control is silently
+  // unreachable. Report it so the failure is legible instead of looking like a broken panel.
+  onOverlayState(
+    (session as unknown as { domOverlayState?: { type?: string } }).domOverlayState?.type ?? null,
+  );
   video.play().catch(() => undefined);
 
   const viewerSpace = await session.requestReferenceSpace("viewer");
@@ -508,6 +515,10 @@ function TuningPanel({
   onToggle: () => void;
   showLock: boolean;
   edgeDefaults: { edgeMin: number; edgeMax: number };
+  // Rendered in normal flow instead of pinned to a corner. Used on the pre-AR landing screen,
+  // which is ordinary page DOM — so the mode can be chosen even when the in-session overlay
+  // fails to render, as it does under the WebXR emulator.
+  inline?: boolean;
 }) {
   const modes: { id: LockMode; label: string; hint: string }[] = [
     { id: "placed", label: "Placed", hint: "Tap the floor. Stays in the room." },
@@ -524,12 +535,13 @@ function TuningPanel({
       // injected at document level so it cannot be out-stacked from in here — the only fix is to
       // not be underneath it. Sits below the tier chip, which is clear in the headset too.
       style={{
-        position: "absolute",
-        left: 20,
-        top: 64,
-        width: open ? 300 : "auto",
-        maxHeight: "calc(100vh - 88px)",
-        overflowY: "auto",
+        position: inline ? "relative" : "absolute",
+        left: inline ? undefined : 20,
+        top: inline ? undefined : 64,
+        width: inline ? "min(320px, 86vw)" : open ? 300 : "auto",
+        textAlign: "left",
+        maxHeight: inline ? undefined : "calc(100vh - 88px)",
+        overflowY: inline ? undefined : "auto",
         pointerEvents: "auto",
         background: "rgba(0,0,0,0.72)",
         color: "#fff",
@@ -552,10 +564,10 @@ function TuningPanel({
         }}
       >
         {open ? "▾" : "▸"} Tuning
-        {/* Names the context. The panel is otherwise identical in AR and preview but silently
-            carries fewer controls in preview, which reads as "the modes are missing". */}
+        {/* Names the context. The panel is otherwise identical everywhere but silently carries
+            fewer controls in preview, which reads as "the modes are missing". */}
         <span style={{ opacity: 0.55, fontWeight: 400, marginLeft: 6 }}>
-          {showLock ? "AR session" : "preview"}
+          {inline ? "applies on entry" : showLock ? "AR session" : "preview"}
         </span>
       </button>
 
@@ -685,6 +697,10 @@ export default function HologramPlayer() {
     ...EDGE_DEFAULTS.flat,
   });
   const [panelOpen, setPanelOpen] = useState(true);
+  // null = the last session did not grant dom-overlay (or none has run yet). Surfaced on the
+  // landing screen so an unreachable in-session panel reads as a refused feature, not a bug.
+  const [overlayType, setOverlayType] = useState<string | null>(null);
+  const [sessionRan, setSessionRan] = useState(false);
   // The render loop samples this every frame; state alone would mean re-entering the session to
   // pick up a slider change.
   const settingsRef = useRef<ArSettings>(settings);
@@ -780,6 +796,7 @@ export default function HologramPlayer() {
     if (!manifest || !videoUrl || !containerRef.current || !overlayRef.current) return;
     try {
       setInAr(true);
+      setSessionRan(true);
       await startArSession(
         containerRef.current,
         overlayRef.current,
@@ -793,6 +810,7 @@ export default function HologramPlayer() {
           sessionRef.current = s;
         },
         settingsRef,
+        setOverlayType,
       );
     } catch (e) {
       setInAr(false);
@@ -981,6 +999,26 @@ export default function HologramPlayer() {
               }}
             >
               {tierLabel}
+            </div>
+          )}
+          {/* Chosen here, before entering. The in-session panel needs dom-overlay, which is an
+              optional feature the UA can refuse — under the WebXR emulator it does. This page is
+              ordinary DOM, so the mode is always reachable; the render loop reads it live. */}
+          {manifest && (
+            <TuningPanel
+              settings={settings}
+              onChange={patch}
+              open={panelOpen}
+              onToggle={() => setPanelOpen((o) => !o)}
+              showLock
+              inline
+              edgeDefaults={edgeDefaults}
+            />
+          )}
+          {overlayType === null && sessionRan && (
+            <div style={{ maxWidth: 360, fontSize: 13, color: "#ffb86b", lineHeight: 1.5 }}>
+              That session did not grant <code>dom-overlay</code>, so the in-AR panel could not be
+              shown. Set the mode here instead — it applies as soon as you enter.
             </div>
           )}
           {arSupported === true && manifest && (


### PR DESCRIPTION
On a headset the tuning panel made the landing screen taller than the viewport and **the Enter AR
button became unreachable** — no way into VR at all. Regression from #320, which put the panel on
this screen.

## Cause

```js
position: "fixed", inset: 0,
display: "flex", flexDirection: "column",
justifyContent: "center",     // <- and no overflow rule
```

Centring a flex column that overflows does not merely clip it — the overflow lands *outside the
scrollable area in both directions*, so no amount of scrolling reaches it. The content was there
and permanently unreachable.

## Fix

`overflow-y: auto` on the container, and `margin: auto 0` on a new inner column instead of
`justify-content: center`. Auto margins centre the content while it fits and yield to scrolling
when it does not, which is exactly the behaviour wanted here. `justify-content: center` cannot do
that, so it is deliberately gone rather than merely supplemented.

**Also reorders**: the tuning panel now sits *below* the Enter AR / 3D Preview buttons. The panel
is tall by nature, and having the primary action after it is what created the trap. Primary action
first means entering AR never depends on scrolling in the first place — the scroll fix is the
safety net, not the only thing standing between you and VR.

## Verification

Verified with **`npm run build`** (`tsc -b && vite build`), the command CI and the Dockerfile run.
Not `npx tsc --noEmit`, which resolves the root solution-style `tsconfig.json` (`"files": []`, two
references) and type-checks nothing — that blind spot is what let the broken build through in #320.

`eslint` clean · `vitest` 101/101.

Not verified: how it feels on the headset. That is the thing this unblocks.