### PR TITLE
fix(ar): remove the duplicated landing tuning panel

### DIFF
--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -709,6 +709,10 @@ export default function HologramPlayer() {
     ...EDGE_DEFAULTS.flat,
   });
   const [panelOpen, setPanelOpen] = useState(true);
+  // Separate from panelOpen, and closed by default. The landing copy exists only as a fallback for
+  // a UA that refuses dom-overlay; where the in-session panel works it is redundant, and open by
+  // default it reads as a second, competing tuning UI.
+  const [landingPanelOpen, setLandingPanelOpen] = useState(false);
   // null = the last session did not grant dom-overlay (or none has run yet). Surfaced on the
   // landing screen so an unreachable in-session panel reads as a refused feature, not a bug.
   const [overlayType, setOverlayType] = useState<string | null>(null);
@@ -790,7 +794,9 @@ export default function HologramPlayer() {
 
   // Desktop 3D preview: same mesh + shaders as AR, orbited with the mouse instead of your feet.
   useEffect(() => {
-    if (!inPreview || !manifest || !videoUrl || !containerRef.current) return;
+    // !inAr as well: the two modes each append their own canvas to the same container and render
+    // their own panel, so any state where both are true duplicates the entire player.
+    if (inAr || !inPreview || !manifest || !videoUrl || !containerRef.current) return;
     const stop = startPreview(
       containerRef.current,
       manifest,
@@ -802,11 +808,12 @@ export default function HologramPlayer() {
       settingsRef,
     );
     return stop;
-  }, [inPreview, manifest, videoUrl]);
+  }, [inAr, inPreview, manifest, videoUrl]);
 
   const enterAR = async () => {
     if (!manifest || !videoUrl || !containerRef.current || !overlayRef.current) return;
     try {
+      setInPreview(false); // never both — each owns a canvas on the same container
       setInAr(true);
       setSessionRan(true);
       await startArSession(
@@ -939,7 +946,7 @@ export default function HologramPlayer() {
         )}
       </div>
 
-      {inPreview && (
+      {inPreview && !inAr && (
         <>
           {tierLabel && (
             <div
@@ -1028,26 +1035,6 @@ export default function HologramPlayer() {
               {tierLabel}
             </div>
           )}
-          {/* Chosen here, before entering. The in-session panel needs dom-overlay, which is an
-              optional feature the UA can refuse — under the WebXR emulator it does. This page is
-              ordinary DOM, so the mode is always reachable; the render loop reads it live. */}
-          {manifest && (
-            <TuningPanel
-              settings={settings}
-              onChange={patch}
-              open={panelOpen}
-              onToggle={() => setPanelOpen((o) => !o)}
-              showLock
-              inline
-              edgeDefaults={edgeDefaults}
-            />
-          )}
-          {overlayType === null && sessionRan && (
-            <div style={{ maxWidth: 360, fontSize: 13, color: "#ffb86b", lineHeight: 1.5 }}>
-              That session did not grant <code>dom-overlay</code>, so the in-AR panel could not be
-              shown. Set the mode here instead — it applies as soon as you enter.
-            </div>
-          )}
           {arSupported === true && manifest && (
             <button
               onClick={enterAR}
@@ -1090,8 +1077,8 @@ export default function HologramPlayer() {
             <TuningPanel
               settings={settings}
               onChange={patch}
-              open={panelOpen}
-              onToggle={() => setPanelOpen((o) => !o)}
+              open={landingPanelOpen}
+              onToggle={() => setLandingPanelOpen((o) => !o)}
               showLock
               inline
               edgeDefaults={edgeDefaults}


### PR DESCRIPTION
The landing screen rendered the tuning panel **twice** — once above the Enter AR button and once
below it — plus two copies of the dom-overlay warning. A move that should have relocated the panel
left the original behind.

## Why I missed it twice

I checked that the three render branches are mutually exclusive:

```
{inAr && …}                  // AR overlay
{inPreview && …}             // desktop preview
{!inAr && !inPreview && …}   // landing
```

They are. But **the duplicate was inside a single branch**, which that check could never find. I
concluded "two panels is impossible" and said so, when the right check was `grep -c '<TuningPanel'`
— which returns 4, not 3.

## Changes

**Removes the earlier copy** of the panel and the warning. Count is now three call sites, one per
branch, and one warning.

**Makes AR and preview exclusive in fact, not just by convention.** The preview render and its
effect now require `!inAr`, and entering AR clears `inPreview`. Each mode appends its own canvas to
the same container, so a state where both were true would have duplicated the entire player rather
than just a panel. Not the reported bug, but the same failure one step further out.

**The surviving landing panel defaults to collapsed**, with its own open state. It exists only as a
fallback for a UA that refuses `dom-overlay`; where the in-session panel works it is redundant, and
open by default it reads as a second, competing tuning UI. One line, expandable.

## Verification

`npm run build` · `eslint` clean · `vitest` 101/101 · and by counting rendered instances, which is
the check that would have caught this in the first place.