### PR TITLE
Collapse archived takes under the segment that replaced them

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -156,8 +156,11 @@ export interface SegmentResponse {
   id: string;
   job_id: string;
   /** The seed this segment generated with, or null when it derives one from the job
-   *  (job.seed + index) — which is every segment that was never re-rolled. */
-  seed: number | null;
+   *  (job.seed + index) — a segment that never asked for a particular seed.
+   *
+   *  A STRING: seeds are 64-bit and 95% of jobs have one above 2**53, so as a JSON number it
+   *  would arrive rounded and display as a seed that never generated anything. */
+  seed: string | null;
   index: number;
   /** Human observation. The metrics cannot rank quality — expression rewards the mouth-gape
    *  artifact it should penalise — so what a person saw is primary evidence, not a footnote. */

--- a/src/lib/segmentTakes.test.ts
+++ b/src/lib/segmentTakes.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import type { SegmentResponse } from "../api/types";
+import { groupTakes, takeSeed } from "./segmentTakes";
+
+const seg = (over: Partial<SegmentResponse>): SegmentResponse =>
+  ({ id: String(Math.random()), index: 0, discarded: false, created_at: "2026-08-14T10:00:00Z", ...over }) as SegmentResponse;
+
+describe("groupTakes", () => {
+  it("keeps only live segments in video order", () => {
+    const one = seg({ index: 1 });
+    const zero = seg({ index: 0 });
+    const { live } = groupTakes([one, zero, seg({ index: 0, discarded: true })]);
+    expect(live.map((s) => s.index)).toEqual([0, 1]);
+  });
+
+  it("files archived takes under the index they were replaced at", () => {
+    const archived = seg({ index: 0, discarded: true });
+    const { archivedByIndex } = groupTakes([seg({ index: 0 }), archived, seg({ index: 1 })]);
+    expect(archivedByIndex.get(0)).toEqual([archived]);
+    expect(archivedByIndex.has(1)).toBe(false);
+  });
+
+  it("orders archived takes newest first", () => {
+    // The most recently archived one is what the current take is being compared against.
+    const older = seg({ index: 0, discarded: true, created_at: "2026-08-14T09:00:00Z" });
+    const newer = seg({ index: 0, discarded: true, created_at: "2026-08-14T11:00:00Z" });
+    const { archivedByIndex } = groupTakes([seg({ index: 0 }), older, newer]);
+    expect(archivedByIndex.get(0)).toEqual([newer, older]);
+  });
+
+  it("handles a job whose only take is archived", () => {
+    // Possible mid-re-roll, before the replacement lands.
+    const { live, archivedByIndex } = groupTakes([seg({ index: 0, discarded: true })]);
+    expect(live).toEqual([]);
+    expect(archivedByIndex.get(0)).toHaveLength(1);
+  });
+});
+
+describe("takeSeed", () => {
+  it("shows a seed the segment carries", () => {
+    expect(takeSeed(seg({ seed: "150488800771430" }))).toBe("150488800771430");
+  });
+
+  it("shows nothing rather than a derived guess", () => {
+    // job.seed + index cannot be computed honestly in the browser: 95% of job seeds exceed
+    // 2**53, so the value held here has already been rounded.
+    expect(takeSeed(seg({ seed: null }))).toBeNull();
+  });
+
+  it("keeps the seed as a string, digit for digit", () => {
+    const big = "9223372036854775801";
+    expect(takeSeed(seg({ seed: big }))).toBe(big);
+    expect(String(Number(big))).not.toBe(big); // why it is not a number
+  });
+});

--- a/src/lib/segmentTakes.ts
+++ b/src/lib/segmentTakes.ts
@@ -1,0 +1,56 @@
+import type { SegmentResponse } from "../api/types";
+
+/**
+ * Split a job's segments into the ones that are part of the video and the archived takes that
+ * sit behind them.
+ *
+ * Re-rolling makes index stop being unique. The archived take keeps index 0 so the record reads
+ * as "the discarded version of segment 0", and the replacement takes index 0 as its position in
+ * the video — so a flat list shows two segment 0s, each with its own trim controls, drawn by the
+ * branch lane as though the second continued from the first. They are not a sequence, they are
+ * alternatives, and the display has to say so.
+ *
+ * Everything that treats a segment as a position in the video — the lane, trims, transitions,
+ * "what plays next" — belongs to `live`. Archived takes are evidence, reachable under the take
+ * that replaced them.
+ */
+export interface TakeGroups {
+  /** In video order. One per index. */
+  live: SegmentResponse[];
+  /** Archived takes keyed by the index they were replaced at, newest first. */
+  archivedByIndex: Map<number, SegmentResponse[]>;
+}
+
+export function groupTakes(videoSegments: SegmentResponse[]): TakeGroups {
+  const live = videoSegments
+    .filter((s) => !s.discarded)
+    .sort((a, b) => a.index - b.index);
+
+  const archivedByIndex = new Map<number, SegmentResponse[]>();
+  for (const seg of videoSegments) {
+    if (!seg.discarded) continue;
+    const takes = archivedByIndex.get(seg.index) ?? [];
+    takes.push(seg);
+    archivedByIndex.set(seg.index, takes);
+  }
+  // Newest first: the most recently archived take is the one just replaced, and it is the one
+  // being compared against.
+  for (const takes of archivedByIndex.values()) {
+    takes.sort((a, b) => (b.created_at ?? "").localeCompare(a.created_at ?? ""));
+  }
+
+  return { live, archivedByIndex };
+}
+
+/**
+ * What to show as a take's seed.
+ *
+ * Only a seed the segment actually carries. The alternative — deriving job.seed + index in the
+ * browser — cannot be done honestly: seeds are stored as 64-bit integers and 95% of existing jobs
+ * have one above 2**53, so the job seed the browser holds has already been rounded and any sum
+ * from it is a number that never generated anything. The API sends seeds as strings for exactly
+ * this reason, and stamps an archived take with the seed it ran on.
+ */
+export function takeSeed(seg: SegmentResponse): string | null {
+  return seg.seed ?? null;
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -46,6 +46,7 @@ import {
   ClearOutlined,
   Download,
   ExpandMore,
+  ExpandLess,
   Repeat,
   Visibility,
   ChevronLeft,
@@ -99,6 +100,7 @@ import { discardSegment } from "../api/client";
 import SegmentPromptPopover from "../components/SegmentPromptPopover";
 import { buildFaceswapFields, resolveFaceswapImage } from "../lib/faceswapPayload";
 import { canRerollSeed } from "../lib/rerollEligibility";
+import { groupTakes, takeSeed } from "../lib/segmentTakes";
 import { useGoBack } from "../hooks/useGoBack";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
 import HologramConfig from "../components/HologramConfig";
@@ -149,11 +151,14 @@ function resolveSegmentStartImage(
   segments: SegmentResponse[],
   startingImage: string | null,
 ): string | null {
+  // Found by index among LIVE segments, not by array position. Those were the same thing until a
+  // re-roll could put two segments at index 0: after one, segments[0] may be the archived take,
+  // so position lookup would show segment 1 starting from a frame that was thrown away.
   return (
     seg.start_image ??
     (seg.index === 0
       ? startingImage
-      : segments[seg.index - 1]?.last_frame_path) ??
+      : segments.find((s) => !s.discarded && s.index === seg.index - 1)?.last_frame_path) ??
     null
   );
 }
@@ -283,6 +288,7 @@ export default function JobDetail() {
   const [reopening, setReopening] = useState(false);
   const [reopenConfirm, setReopenConfirm] = useState(false);
   const [rerollConfirm, setRerollConfirm] = useState(false);
+  const [openTakes, setOpenTakes] = useState<Set<number>>(new Set());
   const [rerolling, setRerolling] = useState(false);
   const [holoOpen, setHoloOpen] = useState(false);
   const [holoBusy, setHoloBusy] = useState(false);
@@ -657,7 +663,13 @@ export default function JobDetail() {
     loadFramePreview(framePreview.segId, framePreview.position, newTrim);
   };
 
-  const groups = useMemo(() => job ? buildGroups(job.segments.filter(isVideoSegment), job) : [], [job]);
+  // Live segments only. The lane draws a chain of what continues from what, and an archived take
+  // continues nothing — drawn in, it reads as though the replacement followed the take it
+  // replaced rather than standing in for it.
+  const groups = useMemo(
+    () => (job ? buildGroups(job.segments.filter(isVideoSegment).filter((s) => !s.discarded), job) : []),
+    [job],
+  );
 
   if (loading) {
     return (
@@ -678,10 +690,19 @@ export default function JobDetail() {
   if (!job) return null;
 
   const videoSegments = job.segments.filter(isVideoSegment);
-  const lastSegment = videoSegments[videoSegments.length - 1];
+  // Archived takes are alternatives, not positions in the video, so they come out of the
+  // sequence and sit under the take that replaced them.
+  const { live: liveSegments, archivedByIndex } = groupTakes(videoSegments);
+  const liveTakeSeed = liveSegments.length === 1 ? takeSeed(liveSegments[0]) : null;
+  const liveSeed = liveTakeSeed
+    ? { value: liveTakeSeed, fromTake: true }
+    : { value: `${job.seed}`, fromTake: false };
+  // The last LIVE segment: an archived take is not what a new segment continues from, and this
+  // is what pre-fills the next-segment dialog.
+  const lastSegment = liveSegments[liveSegments.length - 1];
   const canAddSegment =
     job.status === "awaiting" &&
-    !videoSegments.some((s) =>
+    !liveSegments.some((s) =>
       ["pending", "claimed", "processing"].includes(s.status),
     );
   const canReroll = canRerollSeed(videoSegments);
@@ -776,7 +797,14 @@ export default function JobDetail() {
             >
               <MetaItem label="Dimensions" value={`${job.width}x${job.height}`} />
               <MetaItem label="FPS" value={`${job.fps}`} />
-              <MetaItem label="Seed" value={`${job.seed}`} />
+              {/* The live take's seed when it has one of its own, because after a re-roll the
+                  job seed is no longer what generated what is on screen — it is only the seed the
+                  first take derived from. Falls back to the job seed, which is still the answer
+                  for every take that never asked for a particular one. */}
+              <MetaItem
+                label={liveSeed.fromTake ? "Seed (this take)" : "Seed"}
+                value={liveSeed.value}
+              />
               <MetaItem
                 label="Segments"
                 value={`${job.completed_segment_count}`}
@@ -1060,9 +1088,9 @@ export default function JobDetail() {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {videoSegments.flatMap((seg) => {
+                {liveSegments.flatMap((seg) => {
                   const rows = [
-                  <TableRow key={seg.id} sx={seg.discarded ? { opacity: 0.5 } : undefined}>
+                  <TableRow key={seg.id}>
                     {groups.length > 0 && (
                       <TableCell padding="none" sx={{ width: laneWidth, minWidth: laneWidth, position: "relative" }}>
                         <div style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%" }}>
@@ -1077,12 +1105,7 @@ export default function JobDetail() {
                     )}
                     <TableCell sx={groups.length > 0 ? { pl: 0 } : undefined}>
                       {(() => {
-                        const img =
-                          seg.start_image ??
-                          (seg.index === 0
-                            ? job.starting_image
-                            : job.segments[seg.index - 1]?.last_frame_path) ??
-                          null;
+                        const img = resolveSegmentStartImage(seg, job.segments, job.starting_image);
                         return img ? (
                           <Box
                             component="img"
@@ -1200,23 +1223,17 @@ export default function JobDetail() {
                     <TableCell>
                       <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap" }}>
                         <StatusChip status={seg.status} />
-                        {seg.discarded && (
-                          <Tooltip title="Kept for its feedback, excluded from the video">
-                            <Chip size="small" label="Discarded" variant="outlined" color="warning" />
-                          </Tooltip>
-                        )}
-                        {/* Only takes that carry their OWN seed show one — today, re-rolled ones.
-                            The rest derive it from the job seed shown in the header, and that
-                            derivation is deliberately not repeated here: jobs created before
-                            seeds were kept JS-safe already display a rounded job seed, so a
-                            client-side (job.seed + index) would render a number that never
-                            generated anything. */}
-                        {seg.seed != null && (
-                          <Tooltip title="This take's own seed — the only thing that differs from the take it replaced">
+                        {/* Only a seed the segment actually carries. Deriving job.seed + index
+                            here would be dishonest: seeds are 64-bit and 95% of jobs have one
+                            above 2**53, so the job seed in this browser has already been rounded
+                            and any sum from it never generated anything. Archiving stamps the
+                            real value in, so takes in the archive answer for themselves. */}
+                        {takeSeed(seg) && (
+                          <Tooltip title="The seed this take generated with">
                             <Chip
                               size="small"
                               variant="outlined"
-                              label={`seed ${seg.seed}`}
+                              label={`seed ${takeSeed(seg)}`}
                               sx={{ fontFamily: "monospace" }}
                             />
                           </Tooltip>
@@ -1448,6 +1465,113 @@ export default function JobDetail() {
                       </TableCell>
                     </TableRow>
                   );
+
+                  // Archived takes of this position, folded away under it. They are alternatives
+                  // to this take, not steps after it, so they get no lane, no trim controls and
+                  // no transition — none of which mean anything for a clip that is not in the cut.
+                  const takes = archivedByIndex.get(seg.index) ?? [];
+                  if (takes.length > 0) {
+                    const open = openTakes.has(seg.index);
+                    rows.push(
+                      <TableRow key={`takes-toggle-${seg.id}`}>
+                        {groups.length > 0 && <TableCell padding="none" sx={{ width: laneWidth }} />}
+                        <TableCell colSpan={9} sx={{ py: 0.25, borderBottom: open ? "none" : undefined }}>
+                          <Button
+                            size="small"
+                            onClick={() =>
+                              setOpenTakes((prev) => {
+                                const next = new Set(prev);
+                                if (!next.delete(seg.index)) next.add(seg.index);
+                                return next;
+                              })
+                            }
+                            startIcon={open ? <ExpandLess /> : <ExpandMore />}
+                            sx={{ color: "text.secondary", textTransform: "none" }}
+                          >
+                            {takes.length} previous take{takes.length > 1 ? "s" : ""}
+                          </Button>
+                        </TableCell>
+                      </TableRow>,
+                    );
+                    if (open) {
+                      takes.forEach((take) => {
+                        rows.push(
+                          <TableRow key={take.id} sx={{ bgcolor: "action.hover" }}>
+                            {groups.length > 0 && <TableCell padding="none" sx={{ width: laneWidth }} />}
+                            <TableCell colSpan={9} sx={{ py: 1 }}>
+                              <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, pl: 4, flexWrap: "wrap" }}>
+                                {take.last_frame_path ? (
+                                  <Box
+                                    component="img"
+                                    src={getFileUrl(take.last_frame_path, take.completed_at ?? undefined)}
+                                    alt="Last frame"
+                                    onClick={() =>
+                                      take.output_path &&
+                                      setVideoModal({
+                                        path: take.output_path,
+                                        v: take.completed_at ?? undefined,
+                                        segIndex: take.index,
+                                      })
+                                    }
+                                    sx={{
+                                      width: 56,
+                                      height: 56,
+                                      objectFit: "cover",
+                                      borderRadius: 0.5,
+                                      cursor: take.output_path ? "pointer" : "default",
+                                    }}
+                                  />
+                                ) : (
+                                  <Box sx={{ width: 56, height: 56, bgcolor: "action.disabledBackground", borderRadius: 0.5 }} />
+                                )}
+                                <StatusChip status={take.status} />
+                                {takeSeed(take) && (
+                                  <Tooltip title="The seed this take generated with">
+                                    <Chip
+                                      size="small"
+                                      variant="outlined"
+                                      label={`seed ${takeSeed(take)}`}
+                                      sx={{ fontFamily: "monospace" }}
+                                    />
+                                  </Tooltip>
+                                )}
+                                <IdentityChip segment={take} />
+                                {(() => {
+                                  const reviewed =
+                                    take.rating != null || !!take.notes || !!take.observation_tags;
+                                  return (
+                                    <Tooltip title={reviewed ? "Edit observations" : "Add observations"}>
+                                      <IconButton
+                                        size="small"
+                                        onClick={() => setObserving(take)}
+                                        color={reviewed ? "primary" : "default"}
+                                      >
+                                        {reviewed ? <RateReview fontSize="small" /> : <RateReviewOutlined fontSize="small" />}
+                                      </IconButton>
+                                    </Tooltip>
+                                  );
+                                })()}
+                                <Typography variant="caption" color="text.secondary">
+                                  {formatDate(take.created_at)}
+                                </Typography>
+                                <Box sx={{ flex: 1 }} />
+                                <Tooltip title="Delete this take permanently">
+                                  <IconButton
+                                    size="small"
+                                    color="error"
+                                    onClick={() => setDeleteConfirm(take)}
+                                    disabled={actionLoading === take.id}
+                                  >
+                                    <DeleteOutline fontSize="small" />
+                                  </IconButton>
+                                </Tooltip>
+                              </Box>
+                            </TableCell>
+                          </TableRow>,
+                        );
+                      });
+                    }
+                  }
                   return rows;
                 })}
               </TableBody>
@@ -1458,13 +1582,9 @@ export default function JobDetail() {
         {/* Mobile card layout */}
         {isMobile && (
           <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, p: 1.5 }}>
-            {job.segments.flatMap((seg) => {
+            {liveSegments.flatMap((seg) => {
               const startImg =
-                seg.start_image ??
-                (seg.index === 0
-                  ? job.starting_image
-                  : job.segments[seg.index - 1]?.last_frame_path) ??
-                null;
+                resolveSegmentStartImage(seg, job.segments, job.starting_image);
               const card = (
                 <Card key={seg.id} variant="outlined">
                   <Box sx={{ p: 1.5 }}>
@@ -1750,6 +1870,67 @@ export default function JobDetail() {
                   </Box>
                 </Box>
               );
+
+              // Same treatment as the table: archived takes fold away under the take that
+              // replaced them, with no trim controls of their own.
+              const takes = archivedByIndex.get(seg.index) ?? [];
+              if (takes.length > 0) {
+                const open = openTakes.has(seg.index);
+                items.push(
+                  <Box key={`takes-${seg.id}`} sx={{ pl: 1 }}>
+                    <Button
+                      size="small"
+                      onClick={() =>
+                        setOpenTakes((prev) => {
+                          const next = new Set(prev);
+                          if (!next.delete(seg.index)) next.add(seg.index);
+                          return next;
+                        })
+                      }
+                      startIcon={open ? <ExpandLess /> : <ExpandMore />}
+                      sx={{ color: "text.secondary", textTransform: "none" }}
+                    >
+                      {takes.length} previous take{takes.length > 1 ? "s" : ""}
+                    </Button>
+                    {open &&
+                      takes.map((take) => (
+                        <Box
+                          key={take.id}
+                          sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.75, pl: 1, flexWrap: "wrap" }}
+                        >
+                          {take.last_frame_path && (
+                            <Box
+                              component="img"
+                              src={getFileUrl(take.last_frame_path, take.completed_at ?? undefined)}
+                              alt="Last frame"
+                              onClick={() =>
+                                take.output_path &&
+                                setVideoModal({
+                                  path: take.output_path,
+                                  v: take.completed_at ?? undefined,
+                                  segIndex: take.index,
+                                })
+                              }
+                              sx={{ width: 44, height: 44, objectFit: "cover", borderRadius: 0.5 }}
+                            />
+                          )}
+                          <StatusChip status={take.status} />
+                          {takeSeed(take) && (
+                            <Chip
+                              size="small"
+                              variant="outlined"
+                              label={`seed ${takeSeed(take)}`}
+                              sx={{ fontFamily: "monospace", fontSize: 11 }}
+                            />
+                          )}
+                          <IconButton size="small" onClick={() => setObserving(take)}>
+                            <RateReview fontSize="small" />
+                          </IconButton>
+                        </Box>
+                      ))}
+                  </Box>,
+                );
+              }
               return items;
             })}
           </Box>


### PR DESCRIPTION
Refs #336. Needs **wanly-api#194** merged first (seeds as strings, archived takes stamped).

From testing the re-roll on a real job: a re-roll makes `index` stop being unique, and the job detail view assumed it was.

## The five things

1. **Archived takes had editable Trim/Transition rows.** Trim and transition only affect the final video, which a discarded segment is excluded from. Gone.
2. **Two rows labelled "Trim #0".** Fixed by the collapse — only live segments own a position in the video, so only they get trim controls.
3. **The branch lane drew them as a chain**, implying the replacement continued from the take it replaced. Lane groups are built from live segments only.
4. **The archived take showed no seed**, so the table couldn't answer the one question the feature exists for. The API now stamps an archived take with the seed it ran on (#194) and sends seeds as strings — 64-bit values, 95% of which exceed 2^53 and would arrive rounded as JSON numbers.
5. **The job header showed `job.seed`**, which after a re-roll is not what generated what is on screen. Now shows the live take's own seed when it has one, labelled "Seed (this take)".

## The shape

Archived takes fold under the live segment behind an **"N previous takes"** toggle, in both the table and the mobile cards. Each shows what a take is evidence *for* — clip, seed, identity scores, observations, when it ran — and none of what belongs to a position in the video.

Grouping is `src/lib/segmentTakes.ts` with tests, including the newest-first ordering and the mid-re-roll case where a job's only take is archived.

## Two latent bugs from the same root

Found while fixing the visible ones, both live today:

- **Start-image resolution indexed the segments ARRAY by segment index.** Identical behaviour until two segments could share index 0 — afterwards `segments[0]` may be the archived take, so **segment 1 was displayed as starting from a frame that had been thrown away**. Now looked up by index among live segments. There were three copies of that expression inline; now one function.
- **The next-segment dialog pre-filled from `videoSegments[last]`**, which can be an archived take — it would carry the discarded take's faceswap and settings into a new segment. Now the last *live* segment, as is the "is anything still running" check that gates the button.

## Verification
- `npm run build` — green
- `npm test` — **143 passed** (7 new)
- `npm run lint` — 4 errors, all pre-existing in files this branch does not touch

Not exercised against a live API — #194 needs to deploy first, and the seed type changes from number to string with it.