### PR TITLE
fix(ar): restore the placed pose; revert negative distance

### DIFF
--- a/src/lib/arFollow.test.ts
+++ b/src/lib/arFollow.test.ts
@@ -119,28 +119,10 @@ describe("followTarget", () => {
     expect(up.y).toBeCloseTo(level.y + settings.followDistance, 12);
   });
 
-  it("projects backwards through the viewer at negative distance", () => {
-    // First-person framing: looking down with a negative distance pulls the clip back through
-    // your own body so it lines up with chest/hips rather than floating out in front.
-    const behind = followTarget(
-      { x: 0, y: 1.6, z: 0 },
-      { x: 0, y: -1, z: 0 },
-      { followDistance: -0.5, followHeight: 0 },
-      1.7,
-    );
-    const ahead = followTarget(
-      { x: 0, y: 1.6, z: 0 },
-      { x: 0, y: -1, z: 0 },
-      { followDistance: 0.5, followHeight: 0 },
-      1.7,
-    );
-    // Gaze is straight down, so a negative distance must place it ABOVE the positive case.
-    expect(behind.y).toBeGreaterThan(ahead.y);
-    expect(behind.y - ahead.y).toBeCloseTo(1.0, 12);
-  });
-
-  it("puts the target at the viewer's eye when distance is zero", () => {
-    // The degenerate point a negative range must sweep through; the player holds orientation here.
+  it("puts the target on the viewer's own x/z when distance is zero", () => {
+    // Distance 0 is the chest/hips framing: the clip occupies your own position and the Height
+    // offset drops it down your body. It is also degenerate for the yaw bearing — the player
+    // guards that on horizontal separation, which is exactly 0 here while the 3D distance is not.
     const t = followTarget(
       { x: 1, y: 1.6, z: 2 },
       { x: 0, y: -1, z: 0 },

--- a/src/pages/HologramPlayer.tsx
+++ b/src/pages/HologramPlayer.tsx
@@ -349,12 +349,19 @@ async function startArSession(
   ).requestHitTestSource({ space: viewerSpace });
 
   let placedOnce = false;
+  // The placed pose has to be remembered, not just written once. A follow mode overwrites
+  // group.position/quaternion every frame, so without this, switching back to `placed` strands the
+  // clip wherever follow abandoned it — mid-air, never returning to the spot you tapped.
+  const placedPos = new THREE.Vector3();
+  const placedQuat = new THREE.Quaternion();
   const place = () => {
     if (!reticle.visible) return;
     group.position.setFromMatrixPosition(reticle.matrix);
     // Face the user (yaw only) at placement, then stay put.
     const viewerPos = new THREE.Vector3().setFromMatrixPosition(camera.matrixWorld);
     group.rotation.y = Math.atan2(viewerPos.x - group.position.x, viewerPos.z - group.position.z);
+    placedPos.copy(group.position);
+    placedQuat.copy(group.quaternion);
     group.visible = true;
     placedOnce = true;
     reticle.visible = false; // done placing — don't leave a cyan ring on the floor
@@ -395,9 +402,14 @@ async function startArSession(
     holo.uniforms.edgeMax.value = s.edgeMax;
 
     if (s.lockMode === "placed") {
-      // Original behaviour, untouched: reticle until the tap, then frozen in the room.
+      // Reticle until the tap, then frozen in the room — restored from the remembered pose every
+      // frame, because a follow mode may have moved the group since it was placed.
       holo.shadow.visible = true;
       group.visible = placedOnce;
+      if (placedOnce) {
+        group.position.copy(placedPos);
+        group.quaternion.copy(placedQuat);
+      }
       if (frame && !placedOnce) {
         const refSpace = renderer.xr.getReferenceSpace();
         const results = frame.getHitTestResults(hitSource);
@@ -447,28 +459,36 @@ async function startArSession(
       // through the eye at distance 0. There "face the viewer" has no direction: lookAt gets a
       // zero-length vector and atan2(0, 0) collapses to yaw 0, either of which would spin the clip
       // as it crossed over. Hold the orientation through that neighbourhood instead.
-      const facing = group.position.distanceTo(camPos) > 1e-3;
-      if (facing) {
-        // Upright is the floor of the blend, full face-on the ceiling, and Tilt slides between
-        // them. Building both and slerping is what makes the intermediate angles available at
-        // all — lookAt alone only ever gives the fully face-on end.
-        const yaw = Math.atan2(camPos.x - group.position.x, camPos.z - group.position.z);
-        targetQuat.setFromEuler(billboardEuler.set(0, yaw, 0));
-        // Settings restored from localStorage can predate this field entirely, and `undefined > 0`
-        // is false — which would quietly pin every saved hologram to upright. Default, then clamp.
-        const tilt = Number.isFinite(s.followTilt)
-          ? Math.min(Math.max(s.followTilt, 0), 1)
-          : DEFAULT_AR_SETTINGS.followTilt;
-        if (s.lockMode === "follow" && tilt > 0) {
-          billboard.position.copy(group.position);
-          billboard.lookAt(camPos); // +Z is the quad's normal
-          targetQuat.slerp(billboard.quaternion, tilt);
-        }
+      // Two independent degeneracies, and they do NOT coincide — which is why one distance check
+      // cannot guard both. At Distance 0 the clip shares your x/z, so the yaw bearing is
+      // undefined (atan2(0,0) silently returns 0, snapping it to an arbitrary world heading) while
+      // the 3D separation is still non-zero thanks to the height offset. lookAt fails on the
+      // second, not the first. Guard each on its own measure and hold the last good orientation.
+      const dx = camPos.x - group.position.x;
+      const dz = camPos.z - group.position.z;
+      const horizontal = Math.hypot(dx, dz);
+      let haveTarget = false;
+      if (horizontal > 1e-3) {
+        // Upright is the floor of the blend, full face-on the ceiling, Tilt slides between them.
+        targetQuat.setFromEuler(billboardEuler.set(0, Math.atan2(dx, dz), 0));
+        haveTarget = true;
+      }
+      // Settings restored from localStorage can predate this field entirely, and `undefined > 0`
+      // is false — which would quietly pin every saved hologram to upright. Default, then clamp.
+      const tilt = Number.isFinite(s.followTilt)
+        ? Math.min(Math.max(s.followTilt, 0), 1)
+        : DEFAULT_AR_SETTINGS.followTilt;
+      if (s.lockMode === "follow" && tilt > 0 && group.position.distanceTo(camPos) > 1e-3) {
+        billboard.position.copy(group.position);
+        billboard.lookAt(camPos); // +Z is the quad's normal
+        if (haveTarget) targetQuat.slerp(billboard.quaternion, tilt);
+        else targetQuat.copy(billboard.quaternion);
+        haveTarget = true;
       }
       if (snapNext) {
-        if (facing) group.quaternion.copy(targetQuat);
+        if (haveTarget) group.quaternion.copy(targetQuat);
         snapNext = false;
-      } else if (facing) {
+      } else if (haveTarget) {
         group.quaternion.slerp(targetQuat, smoothing(s.followTightness, dt));
       }
     }
@@ -631,13 +651,14 @@ function TuningPanel({
           {showLock && isFollow && (
             <>
               <Slider
-                // Goes negative on purpose: the target is eye + forward x distance, so a negative
-                // value projects backwards along the gaze. Looking down, that pulls the clip back
-                // through your own body — the first-person framing where it lines up with your
-                // chest and hips instead of floating out in front of you.
+                // Floors at 0, not below. A negative distance anchors the clip BEHIND the gaze
+                // ray, so turning to look at it rotates the target away by the same amount — it is
+                // unreachable by construction, and the damping renders that as an endless spin.
+                // 0 is the useful end of the range: the clip sits at your own position, which with
+                // a negative Height is the chest/hips framing without any chase.
                 label="Distance"
                 value={settings.followDistance}
-                min={-1}
+                min={0}
                 max={4}
                 step={0.05}
                 unit=" m"


### PR DESCRIPTION
Two regressions from the follow work, reported from the headset.

## 1. Placed mode stopped working

The placed branch wrote the pose **once**, in the `select` handler, and never again. A follow mode
overwrites `group.position` and `.quaternion` every frame — so switching back to `placed` left the
clip stranded wherever follow abandoned it, mid-air, never returning to the spot that was tapped.

Placement now records the pose, and the placed branch restores it each frame. "Frozen in the room"
has to be actively maintained once something else is allowed to move the group.

## 2. Negative Distance — reverted, my design error

Not a slip that can be patched. The target is `eye + forward × distance`, so a negative value
anchors the clip **behind the gaze ray**. Turning to look at it rotates the target away by exactly
the same amount: it is unreachable *by construction*, and the damping renders that as the endless
spin reported. No tuning fixes an anchor you cannot face.

I proposed this without working through what a negative value does to a gaze-relative anchor. The
floor is back to `0`.

**Distance 0 remains reachable and is the useful end of that range** — the clip occupies your own
position, which with a negative Height gives the chest/hips framing with no chase.

### A second degeneracy that exposed

The previous single distance check could not guard both failure modes, because **they do not
coincide**:

| At Distance 0 | |
|---|---|
| Horizontal separation | **0** → `atan2(0,0)` returns 0, snapping the clip to an arbitrary world heading |
| 3D separation | **non-zero** (the height offset) → `lookAt` is still perfectly valid |

One check on 3D distance passes while the yaw path is silently broken. Each is now guarded on its
own measure, holding the last good orientation instead.

## Verification

`npm run build` · `eslint` clean · `vitest` 102/102 (the negative-distance test is replaced by one
pinning Distance 0 to the viewer's own x/z, and noting why that point is degenerate for yaw).

**Still not addressed:** the chest/hips framing you actually asked for. Distance 0 plus a negative
Height approximates it, but a clip that takes *your heading* rather than turning to face you is
probably the real answer — noted, not built.