### PR TITLE
Re-roll seed button on the job banner

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -156,6 +156,15 @@ export async function addSegment(
   return data;
 }
 
+/** Archive segment 0 and queue an identical one with a new random seed.
+ *
+ *  Returns the NEW segment. The job also moves back to pending and the old take becomes
+ *  discarded, so callers refetch the job rather than patching this into state. */
+export async function rerollJobSeed(jobId: string): Promise<SegmentResponse> {
+  const { data } = await api.post<SegmentResponse>(`/jobs/${jobId}/reroll`);
+  return data;
+}
+
 export async function retrySegment(
   segmentId: string,
 ): Promise<SegmentResponse> {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -155,6 +155,9 @@ export interface JobResponse {
 export interface SegmentResponse {
   id: string;
   job_id: string;
+  /** The seed this segment generated with, or null when it derives one from the job
+   *  (job.seed + index) — which is every segment that was never re-rolled. */
+  seed: number | null;
   index: number;
   /** Human observation. The metrics cannot rank quality — expression rewards the mouth-gape
    *  artifact it should penalise — so what a person saw is primary evidence, not a footnote. */

--- a/src/lib/rerollEligibility.test.ts
+++ b/src/lib/rerollEligibility.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import type { SegmentResponse, SegmentStatus } from "../api/types";
+import { canRerollSeed } from "./rerollEligibility";
+
+const seg = (over: Partial<SegmentResponse>): SegmentResponse =>
+  ({ index: 0, status: "completed", discarded: false, ...over }) as SegmentResponse;
+
+describe("canRerollSeed", () => {
+  it("allows a job with one finished take", () => {
+    expect(canRerollSeed([seg({})])).toBe(true);
+    expect(canRerollSeed([seg({ status: "failed" })])).toBe(true);
+  });
+
+  it("still allows it once earlier takes have been archived", () => {
+    // The workflow is rolling repeatedly. Counting archived takes would hide the button after
+    // the first use — the opposite of what it is for.
+    expect(canRerollSeed([seg({ discarded: true }), seg({})])).toBe(true);
+  });
+
+  it("refuses once a successor segment exists", () => {
+    // Segment 1 was generated from segment 0's last frame; replacing 0 orphans it.
+    expect(canRerollSeed([seg({}), seg({ index: 1 })])).toBe(false);
+  });
+
+  it("refuses while the take is still running", () => {
+    const running: SegmentStatus[] = ["pending", "claimed", "processing"];
+    for (const status of running) {
+      expect(canRerollSeed([seg({ status })])).toBe(false);
+    }
+  });
+
+  it("refuses a job with no live take at all", () => {
+    expect(canRerollSeed([])).toBe(false);
+    expect(canRerollSeed([seg({ discarded: true })])).toBe(false);
+  });
+});

--- a/src/lib/rerollEligibility.ts
+++ b/src/lib/rerollEligibility.ts
@@ -1,0 +1,25 @@
+import type { SegmentResponse } from "../api/types";
+
+/**
+ * Can this job be re-rolled — archived and re-generated with a new seed?
+ *
+ * Only while the job is still a single take.
+ *
+ * LIVE segments only. After a roll the job holds the archived take beside the new one, and
+ * rolling again is the entire workflow — counting archived takes would let the button disappear
+ * after the first use, which is the opposite of what it is for.
+ *
+ * It goes away once a segment 1 exists: segment 1 was generated from segment 0's last frame, so
+ * replacing 0 would leave every successor continuing from a frame that no longer exists.
+ *
+ * And only for a finished take. A running segment has to be cancelled first, or the worker
+ * spends the GPU time finishing something that has already been archived.
+ */
+export function canRerollSeed(videoSegments: SegmentResponse[]): boolean {
+  const live = videoSegments.filter((s) => !s.discarded);
+  return (
+    live.length === 1 &&
+    live[0].index === 0 &&
+    ["completed", "failed"].includes(live[0].status)
+  );
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -39,6 +39,7 @@ import {
   PlayCircleOutline,
   Close,
   Replay,
+  Casino,
   StopCircle,
   DeleteOutline,
   RemoveCircleOutline,
@@ -62,6 +63,7 @@ import {
   addSegment,
   uploadFile,
   retrySegment,
+  rerollJobSeed,
   cancelSegment,
   deleteSegment,
   makeHologram,
@@ -96,6 +98,7 @@ import SegmentObservationDialog from "../components/SegmentObservationDialog";
 import { discardSegment } from "../api/client";
 import SegmentPromptPopover from "../components/SegmentPromptPopover";
 import { buildFaceswapFields, resolveFaceswapImage } from "../lib/faceswapPayload";
+import { canRerollSeed } from "../lib/rerollEligibility";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
 import HologramConfig from "../components/HologramConfig";
 import { QRCodeCanvas } from "qrcode.react";
@@ -274,6 +277,8 @@ export default function JobDetail() {
   const [deletingJob, setDeletingJob] = useState(false);
   const [reopening, setReopening] = useState(false);
   const [reopenConfirm, setReopenConfirm] = useState(false);
+  const [rerollConfirm, setRerollConfirm] = useState(false);
+  const [rerolling, setRerolling] = useState(false);
   const [holoOpen, setHoloOpen] = useState(false);
   const [holoBusy, setHoloBusy] = useState(false);
   const [archiving, setArchiving] = useState(false);
@@ -389,6 +394,24 @@ export default function JobDetail() {
       setError("Failed to finalize job");
     } finally {
       setFinalizing(false);
+    }
+  };
+
+  const handleReroll = async () => {
+    if (!id) return;
+    setRerollConfirm(false);
+    setRerolling(true);
+    try {
+      await rerollJobSeed(id);
+      // Refetch rather than patching state in: the response is the new segment, but the job's
+      // status went back to pending and the old take is now archived, so the whole page moved.
+      await fetchJob();
+      setError("");
+    } catch (e) {
+      const detail = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setError(detail || "Failed to re-roll the segment");
+    } finally {
+      setRerolling(false);
     }
   };
 
@@ -656,6 +679,7 @@ export default function JobDetail() {
     !videoSegments.some((s) =>
       ["pending", "claimed", "processing"].includes(s.status),
     );
+  const canReroll = canRerollSeed(videoSegments);
   const laneWidth = groups.length > 0 ? groups.length * 24 + 24 : 0;
 
   return (
@@ -918,6 +942,30 @@ export default function JobDetail() {
                 </Typography>
               </>
             )}
+            {canReroll && (
+              <Tooltip
+                title="Archive this take and generate another one from the same settings with a new random seed"
+                arrow
+              >
+                <span>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => setRerollConfirm(true)}
+                    disabled={rerolling}
+                    startIcon={
+                      rerolling ? (
+                        <CircularProgress size={16} color="inherit" />
+                      ) : isMobile ? undefined : (
+                        <Casino />
+                      )
+                    }
+                  >
+                    {rerolling ? "Rolling..." : isMobile ? "Re-roll" : "Re-roll Seed"}
+                  </Button>
+                </span>
+              </Tooltip>
+            )}
             {canAddSegment && (
               <Button
                 variant="contained"
@@ -1150,6 +1198,22 @@ export default function JobDetail() {
                         {seg.discarded && (
                           <Tooltip title="Kept for its feedback, excluded from the video">
                             <Chip size="small" label="Discarded" variant="outlined" color="warning" />
+                          </Tooltip>
+                        )}
+                        {/* Only takes that carry their OWN seed show one — today, re-rolled ones.
+                            The rest derive it from the job seed shown in the header, and that
+                            derivation is deliberately not repeated here: jobs created before
+                            seeds were kept JS-safe already display a rounded job seed, so a
+                            client-side (job.seed + index) would render a number that never
+                            generated anything. */}
+                        {seg.seed != null && (
+                          <Tooltip title="This take's own seed — the only thing that differs from the take it replaced">
+                            <Chip
+                              size="small"
+                              variant="outlined"
+                              label={`seed ${seg.seed}`}
+                              sx={{ fontFamily: "monospace" }}
+                            />
                           </Tooltip>
                         )}
                         <IdentityChip segment={seg} />
@@ -1803,6 +1867,27 @@ export default function JobDetail() {
       </Dialog>
 
       {/* Re-open job confirm dialog */}
+      {/* Re-roll confirmation */}
+      <Dialog open={rerollConfirm} onClose={() => setRerollConfirm(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Re-roll with a new seed?</DialogTitle>
+        <DialogContent>
+          <Typography>
+            The current take is <strong>archived</strong>, not deleted — its video, rating and
+            notes stay on the job, under the seed that produced it.
+          </Typography>
+          <Typography sx={{ mt: 1.5 }}>
+            A new segment 0 is queued with the same prompt, LoRAs, preset and start image. Only
+            the seed changes, so the two takes are directly comparable.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRerollConfirm(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handleReroll} disabled={rerolling}>
+            {rerolling ? "Rolling..." : "Re-roll"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
       <Dialog
         open={reopenConfirm}
         onClose={() => setReopenConfirm(false)}


### PR DESCRIPTION
Closes #336. Needs **wanly-api#193** merged and deployed first.

A **Re-roll Seed** button in the job detail banner: archives the current take and queues an identical segment 0 with a new random seed. Same prompt, LoRAs, preset, start image and faceswap — the seed is the only thing that differs, so the two takes are directly comparable.

## When it appears

Only while the job is a single take, and only on a finished one:

| situation | button |
|---|---|
| one completed/failed segment 0 | shown |
| one live segment 0, plus archived takes | **shown** — rolling repeatedly is the workflow |
| a segment 1 exists | hidden — it was generated from segment 0's last frame, so replacing 0 orphans it |
| segment still running | hidden — cancel first, or the worker finishes something already archived |
| no live segment | hidden |

The gate is `src/lib/rerollEligibility.ts` with tests, since "live segments only" is the part that is easy to get subtly wrong.

## The confirmation

Small modal, as asked. It leads with what reassures rather than what warns — the take is **archived, not deleted**, and keeps its video, rating and notes under the seed that produced it — then says the new segment reuses everything except the seed.

## Seed chips

Segments that carry their own seed now show it. Segments that don't (everything not re-rolled) show nothing rather than a computed value: the derivation is `job.seed + index`, and jobs created before seeds were kept JS-safe **already display a rounded job seed**, so computing from it in the browser would render a number that never generated anything. The API PR has the detail.

## Verification
- `npm run build` — green
- `npm test` — **133 passed** (5 new, covering each gate case)
- `npm run lint` — 4 errors, all pre-existing in files this branch does not touch

Not tested against a live API — #193 isn't deployed yet, so the request path is unexercised.