### PR TITLE
Filter video presets to a group

### DIFF
--- a/src/lib/presetGroups.test.ts
+++ b/src/lib/presetGroups.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { UNGROUPED, collectGroups, filterByGroups, groupOf } from "./presetGroups";
+
+const p = (name: string) => ({ name });
+
+describe("groupOf", () => {
+  it("takes the text before the first spaced hyphen", () => {
+    expect(groupOf("Final - Doggystyle (front facing)")).toBe("Final");
+    expect(groupOf("Final - Doggystyle - front")).toBe("Final");
+  });
+
+  it("ignores hyphens that are not the separator", () => {
+    // "Wan-2.2 base" is one name. Matching a bare hyphen would invent a "Wan" group.
+    expect(groupOf("Wan-2.2 base")).toBeNull();
+    expect(groupOf("k3llydw")).toBeNull();
+  });
+
+  it("has no group when the name starts with the separator", () => {
+    expect(groupOf(" - orphan")).toBeNull();
+  });
+});
+
+describe("collectGroups", () => {
+  it("lists each group once, alphabetically", () => {
+    expect(collectGroups([p("Test - b"), p("Final - a"), p("Final - c")])).toEqual([
+      "Final",
+      "Test",
+    ]);
+  });
+
+  it("treats groups case-insensitively, keeping the first spelling", () => {
+    expect(collectGroups([p("Final - a"), p("final - b")])).toEqual(["Final"]);
+  });
+
+  it("adds Ungrouped last, and only when something is ungrouped", () => {
+    expect(collectGroups([p("Final - a"), p("k3llydw")])).toEqual(["Final", UNGROUPED]);
+    expect(collectGroups([p("Final - a")])).toEqual(["Final"]);
+  });
+
+  it("derives from whatever list it is given — which is how it follows the archived toggle", () => {
+    const all = [p("Final - a"), p("Retired - b")];
+    expect(collectGroups(all)).toEqual(["Final", "Retired"]);
+    expect(collectGroups(all.slice(0, 1))).toEqual(["Final"]);
+  });
+});
+
+describe("filterByGroups", () => {
+  const presets = [p("Final - a"), p("Test - b"), p("k3llydw")];
+
+  it("shows everything when no pill is selected", () => {
+    expect(filterByGroups(presets, new Set())).toEqual(presets);
+  });
+
+  it("narrows to one group", () => {
+    expect(filterByGroups(presets, new Set(["Final"])).map((x) => x.name)).toEqual(["Final - a"]);
+  });
+
+  it("unions multiple selected groups", () => {
+    expect(filterByGroups(presets, new Set(["Final", "Test"])).map((x) => x.name)).toEqual([
+      "Final - a",
+      "Test - b",
+    ]);
+  });
+
+  it("selects the ungrouped presets via the Ungrouped pill", () => {
+    expect(filterByGroups(presets, new Set([UNGROUPED])).map((x) => x.name)).toEqual(["k3llydw"]);
+  });
+
+  it("matches the pill against the name case-insensitively", () => {
+    expect(filterByGroups([p("final - a")], new Set(["Final"]))).toHaveLength(1);
+  });
+});

--- a/src/lib/presetGroups.ts
+++ b/src/lib/presetGroups.ts
@@ -1,0 +1,69 @@
+/**
+ * Preset "groups", derived from the name rather than stored.
+ *
+ * Presets are named `<GROUP> - <DESCRIPTION>` by hand ("Final - Doggystyle (front facing)"), so
+ * the grouping already exists in the library — it is just not addressable. Reading it back out of
+ * the name means no schema column, no migration, and no second place to keep in sync: renaming a
+ * preset regroups it. The cost is that the convention is only a convention, which is why anything
+ * without the separator stays visible under UNGROUPED instead of silently disappearing.
+ */
+
+/** The separator is the SPACED hyphen. "Wan-2.2 base" is one name, not group "Wan" — hyphens
+ *  inside a word are common enough that matching a bare "-" would invent groups nobody meant. */
+const SEPARATOR = " - ";
+
+/** Bucket for presets that do not follow the naming convention. Not a group anyone typed, so it
+ *  only ever appears as a pill when something actually falls into it. */
+export const UNGROUPED = "Ungrouped";
+
+export interface NamedPreset {
+  name: string;
+}
+
+/** The group a preset name declares, or null if it declares none.
+ *
+ *  Split on the FIRST separator: "Final - Doggystyle - front" is group "Final", because the
+ *  description is free text and may well contain another spaced hyphen. */
+export function groupOf(name: string): string | null {
+  const i = name.indexOf(SEPARATOR);
+  if (i <= 0) return null;
+  return name.slice(0, i).trim() || null;
+}
+
+/**
+ * Every group present in `presets`, alphabetically, with UNGROUPED last if it is occupied.
+ *
+ * Derived from whatever list is passed in — which is how the pills end up respecting the "show
+ * archived" toggle without knowing it exists: pass the archived-included list and archived-only
+ * groups appear; pass the active list and they do not.
+ *
+ * Matching is case-insensitive so "final - a" and "Final - b" are one pill rather than two; the
+ * first spelling encountered is the one shown.
+ */
+export function collectGroups(presets: NamedPreset[]): string[] {
+  const seen = new Map<string, string>();
+  let hasUngrouped = false;
+  for (const p of presets) {
+    const g = groupOf(p.name);
+    if (!g) {
+      hasUngrouped = true;
+      continue;
+    }
+    const key = g.toLowerCase();
+    if (!seen.has(key)) seen.set(key, g);
+  }
+  const groups = [...seen.values()].sort((a, b) => a.localeCompare(b));
+  return hasUngrouped ? [...groups, UNGROUPED] : groups;
+}
+
+/**
+ * The presets to show for a pill selection.
+ *
+ * No selection means no filter — the pills are a way to narrow the library, not a gate in front
+ * of it. Multiple selected pills union, so two groups can be compared side by side.
+ */
+export function filterByGroups<T extends NamedPreset>(presets: T[], selected: Set<string>): T[] {
+  if (selected.size === 0) return presets;
+  const wanted = new Set([...selected].map((g) => g.toLowerCase()));
+  return presets.filter((p) => wanted.has((groupOf(p.name) ?? UNGROUPED).toLowerCase()));
+}

--- a/src/pages/VideoPresetLibrary.tsx
+++ b/src/pages/VideoPresetLibrary.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Box,
   Typography,
   Button,
   Card,
   CardContent,
+  Chip,
   IconButton,
   Dialog,
   DialogTitle,
@@ -27,6 +28,7 @@ import type { VideoSettingsPreset, VideoSettingsPresetCreate, LoraListItem } fro
 import { MAX_LORAS } from "../constants";
 import SettingsSignature, { parseSignature, SIG_COLS } from "../components/SettingsSignature";
 import SettingsSignatureInputs from "../components/SettingsSignatureInputs";
+import { collectGroups, filterByGroups } from "../lib/presetGroups";
 
 type LoraSlot = { lora_id: string; name: string; high_weight: number; low_weight: number; preview_image: string | null };
 
@@ -80,11 +82,29 @@ export default function VideoPresetLibrary() {
   const [deleteConfirm, setDeleteConfirm] = useState<VideoSettingsPreset | null>(null);
   const [showArchived, setShowArchived] = useState(false);
   const [rowError, setRowError] = useState<string | null>(null);
+  const [selectedGroups, setSelectedGroups] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     fetchPresets();
     fetchLoras();
   }, [fetchPresets, fetchLoras]);
+
+  const visible = showArchived ? allPresets : presets;
+  const groups = useMemo(() => collectGroups(visible), [visible]);
+  // Intersected with what is actually on offer, so a pill selected while "show archived" was on
+  // does not survive the toggle and leave the grid mysteriously empty.
+  const activeGroups = useMemo(
+    () => new Set(groups.filter((g) => selectedGroups.has(g))),
+    [groups, selectedGroups],
+  );
+  const shown = useMemo(() => filterByGroups(visible, activeGroups), [visible, activeGroups]);
+
+  const toggleGroup = (g: string) =>
+    setSelectedGroups((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(g)) next.add(g);
+      return next;
+    });
 
   const loadLoraSlots = (p: VideoSettingsPreset | null) =>
     setLoraSlots(
@@ -236,11 +256,31 @@ export default function VideoPresetLibrary() {
           {rowError}
         </Alert>
       )}
+      {!loading && groups.length > 0 && (
+        <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 1, mb: 2 }}>
+          {groups.map((g) => (
+            <Chip
+              key={g}
+              label={g}
+              size="small"
+              onClick={() => toggleGroup(g)}
+              color={activeGroups.has(g) ? "primary" : "default"}
+              variant={activeGroups.has(g) ? "filled" : "outlined"}
+              sx={{ cursor: "pointer" }}
+            />
+          ))}
+          {activeGroups.size > 0 && (
+            <Button size="small" onClick={() => setSelectedGroups(new Set())}>
+              Clear
+            </Button>
+          )}
+        </Box>
+      )}
       {loading ? (
         <CircularProgress />
       ) : (
         <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-          {(showArchived ? allPresets : presets).map((p) => (
+          {shown.map((p) => (
             <Card key={p.id} sx={{ width: 340, opacity: p.archived ? 0.55 : 1 }}>
               <CardContent>
                 <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
@@ -282,8 +322,10 @@ export default function VideoPresetLibrary() {
               </CardContent>
             </Card>
           ))}
-          {presets.length === 0 && (
-            <Typography color="text.secondary" sx={{ p: 2 }}>No presets yet.</Typography>
+          {shown.length === 0 && (
+            <Typography color="text.secondary" sx={{ p: 2 }}>
+              {visible.length === 0 ? "No presets yet." : "No presets in the selected groups."}
+            </Typography>
           )}
         </Box>
       )}


### PR DESCRIPTION
Closes #329

Groups across the top of the Video Presets page as click on/off pills, derived from the `<GROUP> - <DESCRIPTION>` naming convention already in use.

- **Derived, not stored** — the group is read from the name, so there is no column to migrate and no second place to keep in sync; renaming a preset regroups it. Split on the first *spaced* hyphen, so `Wan-2.2 base` is one name rather than a `Wan` group.
- **Respects the archived toggle** — the pill list is built from whatever list is on screen, so archived-only groups appear only when archived presets do.
- **Selection is pruned to the pills on offer** — otherwise a group picked while archived presets were shown would survive the toggle and leave the grid empty with no visible cause.
- **Multiple pills union**, none selected means no filter, and a Clear button appears once something is selected.
- **`Ungrouped` pill** for presets that do not follow the convention, so they are reachable instead of only visible in the unfiltered view.
- Fixed the empty-state message alongside: it was keyed to the *active* preset list, so it stayed hidden when an archived-only (and now group-filtered) result set was empty.

Parsing/filtering lives in `src/lib/presetGroups.ts` with 12 tests.

## Verification
- `npm run build` — green
- `npm test` — 114 passed (9 files)
- `npm run lint` — 4 errors, all pre-existing in files this branch does not touch