### PR TITLE
Image repo: tag pills that AND, with counts

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -30,6 +30,7 @@ import type {
   ImageFile,
   ImageJobInfo,
   ImageSearchResponse,
+  ImageTagCount,
   FavoriteToggleRequest,
   SegmentClip,
   SmashcutBody,
@@ -38,6 +39,7 @@ import type {
   AppSettingsResponse,
   AppSettingsUpdate,
 } from "./types";
+import { REPEAT_ARRAY_PARAMS } from "../lib/repeatArrayParams";
 import { LOCAL_STORAGE_TOKEN_KEY } from "../constants";
 
 const API_URL = import.meta.env.VITE_API_URL || "/api";
@@ -454,12 +456,31 @@ export async function updateImageTags(path: string, tags: string | null): Promis
 }
 
 export async function searchImages(params: {
-  q: string;
+  q?: string;
+  tags?: string[];
+  exclude?: string[];
   limit?: number;
   offset?: number;
 }): Promise<ImageSearchResponse> {
-  const { data } = await api.get<ImageSearchResponse>("/images/search", { params });
+  const { data } = await api.get<ImageSearchResponse>("/images/search", {
+    params,
+    ...REPEAT_ARRAY_PARAMS,
+  });
   return data;
+}
+
+/** Every tag in use with how many images carry it UNDER THE GIVEN FILTER — so the pills can show
+ *  what exists inside the current result set rather than offering dead ends. */
+export async function getImageTagCounts(params: {
+  q?: string;
+  tags?: string[];
+  exclude?: string[];
+}): Promise<ImageTagCount[]> {
+  const { data } = await api.get<{ items: ImageTagCount[] }>("/images/tag-counts", {
+    params,
+    ...REPEAT_ARRAY_PARAMS,
+  });
+  return data.items;
 }
 
 export async function uploadImage(file: File, folder: string): Promise<{ path: string }> {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -511,6 +511,11 @@ export interface ImageFile {
   tags: string | null;
 }
 
+export interface ImageTagCount {
+  tag: string;
+  count: number;
+}
+
 export interface ImageSearchResponse {
   items: ImageFile[];
   total: number;

--- a/src/components/ImageTagFilter.tsx
+++ b/src/components/ImageTagFilter.tsx
@@ -1,0 +1,59 @@
+import { Box, Button, Chip, Typography } from "@mui/material";
+import type { ImageTagCount } from "../api/types";
+import { isTagSelected } from "../lib/imageFilter";
+
+interface Props {
+  counts: ImageTagCount[];
+  selected: string[];
+  onToggle: (tag: string) => void;
+  onClear: () => void;
+}
+
+/**
+ * The tag pills above the image grid. Clicking narrows; every selection ANDs.
+ *
+ * Counts come from the API scoped to the CURRENT filter, which is what makes this navigable
+ * rather than a guessing game: with Kelly selected, the pills left standing are the tags that
+ * actually co-occur with Kelly, and a combination with nothing in it simply is not offered. A
+ * selected tag always survives that filter (its count is the result count), so it can be clicked
+ * off again.
+ *
+ * The list is what is USED, not the title_tags vocabulary. Production has drifted -- kellyteacher
+ * is on 76 images and is not in the vocabulary -- and pills built from the vocabulary would
+ * strand them. It also puts the fat-fingers ("pusy", "cowgirlowgirl", one image each) on screen
+ * with their counts, which is the only way they will ever get cleaned up.
+ */
+export default function ImageTagFilter({ counts, selected, onToggle, onClear }: Props) {
+  if (counts.length === 0 && selected.length === 0) return null;
+
+  return (
+    <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 0.75, mb: 2 }}>
+      {counts.map(({ tag, count }) => {
+        const on = isTagSelected(selected, tag);
+        return (
+          <Chip
+            key={tag}
+            size="small"
+            label={
+              <Box component="span" sx={{ display: "inline-flex", gap: 0.5 }}>
+                <span>{tag}</span>
+                <Typography component="span" variant="caption" sx={{ opacity: 0.7 }}>
+                  {count}
+                </Typography>
+              </Box>
+            }
+            onClick={() => onToggle(tag)}
+            color={on ? "primary" : "default"}
+            variant={on ? "filled" : "outlined"}
+            sx={{ cursor: "pointer" }}
+          />
+        );
+      })}
+      {selected.length > 0 && (
+        <Button size="small" onClick={onClear}>
+          Clear
+        </Button>
+      )}
+    </Box>
+  );
+}

--- a/src/lib/imageFilter.test.ts
+++ b/src/lib/imageFilter.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import {
+  describeFilter,
+  hasFilter,
+  isTagSelected,
+  parseTagParam,
+  serializeTagParam,
+  toggleTag,
+} from "./imageFilter";
+
+describe("parseTagParam", () => {
+  it("splits on commas and trims", () => {
+    expect(parseTagParam("Kelly, Missionary")).toEqual(["Kelly", "Missionary"]);
+  });
+
+  it("drops empty segments rather than sending blank tags", () => {
+    // The API rejects a filter that filters nothing, and ",,Kelly," is easy to produce by
+    // hand-editing the URL.
+    expect(parseTagParam(",,Kelly,")).toEqual(["Kelly"]);
+    expect(parseTagParam("")).toEqual([]);
+    expect(parseTagParam(null)).toEqual([]);
+  });
+
+  it("de-duplicates case-insensitively, keeping the first spelling", () => {
+    expect(parseTagParam("Kelly,kelly")).toEqual(["Kelly"]);
+  });
+});
+
+describe("serializeTagParam", () => {
+  it("joins with commas", () => {
+    expect(serializeTagParam(["Kelly", "Missionary"])).toBe("Kelly,Missionary");
+  });
+
+  it("returns null for an empty selection so the param is dropped", () => {
+    expect(serializeTagParam([])).toBeNull();
+    expect(serializeTagParam(["  "])).toBeNull();
+  });
+});
+
+describe("toggleTag", () => {
+  it("adds then removes", () => {
+    expect(toggleTag([], "Kelly")).toEqual(["Kelly"]);
+    expect(toggleTag(["Kelly"], "Kelly")).toEqual([]);
+  });
+
+  it("matches case-insensitively so a tag cannot be selected twice", () => {
+    expect(toggleTag(["Kelly"], "kelly")).toEqual([]);
+  });
+
+  it("keeps the other tags in order", () => {
+    expect(toggleTag(["Kelly", "Missionary"], "Kelly")).toEqual(["Missionary"]);
+  });
+});
+
+describe("isTagSelected", () => {
+  it("is case-insensitive", () => {
+    expect(isTagSelected(["Kelly"], "kelly")).toBe(true);
+    expect(isTagSelected(["Kelly"], "KellyYoung")).toBe(false);
+  });
+});
+
+describe("hasFilter", () => {
+  it("is true for either control and false for neither", () => {
+    expect(hasFilter("", [])).toBe(false);
+    expect(hasFilter("   ", [])).toBe(false);
+    expect(hasFilter("00111", [])).toBe(true);
+    expect(hasFilter("", ["Kelly"])).toBe(true);
+  });
+});
+
+describe("describeFilter", () => {
+  it("names both controls, tags first", () => {
+    expect(describeFilter("00111", ["Kelly", "Missionary"])).toBe('Kelly + Missionary + "00111"');
+    expect(describeFilter("", ["Kelly"])).toBe("Kelly");
+    expect(describeFilter("00111", [])).toBe('"00111"');
+  });
+});

--- a/src/lib/imageFilter.ts
+++ b/src/lib/imageFilter.ts
@@ -1,0 +1,60 @@
+/**
+ * The image-repo filter: a filename fragment and a set of whole tags, all ANDed.
+ *
+ * Two controls with two different jobs. Tags match in full — measured on production, a substring
+ * search for "kelly" returned 74% of the repo because it also caught KellyYoung, KellyBangs and
+ * KellyTeacher — while the text box matches the filename as a fragment, which is right there and
+ * is the only way to find an untagged image.
+ *
+ * The selection lives in the URL (?tags=Kelly,Missionary) like the rest of this page's browsing
+ * state, so back/forward and a refresh keep it, and a filtered view can be pasted to yourself.
+ */
+
+/** Tags are comma-joined in the URL. Empty segments are dropped rather than sent as blank tags,
+ *  which the API would reject as a filter that filters nothing. */
+export function parseTagParam(raw: string | null): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const part of raw.split(",")) {
+    const tag = part.trim();
+    if (!tag) continue;
+    const key = tag.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(tag);
+  }
+  return out;
+}
+
+/** Back to a URL value, or null to drop the param entirely when nothing is selected. */
+export function serializeTagParam(tags: string[]): string | null {
+  const cleaned = tags.map((t) => t.trim()).filter(Boolean);
+  return cleaned.length ? cleaned.join(",") : null;
+}
+
+/** Add or remove one tag, comparing case-insensitively so a pill cannot be selected twice under
+ *  two spellings. */
+export function toggleTag(tags: string[], tag: string): string[] {
+  const key = tag.toLowerCase();
+  return tags.some((t) => t.toLowerCase() === key)
+    ? tags.filter((t) => t.toLowerCase() !== key)
+    : [...tags, tag];
+}
+
+export function isTagSelected(tags: string[], tag: string): boolean {
+  const key = tag.toLowerCase();
+  return tags.some((t) => t.toLowerCase() === key);
+}
+
+/** Is anything filtering? Drives whether the page shows results or the folder listing. */
+export function hasFilter(q: string, tags: string[]): boolean {
+  return q.trim().length > 0 || tags.length > 0;
+}
+
+/** How to name the current filter in an empty state, so "no results" says what found nothing. */
+export function describeFilter(q: string, tags: string[]): string {
+  const parts = [...tags];
+  if (q.trim()) parts.push(`"${q.trim()}"`);
+  return parts.join(" + ");
+}

--- a/src/lib/repeatArrayParams.test.ts
+++ b/src/lib/repeatArrayParams.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import axios from "axios";
+import { REPEAT_ARRAY_PARAMS } from "./repeatArrayParams";
+
+describe("REPEAT_ARRAY_PARAMS", () => {
+  const uri = (params: Record<string, unknown>) =>
+    axios.create().getUri({ url: "/images/search", params, ...REPEAT_ARRAY_PARAMS });
+
+  it("repeats the key instead of using the bracket form", () => {
+    // FastAPI reads tags=a&tags=b into a list; tags[]=a is a parameter it does not have, so the
+    // filter would be dropped and the search would return everything.
+    expect(uri({ tags: ["Kelly", "Missionary"] })).toBe(
+      "/images/search?tags=Kelly&tags=Missionary",
+    );
+  });
+
+  it("leaves scalars alone", () => {
+    expect(uri({ q: "00111", limit: 50 })).toBe("/images/search?q=00111&limit=50");
+  });
+
+  it("omits undefined params, so an empty control does not filter", () => {
+    expect(uri({ q: undefined, tags: ["Kelly"] })).toBe("/images/search?tags=Kelly");
+  });
+});

--- a/src/lib/repeatArrayParams.ts
+++ b/src/lib/repeatArrayParams.ts
@@ -1,0 +1,11 @@
+/**
+ * Axios request options that serialise array params as REPEATED KEYS: `tags=a&tags=b`.
+ *
+ * FastAPI reads a repeated key into a list. Axios' default is the bracket form (`tags[]=a`),
+ * which arrives as a parameter named "tags[]" that the endpoint does not have -- so the filter
+ * would be silently dropped and the search would quietly return everything instead of failing.
+ *
+ * Lives here rather than inline in the client so the serialisation can be asserted without
+ * importing api/client, whose import-time interceptors assign window.location on a 401.
+ */
+export const REPEAT_ARRAY_PARAMS = { paramsSerializer: { indexes: null as null } };

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import {
   Box,
   Typography,
@@ -64,12 +64,21 @@ import {
   getUntaggedImages,
   updateImageTags,
   searchImages,
+  getImageTagCounts,
 } from "../api/client";
-import type { ImageFolder, ImageFile, ImageJobInfo } from "../api/types";
+import type { ImageFolder, ImageFile, ImageJobInfo, ImageTagCount } from "../api/types";
 import CreateJobDialog from "../components/CreateJobDialog";
 import CropResizeDialog from "../components/CropResizeDialog";
 import FavoriteHeart from "../components/FavoriteHeart";
 import { useTagStore } from "../stores/tagStore";
+import ImageTagFilter from "../components/ImageTagFilter";
+import {
+  describeFilter,
+  hasFilter,
+  parseTagParam,
+  serializeTagParam,
+  toggleTag,
+} from "../lib/imageFilter";
 import { useQueryState, getPage, pageValue, getPerPage, perPageValue } from "../hooks/useQueryState";
 
 const FOLDER_ROWS_OPTIONS = [12, 24, 48];
@@ -133,6 +142,7 @@ export default function ImageRepo() {
   const [lightboxTags, setLightboxTags] = useState("");
   const tagSaveTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const [searchResults, setSearchResults] = useState<ImageFile[]>([]);
+  const [tagCounts, setTagCounts] = useState<ImageTagCount[]>([]);
   const [searchTotal, setSearchTotal] = useState(0);
   const [searchLoading, setSearchLoading] = useState(false);
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -164,6 +174,18 @@ export default function ImageRepo() {
   // every keystroke.
   const debouncedSearch = params.get("q") ?? "";
   const [searchQuery, setSearchQuery] = useState(debouncedSearch);
+  // Tag selection is URL state too (?tags=Kelly,Missionary), so a filtered view survives
+  // navigation, back/forward and a refresh exactly like the folder and page params do.
+  const tagsParam = params.get("tags");
+  const selectedTags = useMemo(() => parseTagParam(tagsParam), [tagsParam]);
+  // "Is anything filtering?" — the page shows results when it is true and the folder listing
+  // when it is not. Previously this was just "is the search box non-empty".
+  const filterActive = hasFilter(debouncedSearch, selectedTags);
+  const filterLabel = describeFilter(debouncedSearch, selectedTags);
+  const setSelectedTags = useCallback(
+    (next: string[]) => setQuery({ tags: serializeTagParam(next), spage: null }),
+    [setQuery],
+  );
 
   // Scroll the main scroll container to the top on any pagination change
   // (folders, in-folder images, AND search results).
@@ -226,13 +248,13 @@ export default function ImageRepo() {
   // Same "clamp back into range" guard as the folder list, for search results
   // (whose pagination control only renders when the page has results).
   useEffect(() => {
-    if (!debouncedSearch || searchTotal === 0) return;
+    if (!filterActive || searchTotal === 0) return;
     const maxPage = Math.max(0, Math.ceil(searchTotal / searchRowsPerPage) - 1);
     if (searchPage > maxPage) setQuery({ spage: pageValue(maxPage) });
-  }, [debouncedSearch, searchTotal, searchRowsPerPage, searchPage, setQuery]);
+  }, [filterActive, searchTotal, searchRowsPerPage, searchPage, setQuery]);
 
   const fetchSearchResults = useCallback(async () => {
-    if (!debouncedSearch) {
+    if (!filterActive) {
       setSearchResults([]);
       setSearchTotal(0);
       return;
@@ -240,7 +262,8 @@ export default function ImageRepo() {
     setSearchLoading(true);
     try {
       const res = await searchImages({
-        q: debouncedSearch,
+        q: debouncedSearch || undefined,
+        tags: selectedTags.length ? selectedTags : undefined,
         limit: searchRowsPerPage,
         offset: searchPage * searchRowsPerPage,
       });
@@ -251,11 +274,31 @@ export default function ImageRepo() {
     } finally {
       setSearchLoading(false);
     }
-  }, [debouncedSearch, searchPage, searchRowsPerPage]);
+  }, [filterActive, debouncedSearch, selectedTags, searchPage, searchRowsPerPage]);
+
+  // Counts are re-fetched with the filter, not once on mount: they are scoped to the current
+  // result set, which is the whole point — after clicking Kelly the remaining pills show what
+  // co-occurs with Kelly, so a dead end is visible before it is clicked.
+  const fetchTagCounts = useCallback(async () => {
+    try {
+      setTagCounts(
+        await getImageTagCounts({
+          q: debouncedSearch || undefined,
+          tags: selectedTags.length ? selectedTags : undefined,
+        }),
+      );
+    } catch {
+      // A failed census leaves the previous pills up rather than emptying the bar.
+    }
+  }, [debouncedSearch, selectedTags]);
 
   useEffect(() => {
     fetchSearchResults();
   }, [fetchSearchResults]);
+
+  useEffect(() => {
+    fetchTagCounts();
+  }, [fetchTagCounts]);
 
   const fetchFavorites = useCallback(async () => {
     try {
@@ -1160,13 +1203,13 @@ export default function ImageRepo() {
           >
             {isMobile ? "Untag" : "Untagged"}
           </Button>
-          {(favoritesView && favImages.length > 0) || (debouncedSearch && searchResults.length > 0) ? (
+          {(favoritesView && favImages.length > 0) || (filterActive && searchResults.length > 0) ? (
             <Button
               variant="outlined"
               startIcon={isMobile ? undefined : <PlayArrow />}
               size={isMobile ? "small" : "medium"}
               onClick={() => {
-                const pool = debouncedSearch ? searchResults : favImages;
+                const pool = filterActive ? searchResults : favImages;
                 handleOpenScreensaver(pool);
               }}
             >
@@ -1176,7 +1219,7 @@ export default function ImageRepo() {
           <Box sx={{ flex: 1 }} />
           <TextField
             size="small"
-            placeholder="Search images by tag…"
+            placeholder="Search by filename…"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             slotProps={{
@@ -1192,7 +1235,14 @@ export default function ImageRepo() {
           />
         </Box>
 
-        {debouncedSearch && (
+        <ImageTagFilter
+          counts={tagCounts}
+          selected={selectedTags}
+          onToggle={(tag) => setSelectedTags(toggleTag(selectedTags, tag))}
+          onClear={() => setSelectedTags([])}
+        />
+
+        {filterActive && (
           <>
             {searchLoading && (
               <Box sx={{ textAlign: "center", py: 4 }}>
@@ -1202,7 +1252,7 @@ export default function ImageRepo() {
             {!searchLoading && searchResults.length === 0 && (
               <Box sx={{ textAlign: "center", py: 8 }}>
                 <Typography color="text.secondary">
-                  No images found matching "{debouncedSearch}".
+                  No images match {filterLabel}.
                 </Typography>
               </Box>
             )}
@@ -1285,7 +1335,7 @@ export default function ImageRepo() {
           </>
         )}
 
-        {!debouncedSearch && (
+        {!filterActive && (
           <>
         {favoritesView && (
           <>
@@ -1560,7 +1610,7 @@ export default function ImageRepo() {
         <Box sx={{ flex: 1 }} />
         <TextField
           size="small"
-          placeholder="Search images by tag…"
+          placeholder="Search by filename…"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           slotProps={{
@@ -1629,13 +1679,13 @@ export default function ImageRepo() {
           startIcon={isMobile ? undefined : <PlayArrow />}
           size={isMobile ? "small" : "medium"}
           disabled={
-            !debouncedSearch && images.length === 0 ||
-            debouncedSearch && searchResults.length === 0 ||
+            !filterActive && images.length === 0 ||
+            filterActive && searchResults.length === 0 ||
             favoritesOnly && !images.some((img) => favoritesSet.has(img.path))
           }
           onClick={() => {
             let pool: ImageFile[];
-            if (debouncedSearch) {
+            if (filterActive) {
               pool = searchResults;
             } else if (favoritesOnly) {
               pool = images.filter((img) => favoritesSet.has(img.path));
@@ -1708,7 +1758,14 @@ export default function ImageRepo() {
         />
       </Box>
 
-      {debouncedSearch && (
+      <ImageTagFilter
+        counts={tagCounts}
+        selected={selectedTags}
+        onToggle={(tag) => setSelectedTags(toggleTag(selectedTags, tag))}
+        onClear={() => setSelectedTags([])}
+      />
+
+      {filterActive && (
         <>
           {searchLoading && (
             <Box sx={{ textAlign: "center", py: 4 }}>
@@ -1718,7 +1775,7 @@ export default function ImageRepo() {
           {!searchLoading && searchResults.length === 0 && (
             <Box sx={{ textAlign: "center", py: 8 }}>
               <Typography color="text.secondary">
-                No images found matching "{debouncedSearch}".
+                No images match {filterLabel}.
               </Typography>
             </Box>
           )}
@@ -1854,7 +1911,7 @@ export default function ImageRepo() {
         </>
       )}
 
-      {!debouncedSearch && (
+      {!filterActive && (
         <>
       {loading && images.length === 0 && (
         <Box sx={{ textAlign: "center", py: 8 }}>


### PR DESCRIPTION
Closes #335. Needs **wanly-api#192** merged first — the console now sends `tags=`, and `q` no longer matches tags server-side.

## What you get

A row of tag pills above the grid. Clicking narrows; every selection ANDs.

- `Kelly` + `Missionary` → the 102 images carrying both. Previously unaskable.
- `Kelly` no longer drags in `KellyYoung` (1,019), `KellyBangs` (140) or `KellyTeacher` (76). The old substring search returned **2,057 of 2,788 images — 74% of the repo**.
- Pills show **counts under the current filter**, so after clicking `Kelly` the remaining pills are the tags that actually co-occur with it, and a dead end is visible before it is clicked rather than after.
- The pill list is what is **used**, not the `title_tags` vocabulary — production has drifted, and `kellyteacher`'s 76 images would otherwise be unreachable by pill. It also puts the fat-fingers (`pusy`, `cowgirlowgirl`, one image each) on screen with counts, which is the start of cleaning them up.

The text box is now **filename-only**, and its placeholder says so. Fragment matching is right for `00111` and wrong for a tag, and it remains the only way to find an untagged image.

## Mechanics

- Selection is URL state (`?tags=Kelly,Missionary`), like the folder and page params, so a filtered view survives navigation, back/forward and refresh — and can be pasted to yourself.
- `filterActive` ("is anything filtering?") replaces `debouncedSearch` as the results-vs-folder-listing gate, in both the folder-grid and in-folder views, including the Play/screensaver pool and the pagination clamp.
- Empty states name the whole filter (`No images match Kelly + Missionary`) instead of only the typed text.
- Parsing/serialising the selection lives in `src/lib/imageFilter.ts`; the pill bar is `src/components/ImageTagFilter.tsx`, rendered in both views.

## The one that would have bitten silently

Axios serialises array params as `tags[]=a&tags[]=b` by default. FastAPI has no `tags[]` parameter, so it would have **dropped the filter and returned everything** — a wrong result, not an error. Pinned to repeated keys and extracted into `src/lib/repeatArrayParams.ts` so the serialisation is asserted rather than assumed.

## Verification
- `npm run build` — green
- `npm test` — **128 passed** (14 new: filter parsing/toggling/description, and the param serialisation)
- `npm run lint` — 4 errors, all pre-existing in files this branch does not touch