### PR TITLE
Drop the motion_keywords type

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -183,7 +183,6 @@ export interface SegmentResponse {
   transition: string | null;
   trim_start_frames: number;
   trim_end_frames: number;
-  motion_keywords: string[] | null;
   motion_magnitude: number | null;
   identity_mean_cos: number | null;
   identity_mean_cos_ref: number | null;


### PR DESCRIPTION
Closes #285

Last trace of the prompt-injection path removed in **wanly-gpu-daemon#141** (the injection) and **wanly-api#191** (the column and the transport).

The field was only ever *declared* in `src/api/types.ts` — nothing in the console rendered it — so this is a one-line type removal with no UI change.

Background for the issue: the daemon logged `Motion detected: walking, dancing, falling` for clips containing none of that, because nothing was detecting anything. It substring-matched the **prompt** ("move" → dancing, "pace" → walking), then the API handed those keywords to the next segment and the daemon appended canned phrases and **replaced the prompt** before generating. That path is now gone end to end; the prompt written is the prompt that runs.

## Verification
- `npm run build` — green
- `npm test` — 114 passed
- `grep -rn motion_keywords src/` — no matches