### PR TITLE
Back arrow returns to the real previous page

### DIFF
--- a/src/hooks/useGoBack.ts
+++ b/src/hooks/useGoBack.ts
@@ -1,0 +1,21 @@
+import { useCallback } from "react";
+import { useLocation, useNavigate } from "react-router";
+import { backTarget } from "../lib/backNavigation";
+
+/**
+ * A back arrow that returns to wherever the user actually came from, falling back to `fallback`
+ * when this page was opened cold (pasted link, new tab, refresh).
+ *
+ * See backTarget for why the location key is the signal.
+ */
+export function useGoBack(fallback: string): () => void {
+  const navigate = useNavigate();
+  const { key } = useLocation();
+  return useCallback(() => {
+    const target = backTarget(key, fallback);
+    // Two calls, not one: navigate() is overloaded and a history delta is a different call
+    // signature from a path.
+    if (typeof target === "number") navigate(target);
+    else navigate(target);
+  }, [navigate, key, fallback]);
+}

--- a/src/lib/backNavigation.test.ts
+++ b/src/lib/backNavigation.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { backTarget } from "./backNavigation";
+
+describe("backTarget", () => {
+  it("steps back through history when the page was navigated to in-app", () => {
+    // Any pushed location gets a generated key. -1 is what preserves the list's page, filters
+    // and scroll position, because useQueryState kept them on that history entry.
+    expect(backTarget("a1b2c3", "/jobs")).toBe(-1);
+  });
+
+  it("falls back when the page was opened cold", () => {
+    // "default" is the first entry of a session: pasted link, new tab, refresh, or arrived from
+    // another site. history.back() would leave the app entirely.
+    expect(backTarget("default", "/jobs")).toBe("/jobs");
+  });
+
+  it("falls back when there is no key at all", () => {
+    // Defensive: a missing key is not evidence that going back is safe.
+    expect(backTarget(undefined, "/workers")).toBe("/workers");
+  });
+});

--- a/src/lib/backNavigation.ts
+++ b/src/lib/backNavigation.ts
@@ -1,0 +1,25 @@
+/**
+ * Where a page's back arrow should actually go.
+ *
+ * Hard-coding a destination ("/jobs") is wrong whenever the page can be reached from more than
+ * one place, which every detail page can: a job opens from the queue, from Videos, from the
+ * dashboard, from an image's job list. Sending the user to the queue from any of those throws
+ * away where they were, and on the list pages it also throws away the scroll position, page
+ * number and filters that useQueryState went to some trouble to preserve.
+ *
+ * So: step back through history when there is history of our own to step back through, and fall
+ * back to a sensible page when there is not.
+ *
+ * `locationKey` is how "history of our own" is detected. React Router stamps every location it
+ * pushes with a unique key and leaves the FIRST entry in a session as "default" -- so a default
+ * key means this page was opened cold: pasted link, new tab, refresh, or arrived from another
+ * site. Calling history.back() there would leave the app entirely (or do nothing at all), which
+ * is a worse outcome than the hard-coded destination this replaces.
+ *
+ * A refresh resets the key to "default" even though the browser still holds earlier entries.
+ * Falling back is the right call there anyway: after a reload the user's intent is much better
+ * served by a known page than by an entry they may have visited long ago.
+ */
+export function backTarget(locationKey: string | undefined, fallback: string): number | string {
+  return !locationKey || locationKey === "default" ? fallback : -1;
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -99,6 +99,7 @@ import { discardSegment } from "../api/client";
 import SegmentPromptPopover from "../components/SegmentPromptPopover";
 import { buildFaceswapFields, resolveFaceswapImage } from "../lib/faceswapPayload";
 import { canRerollSeed } from "../lib/rerollEligibility";
+import { useGoBack } from "../hooks/useGoBack";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
 import HologramConfig from "../components/HologramConfig";
 import { QRCodeCanvas } from "qrcode.react";
@@ -258,6 +259,10 @@ function BranchLane({ groups, laneWidth, activeFilename, segIndex }: { groups: B
 export default function JobDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  // The queue is only the fallback now: a job is opened from Videos, the dashboard and an
+  // image's job list too, and returning to the queue from any of those loses the page and
+  // filters the user was looking at.
+  const goBack = useGoBack("/jobs");
   const { allPresets: allVideoPresets, fetchPresets: fetchVideoPresets } = useVideoPresetStore();
   const { loras: loraLibrary, fetchLoras } = useLoraStore();
   const [job, setJob] = useState<JobDetailResponse | null>(null);
@@ -685,7 +690,7 @@ export default function JobDetail() {
   return (
     <Box>
       <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 3 }}>
-        <IconButton onClick={() => navigate("/jobs")} size={isMobile ? "small" : "medium"}>
+        <IconButton onClick={goBack} size={isMobile ? "small" : "medium"}>
           <ArrowBack />
         </IconButton>
         {editingName ? (

--- a/src/pages/WorkerDetail.tsx
+++ b/src/pages/WorkerDetail.tsx
@@ -16,7 +16,8 @@ import {
   LinearProgress,
 } from "@mui/material";
 import { ArrowBack, Circle, LinearScale } from "@mui/icons-material";
-import { useParams, useNavigate, Link as RouterLink } from "react-router";
+import { useParams, Link as RouterLink } from "react-router";
+import { useGoBack } from "../hooks/useGoBack";
 import { getWorker, getWorkerSegments } from "../api/client";
 import StatusChip from "../components/StatusChip";
 import type { WorkerResponse, WorkerStatus, WorkerSegmentResponse } from "../api/types";
@@ -65,7 +66,7 @@ function segRunTime(seg: WorkerSegmentResponse): string {
 
 export default function WorkerDetail() {
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
+  const goBack = useGoBack("/workers");
   const [worker, setWorker] = useState<WorkerResponse | null>(null);
   const [segments, setSegments] = useState<WorkerSegmentResponse[]>([]);
   const [loading, setLoading] = useState(true);
@@ -113,7 +114,7 @@ export default function WorkerDetail() {
     return (
       <Box>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 3 }}>
-          <IconButton onClick={() => navigate("/workers")}>
+          <IconButton onClick={goBack}>
             <ArrowBack />
           </IconButton>
           <Typography variant="h4">Worker</Typography>
@@ -133,7 +134,7 @@ export default function WorkerDetail() {
   return (
     <Box>
       <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 3 }}>
-        <IconButton onClick={() => navigate("/workers")}>
+        <IconButton onClick={goBack}>
           <ArrowBack />
         </IconButton>
         <Typography variant="h4" sx={{ flex: 1 }}>


### PR DESCRIPTION
The job detail back arrow was hard-coded to `/jobs`.

That is wrong whenever the page can be reached from more than one place, which it can: a job opens from the queue, from Videos, from the dashboard, and from an image's job list. Returning to the queue from any of those drops you somewhere you weren't — and on the list pages it also discards the page number, filters and scroll position that `useQueryState` goes out of its way to preserve on the entry you left.

## What it does now

Steps back through history, with `/jobs` as the **fallback** rather than the destination.

The fallback matters: React Router keys the first location of a session `"default"`, which is how "opened cold" is detected — pasted link, new tab, refresh, or arrival from another site. Calling `history.back()` in that state would leave the app entirely (or do nothing), which is a worse outcome than the hard-coded destination this replaces. A refresh also resets the key, and falling back is right there too: after a reload a known page serves the user better than an entry they may have visited long ago.

## Scope note

`WorkerDetail` had the identical hard-coded arrow — twice, in the error state and the loaded state — so it gets the same treatment with `/workers` as its fallback. Happy to pull that back out if you would rather keep this to the job page.

`ImageRepo`'s back arrow is untouched: it moves between folders inside the page, not between routes.

## Verification
- `npm run build` — green
- `npm test` — **131 passed** (3 new: navigated-to, opened-cold, and no-key)
- `npm run lint` — 4 errors, all pre-existing in files this branch does not touch

The decision lives in `src/lib/backNavigation.ts` as a pure function so the opened-cold case is covered by a test instead of by reasoning about it; `useGoBack` is the thin hook around it.

Touches `JobDetail.tsx`, which #338 also edits — whichever merges second will want a trivial rebase.