### PR TITLE
feat(ar): negative follow distance + configurable tilt

### DIFF
--- a/src/lib/arFollow.test.ts
+++ b/src/lib/arFollow.test.ts
@@ -119,6 +119,39 @@ describe("followTarget", () => {
     expect(up.y).toBeCloseTo(level.y + settings.followDistance, 12);
   });
 
+  it("projects backwards through the viewer at negative distance", () => {
+    // First-person framing: looking down with a negative distance pulls the clip back through
+    // your own body so it lines up with chest/hips rather than floating out in front.
+    const behind = followTarget(
+      { x: 0, y: 1.6, z: 0 },
+      { x: 0, y: -1, z: 0 },
+      { followDistance: -0.5, followHeight: 0 },
+      1.7,
+    );
+    const ahead = followTarget(
+      { x: 0, y: 1.6, z: 0 },
+      { x: 0, y: -1, z: 0 },
+      { followDistance: 0.5, followHeight: 0 },
+      1.7,
+    );
+    // Gaze is straight down, so a negative distance must place it ABOVE the positive case.
+    expect(behind.y).toBeGreaterThan(ahead.y);
+    expect(behind.y - ahead.y).toBeCloseTo(1.0, 12);
+  });
+
+  it("puts the target at the viewer's eye when distance is zero", () => {
+    // The degenerate point a negative range must sweep through; the player holds orientation here.
+    const t = followTarget(
+      { x: 1, y: 1.6, z: 2 },
+      { x: 0, y: -1, z: 0 },
+      { followDistance: 0, followHeight: 0 },
+      1.7,
+    );
+    expect(t.x).toBeCloseTo(1, 12);
+    expect(t.z).toBeCloseTo(2, 12);
+    expect(t.y).toBeCloseTo(1.6 - 1.7 / 2, 12);
+  });
+
   it("holds eye level for an already-flattened vector — the follow-yaw path", () => {
     // follow-yaw hands in a vector whose y is 0 (via flattenYaw), so the same arithmetic pins the
     // height without followTarget needing to know which mode is active.

--- a/src/lib/arFollow.ts
+++ b/src/lib/arFollow.ts
@@ -25,6 +25,11 @@ export interface ArSettings {
   followHeight: number; // metres relative to eye level (0 = subject centred on the eyeline)
   followTightness: number; // exponential smoothing rate; higher = snappier
   followDeadzone: number; // metres of slack before it starts easing back
+  // How far the clip tilts back/forward to face you, 0..1. 0 holds it bolt upright (a standing
+  // figure you look down at); 1 turns it fully face-on, so looking down shows it square rather
+  // than edge-on. Only meaningful in `follow` — `follow-yaw` never leaves the eyeline, so there
+  // is no pitch to take.
+  followTilt: number;
   edgeMin: number; // matte cut / smoothstep low
   edgeMax: number; // smoothstep high
 }
@@ -51,6 +56,7 @@ export const DEFAULT_AR_SETTINGS: Omit<ArSettings, "edgeMin" | "edgeMax"> = {
   followHeight: 0,
   followTightness: 2.5,
   followDeadzone: 0.12,
+  followTilt: 1,
 };
 
 /** Below this distance from the target the clip counts as arrived and the latch releases. */

--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -443,18 +443,32 @@ async function startArSession(
       // viewer fully, pitch included: it tracks the gaze in 3D, so holding the plane vertical
       // would present it edge-on the moment you looked down — which is the "sliding down a wall"
       // read. `follow-yaw` stays upright by design, since it never leaves the eyeline.
-      if (s.lockMode === "follow") {
-        billboard.position.copy(group.position);
-        billboard.lookAt(camPos); // +Z is the quad's normal
-        targetQuat.copy(billboard.quaternion);
-      } else {
+      // A negative Distance sweeps the clip backwards through the viewer, so it passes exactly
+      // through the eye at distance 0. There "face the viewer" has no direction: lookAt gets a
+      // zero-length vector and atan2(0, 0) collapses to yaw 0, either of which would spin the clip
+      // as it crossed over. Hold the orientation through that neighbourhood instead.
+      const facing = group.position.distanceTo(camPos) > 1e-3;
+      if (facing) {
+        // Upright is the floor of the blend, full face-on the ceiling, and Tilt slides between
+        // them. Building both and slerping is what makes the intermediate angles available at
+        // all — lookAt alone only ever gives the fully face-on end.
         const yaw = Math.atan2(camPos.x - group.position.x, camPos.z - group.position.z);
         targetQuat.setFromEuler(billboardEuler.set(0, yaw, 0));
+        // Settings restored from localStorage can predate this field entirely, and `undefined > 0`
+        // is false — which would quietly pin every saved hologram to upright. Default, then clamp.
+        const tilt = Number.isFinite(s.followTilt)
+          ? Math.min(Math.max(s.followTilt, 0), 1)
+          : DEFAULT_AR_SETTINGS.followTilt;
+        if (s.lockMode === "follow" && tilt > 0) {
+          billboard.position.copy(group.position);
+          billboard.lookAt(camPos); // +Z is the quad's normal
+          targetQuat.slerp(billboard.quaternion, tilt);
+        }
       }
       if (snapNext) {
-        group.quaternion.copy(targetQuat);
+        if (facing) group.quaternion.copy(targetQuat);
         snapNext = false;
-      } else {
+      } else if (facing) {
         group.quaternion.slerp(targetQuat, smoothing(s.followTightness, dt));
       }
     }
@@ -617,9 +631,13 @@ function TuningPanel({
           {showLock && isFollow && (
             <>
               <Slider
+                // Goes negative on purpose: the target is eye + forward x distance, so a negative
+                // value projects backwards along the gaze. Looking down, that pulls the clip back
+                // through your own body — the first-person framing where it lines up with your
+                // chest and hips instead of floating out in front of you.
                 label="Distance"
                 value={settings.followDistance}
-                min={0.4}
+                min={-1}
                 max={4}
                 step={0.05}
                 unit=" m"
@@ -651,6 +669,18 @@ function TuningPanel({
                 unit=" m"
                 onChange={(v) => onChange({ followDeadzone: v })}
               />
+              {settings.lockMode === "follow" && (
+                <Slider
+                  // 0 = bolt upright, 1 = square-on to you. follow-yaw has no pitch to take, so
+                  // this is hidden there rather than shown doing nothing.
+                  label="Tilt to face you"
+                  value={settings.followTilt}
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  onChange={(v) => onChange({ followTilt: v })}
+                />
+              )}
             </>
           )}
 


### PR DESCRIPTION
Two knobs for first-person framing.

## Negative Distance

The target is `eye + forward × distance`, so a negative value projects **backwards along the
gaze**. Looking down, that pulls the clip back through your own body until it lines up with chest
and hips rather than floating out in front — the POV framing.

The maths already supported it; only the slider floor of `0.4` prevented it. Range is now `-1 … 4`.

**That range sweeps through distance 0**, where the clip sits exactly at your eye and "face the
viewer" has no direction: `lookAt` receives a zero-length vector and `atan2(0, 0)` collapses to yaw
0. Either would spin the clip as it crossed over. Orientation is now held through that
neighbourhood.

## Tilt to face you

Previously **not adjustable at all** — `follow` was hard-locked to `lookAt` (fully face-on) and
`follow-yaw` to upright, with nothing in between. Now a 0..1 slider:

- **0** — bolt upright, a standing figure you look down at
- **1** — square-on to you, the current behaviour
- **between** — partial lean

Both quaternions are built and slerped by the tilt amount. That blend is what makes intermediate
angles reachable in the first place; `lookAt` alone only ever produces the face-on end. Hidden in
`follow-yaw`, which never leaves the eyeline and so has no pitch to take.

## Migration detail

Settings restored from `localStorage` predate `followTilt`, and `undefined > 0` is false — which
would have quietly pinned every previously-tuned hologram to upright. Defaulted and clamped, so
existing saved settings land on face-on rather than silently changing behaviour.

## Verification

`npm run build` · `eslint` clean · `vitest` **103/103** (+2: a negative distance places the clip
*above* the positive case under a downward gaze, and distance 0 lands exactly on the eye).

**Not verified:** the feel. Both of these are pure taste knobs and want a headset.