### PR TITLE
fix(ar): follow mode ignored gaze pitch entirely

### DIFF
--- a/src/lib/arFollow.test.ts
+++ b/src/lib/arFollow.test.ts
@@ -6,7 +6,6 @@ import {
   followOriginY,
   followTarget,
   nextEasing,
-  shortestAngleDelta,
   smoothing,
 } from "./arFollow";
 
@@ -28,18 +27,6 @@ describe("smoothing", () => {
 
   it("is zero at zero elapsed time", () => {
     expect(smoothing(5, 0)).toBe(0);
-  });
-});
-
-describe("shortestAngleDelta", () => {
-  it("crosses the ±π seam the short way instead of spinning", () => {
-    // 170° -> -170° is +20°, not -340°.
-    const d = shortestAngleDelta((170 * Math.PI) / 180, (-170 * Math.PI) / 180);
-    expect((d * 180) / Math.PI).toBeCloseTo(20, 6);
-  });
-
-  it("handles the plain case", () => {
-    expect(shortestAngleDelta(0, 1)).toBeCloseTo(1, 12);
   });
 });
 
@@ -116,11 +103,28 @@ describe("followTarget", () => {
     expect(t.z).toBeCloseTo(0.4, 12);
   });
 
-  it("ignores the forward vector's y — height comes from the offset alone", () => {
-    // This is what separates a follow target from a naive eye+forward*d: the clip must not sink
-    // into the floor just because the viewer glanced downward.
+  it("follows the gaze DOWN when the forward vector pitches down", () => {
+    // The whole point of `follow`: look down and the clip comes with you. A previous version
+    // dropped forward.y here, which silently collapsed `follow` into `follow-yaw` vertically and
+    // made the clip creep closer at a fixed height instead — "sliding down a wall".
     const level = followTarget({ x: 0, y: 1.6, z: 0 }, { x: 0, y: 0, z: -1 }, settings, 1.7);
-    const pitched = followTarget({ x: 0, y: 1.6, z: 0 }, { x: 0, y: -0.7, z: -0.7 }, settings, 1.7);
+    const down = followTarget({ x: 0, y: 1.6, z: 0 }, { x: 0, y: -1, z: 0 }, settings, 1.7);
+    expect(down.y).toBeLessThan(level.y);
+    expect(down.y).toBeCloseTo(level.y - settings.followDistance, 12);
+  });
+
+  it("follows the gaze UP symmetrically", () => {
+    const level = followTarget({ x: 0, y: 1.6, z: 0 }, { x: 0, y: 0, z: -1 }, settings, 1.7);
+    const up = followTarget({ x: 0, y: 1.6, z: 0 }, { x: 0, y: 1, z: 0 }, settings, 1.7);
+    expect(up.y).toBeCloseTo(level.y + settings.followDistance, 12);
+  });
+
+  it("holds eye level for an already-flattened vector — the follow-yaw path", () => {
+    // follow-yaw hands in a vector whose y is 0 (via flattenYaw), so the same arithmetic pins the
+    // height without followTarget needing to know which mode is active.
+    const flat = flattenYaw({ x: 0, y: -0.9, z: -0.436 })!;
+    const level = followTarget({ x: 0, y: 1.6, z: 0 }, { x: 0, y: 0, z: -1 }, settings, 1.7);
+    const pitched = followTarget({ x: 0, y: 1.6, z: 0 }, flat, settings, 1.7);
     expect(pitched.y).toBeCloseTo(level.y, 12);
   });
 });

--- a/src/lib/arFollow.ts
+++ b/src/lib/arFollow.ts
@@ -64,12 +64,6 @@ export function smoothing(rate: number, dt: number): number {
   return 1 - Math.exp(-rate * dt);
 }
 
-/** Signed shortest way round the circle, so a yaw crossing ±π eases across instead of spinning. */
-export function shortestAngleDelta(from: number, to: number): number {
-  const d = to - from;
-  return Math.atan2(Math.sin(d), Math.cos(d));
-}
-
 /**
  * Deadzone latch (hysteresis). Inside the deadzone the clip holds still, so small head movement
  * doesn't drag it; once the viewer drifts out it eases all the way home rather than only back to
@@ -103,7 +97,18 @@ export function followOriginY(eyeY: number, offset: number, height: number): num
   return eyeY + offset - height / 2;
 }
 
-/** Where the clip wants to be this frame, given the viewer pose and the follow settings. */
+/**
+ * Where the clip wants to be this frame, given the viewer pose and the follow settings.
+ *
+ * The target sits `followDistance` along `forward` in ALL THREE axes. Pitch is expressed by the
+ * caller through the vector it passes, not by this function second-guessing it: `follow` passes
+ * the raw gaze vector so looking down carries the clip down, and `follow-yaw` passes a vector
+ * already flattened by `flattenYaw`, whose y is 0, so the same arithmetic holds it at eye level.
+ *
+ * An earlier version dropped `forward.y` here unconditionally. That silently collapsed `follow`
+ * into `follow-yaw` vertically, while the horizontal components still shrank as the viewer
+ * pitched — so the clip crept closer at a fixed height instead of following the gaze down.
+ */
 export function followTarget(
   eye: Vec3,
   forward: Vec3,
@@ -112,7 +117,7 @@ export function followTarget(
 ): Vec3 {
   return {
     x: eye.x + forward.x * settings.followDistance,
-    y: followOriginY(eye.y, settings.followHeight, subjectHeight),
+    y: followOriginY(eye.y + forward.y * settings.followDistance, settings.followHeight, subjectHeight),
     z: eye.z + forward.z * settings.followDistance,
   };
 }

--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -508,6 +508,7 @@ function TuningPanel({
   onToggle,
   showLock,
   edgeDefaults,
+  inline,
 }: {
   settings: ArSettings;
   onChange: (patch: Partial<ArSettings>) => void;

--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -832,19 +832,33 @@ export default function HologramPlayer() {
   const edgeDefaults = isDepth ? EDGE_DEFAULTS.depth : EDGE_DEFAULTS.flat;
   const patch = (p: Partial<ArSettings>) => setSettings((s) => ({ ...s, ...p }));
 
+  // Scrolls. `justify-content: center` on a fixed, viewport-height flex column silently clips
+  // anything taller than the viewport AND makes the overflow unreachable — which stranded the
+  // Enter AR button below the fold once the tuning panel was added to this screen. Auto margins
+  // on the inner column centre it while it fits and yield to scrolling when it does not;
+  // `justify-content: center` does not, so it is deliberately absent here.
   const wrap: React.CSSProperties = {
     position: "fixed",
     inset: 0,
+    overflowY: "auto",
     background: "#0b0b0f",
     color: "#eee",
     fontFamily: "system-ui, sans-serif",
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    justifyContent: "center",
-    gap: 16,
     textAlign: "center",
     padding: 24,
+  };
+
+  const wrapInner: React.CSSProperties = {
+    margin: "auto 0",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: 16,
+    width: "100%",
+    maxWidth: 480,
   };
 
   return (
@@ -980,6 +994,7 @@ export default function HologramPlayer() {
 
       {!inAr && !inPreview && (
         <div style={wrap}>
+          <div style={wrapInner}>
           {error && <div style={{ color: "#ff6b6b" }}>⚠ {error}</div>}
           {posterUrl && (
             <img
@@ -1000,26 +1015,6 @@ export default function HologramPlayer() {
               }}
             >
               {tierLabel}
-            </div>
-          )}
-          {/* Chosen here, before entering. The in-session panel needs dom-overlay, which is an
-              optional feature the UA can refuse — under the WebXR emulator it does. This page is
-              ordinary DOM, so the mode is always reachable; the render loop reads it live. */}
-          {manifest && (
-            <TuningPanel
-              settings={settings}
-              onChange={patch}
-              open={panelOpen}
-              onToggle={() => setPanelOpen((o) => !o)}
-              showLock
-              inline
-              edgeDefaults={edgeDefaults}
-            />
-          )}
-          {overlayType === null && sessionRan && (
-            <div style={{ maxWidth: 360, fontSize: 13, color: "#ffb86b", lineHeight: 1.5 }}>
-              That session did not grant <code>dom-overlay</code>, so the in-AR panel could not be
-              shown. Set the mode here instead — it applies as soon as you enter.
             </div>
           )}
           {arSupported === true && manifest && (
@@ -1056,6 +1051,27 @@ export default function HologramPlayer() {
               3D Preview
             </button>
           )}
+          {/* Below the buttons on purpose. The in-session panel needs dom-overlay, an optional
+              feature a UA may refuse, so the mode has to be selectable from ordinary DOM here —
+              but it is tall, and above the buttons it pushed Enter AR off a headset viewport.
+              Primary action first; the render loop reads these live either way. */}
+          {manifest && (
+            <TuningPanel
+              settings={settings}
+              onChange={patch}
+              open={panelOpen}
+              onToggle={() => setPanelOpen((o) => !o)}
+              showLock
+              inline
+              edgeDefaults={edgeDefaults}
+            />
+          )}
+          {overlayType === null && sessionRan && (
+            <div style={{ maxWidth: 360, fontSize: 13, color: "#ffb86b", lineHeight: 1.5 }}>
+              That session did not grant <code>dom-overlay</code>, so the in-AR panel could not be
+              shown. Set the mode here instead — it applies as soon as you enter.
+            </div>
+          )}
           {arSupported === false && (
             <div style={{ maxWidth: 420, lineHeight: 1.5 }}>
               <p style={{ fontWeight: 600 }}>Open this on a Quest 3 (or WebXR headset) to place it in your room.</p>
@@ -1080,6 +1096,7 @@ export default function HologramPlayer() {
             </div>
           )}
           {arSupported === null && !error && <div style={{ opacity: 0.6 }}>Checking AR support…</div>}
+          </div>
         </div>
       )}
     </div>

--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -296,6 +296,7 @@ async function startArSession(
   onEnd: () => void,
   onSession: (s: XRSession) => void,
   settingsRef: { current: ArSettings },
+  onOverlayState: (type: string | null) => void,
 ): Promise<void> {
   const xr = (navigator as unknown as { xr: XRSystem }).xr;
 
@@ -333,6 +334,12 @@ async function startArSession(
   } as XRSessionInit);
   await renderer.xr.setSession(session);
   onSession(session);
+  // dom-overlay is an OPTIONAL feature — a UA is free to start the session without it, in which
+  // case the overlay root is never composited and every in-session control is silently
+  // unreachable. Report it so the failure is legible instead of looking like a broken panel.
+  onOverlayState(
+    (session as unknown as { domOverlayState?: { type?: string } }).domOverlayState?.type ?? null,
+  );
   video.play().catch(() => undefined);
 
   const viewerSpace = await session.requestReferenceSpace("viewer");
@@ -508,6 +515,10 @@ function TuningPanel({
   onToggle: () => void;
   showLock: boolean;
   edgeDefaults: { edgeMin: number; edgeMax: number };
+  // Rendered in normal flow instead of pinned to a corner. Used on the pre-AR landing screen,
+  // which is ordinary page DOM — so the mode can be chosen even when the in-session overlay
+  // fails to render, as it does under the WebXR emulator.
+  inline?: boolean;
 }) {
   const modes: { id: LockMode; label: string; hint: string }[] = [
     { id: "placed", label: "Placed", hint: "Tap the floor. Stays in the room." },
@@ -524,12 +535,13 @@ function TuningPanel({
       // injected at document level so it cannot be out-stacked from in here — the only fix is to
       // not be underneath it. Sits below the tier chip, which is clear in the headset too.
       style={{
-        position: "absolute",
-        left: 20,
-        top: 64,
-        width: open ? 300 : "auto",
-        maxHeight: "calc(100vh - 88px)",
-        overflowY: "auto",
+        position: inline ? "relative" : "absolute",
+        left: inline ? undefined : 20,
+        top: inline ? undefined : 64,
+        width: inline ? "min(320px, 86vw)" : open ? 300 : "auto",
+        textAlign: "left",
+        maxHeight: inline ? undefined : "calc(100vh - 88px)",
+        overflowY: inline ? undefined : "auto",
         pointerEvents: "auto",
         background: "rgba(0,0,0,0.72)",
         color: "#fff",
@@ -552,10 +564,10 @@ function TuningPanel({
         }}
       >
         {open ? "▾" : "▸"} Tuning
-        {/* Names the context. The panel is otherwise identical in AR and preview but silently
-            carries fewer controls in preview, which reads as "the modes are missing". */}
+        {/* Names the context. The panel is otherwise identical everywhere but silently carries
+            fewer controls in preview, which reads as "the modes are missing". */}
         <span style={{ opacity: 0.55, fontWeight: 400, marginLeft: 6 }}>
-          {showLock ? "AR session" : "preview"}
+          {inline ? "applies on entry" : showLock ? "AR session" : "preview"}
         </span>
       </button>
 
@@ -685,6 +697,10 @@ export default function HologramPlayer() {
     ...EDGE_DEFAULTS.flat,
   });
   const [panelOpen, setPanelOpen] = useState(true);
+  // null = the last session did not grant dom-overlay (or none has run yet). Surfaced on the
+  // landing screen so an unreachable in-session panel reads as a refused feature, not a bug.
+  const [overlayType, setOverlayType] = useState<string | null>(null);
+  const [sessionRan, setSessionRan] = useState(false);
   // The render loop samples this every frame; state alone would mean re-entering the session to
   // pick up a slider change.
   const settingsRef = useRef<ArSettings>(settings);
@@ -780,6 +796,7 @@ export default function HologramPlayer() {
     if (!manifest || !videoUrl || !containerRef.current || !overlayRef.current) return;
     try {
       setInAr(true);
+      setSessionRan(true);
       await startArSession(
         containerRef.current,
         overlayRef.current,
@@ -793,6 +810,7 @@ export default function HologramPlayer() {
           sessionRef.current = s;
         },
         settingsRef,
+        setOverlayType,
       );
     } catch (e) {
       setInAr(false);
@@ -981,6 +999,26 @@ export default function HologramPlayer() {
               }}
             >
               {tierLabel}
+            </div>
+          )}
+          {/* Chosen here, before entering. The in-session panel needs dom-overlay, which is an
+              optional feature the UA can refuse — under the WebXR emulator it does. This page is
+              ordinary DOM, so the mode is always reachable; the render loop reads it live. */}
+          {manifest && (
+            <TuningPanel
+              settings={settings}
+              onChange={patch}
+              open={panelOpen}
+              onToggle={() => setPanelOpen((o) => !o)}
+              showLock
+              inline
+              edgeDefaults={edgeDefaults}
+            />
+          )}
+          {overlayType === null && sessionRan && (
+            <div style={{ maxWidth: 360, fontSize: 13, color: "#ffb86b", lineHeight: 1.5 }}>
+              That session did not grant <code>dom-overlay</code>, so the in-AR panel could not be
+              shown. Set the mode here instead — it applies as soon as you enter.
             </div>
           )}
           {arSupported === true && manifest && (

--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -10,7 +10,6 @@ import {
   flattenYaw,
   followTarget,
   nextEasing,
-  shortestAngleDelta,
   smoothing,
 } from "../lib/arFollow";
 import type { ArSettings, LockMode } from "../lib/arFollow";
@@ -369,6 +368,9 @@ async function startArSession(
   const fwd = new THREE.Vector3();
   const target = new THREE.Vector3();
   const lastYawFwd = new THREE.Vector3(0, 0, -1); // held heading for the near-vertical gaze case
+  const billboard = new THREE.Object3D(); // scratch for lookAt-derived orientation
+  const billboardEuler = new THREE.Euler();
+  const targetQuat = new THREE.Quaternion();
   let easing = false; // deadzone hysteresis: latched on when we drift out, off when we arrive
   // Starts true, not false: a session restored straight into a follow mode would otherwise glide
   // in from the world origin on the first frame instead of simply being there.
@@ -437,14 +439,23 @@ async function startArSession(
         if (easing) group.position.lerp(target, smoothing(s.followTightness, dt));
       }
 
-      // Always billboard yaw-only — a clip that pitches with your gaze reads as a decal.
-      const yaw = Math.atan2(camPos.x - group.position.x, camPos.z - group.position.z);
+      // Orientation follows the same rule as position, per mode. `follow` turns to face the
+      // viewer fully, pitch included: it tracks the gaze in 3D, so holding the plane vertical
+      // would present it edge-on the moment you looked down — which is the "sliding down a wall"
+      // read. `follow-yaw` stays upright by design, since it never leaves the eyeline.
+      if (s.lockMode === "follow") {
+        billboard.position.copy(group.position);
+        billboard.lookAt(camPos); // +Z is the quad's normal
+        targetQuat.copy(billboard.quaternion);
+      } else {
+        const yaw = Math.atan2(camPos.x - group.position.x, camPos.z - group.position.z);
+        targetQuat.setFromEuler(billboardEuler.set(0, yaw, 0));
+      }
       if (snapNext) {
-        group.rotation.y = yaw;
+        group.quaternion.copy(targetQuat);
         snapNext = false;
       } else {
-        group.rotation.y +=
-          shortestAngleDelta(group.rotation.y, yaw) * smoothing(s.followTightness, dt);
+        group.quaternion.slerp(targetQuat, smoothing(s.followTightness, dt));
       }
     }
     renderer.render(scene, camera);


### PR DESCRIPTION
Reported from the headset: looking down did not bring the clip down, and it crept toward the viewer
at a fixed height while staying bolt upright — *"like I am sliding my head down a wall"*.

That description pins the bug precisely.

## Cause 1 — the target ignored `forward.y`

```js
y: followOriginY(eye.y, settings.followHeight, subjectHeight),   // forward.y never used
```

Height came from the eye position and the offset alone. So `follow` was collapsed into
`follow-yaw` vertically — while the **horizontal** components `forward.x/z` still shrank as the
viewer pitched down. Constant height plus shrinking horizontal reach *is* sliding down a wall.

The target now advances along all three axes. `follow-yaw` is unaffected: `flattenYaw` already
hands in a vector whose `y` is 0, so the same arithmetic pins it to eye level. The mode
distinction lives in the vector the caller passes, not in a guard inside `followTarget`.

## Cause 2 — orientation had the same flaw from the other side

Billboarding was yaw-only in **every** mode, with a comment claiming a clip that pitches "reads as
a decal". That reasoning holds for a clip anchored at eye level; it is wrong for one tracking the
gaze in 3D, which presents itself edge-on the instant you look down. `follow` now faces the viewer
fully (`lookAt` + `slerp`); `follow-yaw` stays upright by design, since it never leaves the
eyeline.

## Why it shipped green

A test asserted the broken behaviour **as correct**:

```js
it("ignores the forward vector's y — height comes from the offset alone", ...)
```

I wrote a guard against the clip sinking into the floor, then wrote a test locking that guard in,
and never checked it against the actual request — *"in a POV scenario the object in front of me
tracks with my headset. I look down, it moves with me."* The test suite was green and measuring the
wrong thing.

Replaced with tests that the clip follows the gaze **down** and **up** symmetrically, and one
pinning the `follow-yaw` path through `flattenYaw`.

## Also

Drops `shortestAngleDelta` and its two tests — quaternion `slerp` takes the shortest arc itself, so
the helper became dead code. Test count nets 101.

## Verification

`npm run build` (`tsc -b && vite build`) · `eslint` clean · `vitest` 101/101.

**Not verified:** the feel in a headset. Also unexplained: a report of *two* tuning panels showing
at once — the three render branches (`inAr` / `inPreview` / neither) are mutually exclusive, so
that needs one more detail before I can chase it.