### PR TITLE
Reorder the main nav, indent the sub-nav

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,21 +22,25 @@ import {
   Casino,
 } from "@mui/icons-material";
 import { useNavigate, useLocation } from "react-router";
+import type { ReactNode } from "react";
 
 export const DRAWER_WIDTH = 220;
 
-const NAV_ITEMS = [
+/** `sub: true` indents an item under the top-level entry above it. The parents (Videos,
+ *  Settings) are real pages in their own right, so this is presentation only — every row still
+ *  navigates, and there is nothing to expand or collapse. */
+const NAV_ITEMS: { label: string; icon: ReactNode; path: string; sub?: boolean }[] = [
   { label: "Dashboard", icon: <DashboardIcon />, path: "/" },
   { label: "Job Queue", icon: <QueueMusic />, path: "/jobs" },
-  { label: "Successful Configs", icon: <Star />, path: "/configs" },
   { label: "Workers", icon: <Dns />, path: "/workers" },
   { label: "Videos", icon: <VideoLibrary />, path: "/videos" },
-  { label: "Smashcut", icon: <Movie />, path: "/smashcut" },
-  { label: "LoRA Library", icon: <AutoFixHigh />, path: "/loras" },
-  { label: "Video Presets", icon: <Tune />, path: "/video-presets" },
-  { label: "Wildcards", icon: <Casino />, path: "/wildcards" },
+  { label: "Smashcut", icon: <Movie />, path: "/smashcut", sub: true },
   { label: "Image Repo", icon: <Image />, path: "/images" },
   { label: "Settings", icon: <Settings />, path: "/settings" },
+  { label: "LoRA Library", icon: <AutoFixHigh />, path: "/loras", sub: true },
+  { label: "Video Presets", icon: <Tune />, path: "/video-presets", sub: true },
+  { label: "Wildcards", icon: <Casino />, path: "/wildcards", sub: true },
+  { label: "Configurations", icon: <Star />, path: "/configs", sub: true },
 ];
 
 interface SidebarProps {
@@ -76,6 +80,7 @@ export default function Sidebar({ mobileOpen, onClose }: SidebarProps) {
                 mx: 1,
                 borderRadius: 2,
                 mb: 0.5,
+                pl: item.sub ? 3 : 2,
                 color: "rgba(255,255,255,0.6)",
                 "&.Mui-selected": {
                   bgcolor: "rgba(255,255,255,0.08)",
@@ -85,12 +90,21 @@ export default function Sidebar({ mobileOpen, onClose }: SidebarProps) {
                 "&:hover": { bgcolor: "rgba(255,255,255,0.06)" },
               }}
             >
-              <ListItemIcon sx={{ color: "inherit", minWidth: 40 }}>
+              <ListItemIcon
+                sx={{
+                  color: "inherit",
+                  minWidth: item.sub ? 32 : 40,
+                  "& .MuiSvgIcon-root": { fontSize: item.sub ? 19 : 24 },
+                }}
+              >
                 {item.icon}
               </ListItemIcon>
               <ListItemText
                 primary={item.label}
-                primaryTypographyProps={{ fontSize: 14, fontWeight: 500 }}
+                primaryTypographyProps={{
+                  fontSize: item.sub ? 13 : 14,
+                  fontWeight: item.sub ? 400 : 500,
+                }}
               />
             </ListItemButton>
           ))}

--- a/src/pages/SuccessfulConfigs.tsx
+++ b/src/pages/SuccessfulConfigs.tsx
@@ -111,7 +111,7 @@ export default function SuccessfulConfigs() {
     <Box>
       <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 3 }}>
         <Star color="warning" />
-        <Typography variant="h5">Successful Configs</Typography>
+        <Typography variant="h5">Configurations</Typography>
       </Stack>
 
       {loading ? (


### PR DESCRIPTION
Closes #331

```
Dashboard
Job Queue
Workers
Videos
  Smashcut
Image Repo
Settings
  LoRA Library
  Video Presets
  Wildcards
  Configurations
```

- **Indentation is presentation only.** `sub: true` on a nav item shifts the row, shrinks the icon and drops the label to regular weight. Videos and Settings are real pages in their own right, so every row still navigates and there is nothing to expand or collapse — no new state, no route changes.
- **Successful Configs → Configurations**, in the nav and in the page heading. The `/configs` route is untouched, so any existing link or bookmark still resolves.
- **Video Presets** isn't in the issue's list, but the page is live (we shipped the group filter to it in #330), so dropping it would leave it reachable only by typing the URL. Parked with the other library/config pages under Settings — confirmed with David before coding.

## Verification
- `npm run build` — green
- `npm test` — 114 passed (9 files)
- `npm run lint` — 4 errors, all pre-existing in files this branch does not touch