### PR TITLE
Previous takes: one section at the bottom of the segment list

### DIFF
--- a/src/lib/segmentTakes.test.ts
+++ b/src/lib/segmentTakes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { SegmentResponse } from "../api/types";
-import { groupTakes, orphanTakeIndices, takeSeed } from "./segmentTakes";
+import { allArchivedTakes, groupTakes, takeSeed } from "./segmentTakes";
 
 const seg = (over: Partial<SegmentResponse>): SegmentResponse =>
   ({ id: String(Math.random()), index: 0, discarded: false, created_at: "2026-08-14T10:00:00Z", ...over }) as SegmentResponse;
@@ -54,28 +54,24 @@ describe("takeSeed", () => {
   });
 });
 
-describe("orphanTakeIndices", () => {
-  it("finds takes with no live sibling", () => {
-    // Discarding a segment without re-rolling it is the ordinary flow, and those takes have
-    // nothing to fold under. Rendered only under live segments, they would disappear.
-    const groups = groupTakes([
-      seg({ index: 0 }),
-      seg({ index: 1, discarded: true }),
-      seg({ index: 2, discarded: true }),
-    ]);
-    expect(orphanTakeIndices(groups)).toEqual([1, 2]);
+describe("allArchivedTakes", () => {
+  it("lists takes by position, newest first within a position", () => {
+    const oldZero = seg({ index: 0, discarded: true, created_at: "2026-08-14T09:00:00Z" });
+    const newZero = seg({ index: 0, discarded: true, created_at: "2026-08-14T11:00:00Z" });
+    const one = seg({ index: 1, discarded: true });
+    const groups = groupTakes([seg({ index: 0 }), one, newZero, oldZero]);
+    expect(allArchivedTakes(groups)).toEqual([newZero, oldZero, one]);
   });
 
-  it("ignores indices that do have a live take", () => {
-    const groups = groupTakes([seg({ index: 0 }), seg({ index: 0, discarded: true })]);
-    expect(orphanTakeIndices(groups)).toEqual([]);
+  it("includes takes whose position has no live segment", () => {
+    // Discarding without re-rolling is the ordinary flow; those takes have nothing to sit under
+    // and would otherwise never render.
+    const orphan = seg({ index: 1, discarded: true });
+    const groups = groupTakes([seg({ index: 0 }), orphan]);
+    expect(allArchivedTakes(groups)).toEqual([orphan]);
   });
 
-  it("returns them in video order", () => {
-    const groups = groupTakes([
-      seg({ index: 3, discarded: true }),
-      seg({ index: 1, discarded: true }),
-    ]);
-    expect(orphanTakeIndices(groups)).toEqual([1, 3]);
+  it("is empty for a job that has never been re-rolled", () => {
+    expect(allArchivedTakes(groupTakes([seg({ index: 0 })]))).toEqual([]);
   });
 });

--- a/src/lib/segmentTakes.test.ts
+++ b/src/lib/segmentTakes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { SegmentResponse } from "../api/types";
-import { groupTakes, takeSeed } from "./segmentTakes";
+import { groupTakes, orphanTakeIndices, takeSeed } from "./segmentTakes";
 
 const seg = (over: Partial<SegmentResponse>): SegmentResponse =>
   ({ id: String(Math.random()), index: 0, discarded: false, created_at: "2026-08-14T10:00:00Z", ...over }) as SegmentResponse;
@@ -51,5 +51,31 @@ describe("takeSeed", () => {
     const big = "9223372036854775801";
     expect(takeSeed(seg({ seed: big }))).toBe(big);
     expect(String(Number(big))).not.toBe(big); // why it is not a number
+  });
+});
+
+describe("orphanTakeIndices", () => {
+  it("finds takes with no live sibling", () => {
+    // Discarding a segment without re-rolling it is the ordinary flow, and those takes have
+    // nothing to fold under. Rendered only under live segments, they would disappear.
+    const groups = groupTakes([
+      seg({ index: 0 }),
+      seg({ index: 1, discarded: true }),
+      seg({ index: 2, discarded: true }),
+    ]);
+    expect(orphanTakeIndices(groups)).toEqual([1, 2]);
+  });
+
+  it("ignores indices that do have a live take", () => {
+    const groups = groupTakes([seg({ index: 0 }), seg({ index: 0, discarded: true })]);
+    expect(orphanTakeIndices(groups)).toEqual([]);
+  });
+
+  it("returns them in video order", () => {
+    const groups = groupTakes([
+      seg({ index: 3, discarded: true }),
+      seg({ index: 1, discarded: true }),
+    ]);
+    expect(orphanTakeIndices(groups)).toEqual([1, 3]);
   });
 });

--- a/src/lib/segmentTakes.ts
+++ b/src/lib/segmentTakes.ts
@@ -56,17 +56,19 @@ export function takeSeed(seg: SegmentResponse): string | null {
 }
 
 /**
- * Indices whose takes were all archived and never replaced.
+ * Every archived take, in the order they are listed at the bottom of the page.
  *
- * Discarding a segment without re-rolling it is the older, ordinary flow: a bad segment comes out
- * of the cut while its rating and notes stay on the job, because a bad segment is often the most
- * informative one. Those takes have no live sibling to fold under, and rendering only what sits
- * under a live segment would make them vanish from the page entirely — deleting the evidence from
- * view, which is the exact thing discarding exists to avoid.
+ * By position, then newest first within a position. They sit in one section under all the
+ * segments rather than folded under the take that replaced each of them: interleaving them put a
+ * "previous takes" fold between segment 0 and segment 1, which breaks the one thing the segment
+ * list is for — reading the video in order.
+ *
+ * Collecting them all also means a take whose position has no live segment still appears.
+ * Discarding a segment WITHOUT re-rolling it is the ordinary flow — a bad segment leaves the cut
+ * while its rating and notes stay on the job — and those takes have no live sibling to sit under.
  */
-export function orphanTakeIndices(groups: TakeGroups): number[] {
-  const liveIndices = new Set(groups.live.map((s) => s.index));
-  return [...groups.archivedByIndex.keys()]
-    .filter((index) => !liveIndices.has(index))
-    .sort((a, b) => a - b);
+export function allArchivedTakes(groups: TakeGroups): SegmentResponse[] {
+  return [...groups.archivedByIndex.entries()]
+    .sort(([a], [b]) => a - b)
+    .flatMap(([, takes]) => takes);
 }

--- a/src/lib/segmentTakes.ts
+++ b/src/lib/segmentTakes.ts
@@ -54,3 +54,19 @@ export function groupTakes(videoSegments: SegmentResponse[]): TakeGroups {
 export function takeSeed(seg: SegmentResponse): string | null {
   return seg.seed ?? null;
 }
+
+/**
+ * Indices whose takes were all archived and never replaced.
+ *
+ * Discarding a segment without re-rolling it is the older, ordinary flow: a bad segment comes out
+ * of the cut while its rating and notes stay on the job, because a bad segment is often the most
+ * informative one. Those takes have no live sibling to fold under, and rendering only what sits
+ * under a live segment would make them vanish from the page entirely — deleting the evidence from
+ * view, which is the exact thing discarding exists to avoid.
+ */
+export function orphanTakeIndices(groups: TakeGroups): number[] {
+  const liveIndices = new Set(groups.live.map((s) => s.index));
+  return [...groups.archivedByIndex.keys()]
+    .filter((index) => !liveIndices.has(index))
+    .sort((a, b) => a - b);
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import type { ReactElement } from "react";
 import {
   Accordion,
   AccordionSummary,
@@ -100,7 +101,7 @@ import { discardSegment } from "../api/client";
 import SegmentPromptPopover from "../components/SegmentPromptPopover";
 import { buildFaceswapFields, resolveFaceswapImage } from "../lib/faceswapPayload";
 import { canRerollSeed } from "../lib/rerollEligibility";
-import { groupTakes, takeSeed } from "../lib/segmentTakes";
+import { groupTakes, orphanTakeIndices, takeSeed } from "../lib/segmentTakes";
 import { useGoBack } from "../hooks/useGoBack";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
 import HologramConfig from "../components/HologramConfig";
@@ -706,7 +707,187 @@ export default function JobDetail() {
       ["pending", "claimed", "processing"].includes(s.status),
     );
   const canReroll = canRerollSeed(videoSegments);
+
+  /** The "N previous takes" fold for one index — used under the live segment that replaced
+   *  them, and standalone for a position whose takes were all discarded with no replacement. */
+  const takeRows = (index: number) => {
+    const rows: ReactElement[] = [];
+                // Archived takes of this position, folded away under it. They are alternatives
+                // to this take, not steps after it, so they get no lane, no trim controls and
+                // no transition — none of which mean anything for a clip that is not in the cut.
+                const takes = archivedByIndex.get(index) ?? [];
+                if (takes.length > 0) {
+                  const open = openTakes.has(index);
+                  rows.push(
+                    <TableRow key={`takes-toggle-${index}`}>
+                      {groups.length > 0 && <TableCell padding="none" sx={{ width: laneWidth }} />}
+                      <TableCell colSpan={9} sx={{ py: 0.25, borderBottom: open ? "none" : undefined }}>
+                        <Button
+                          size="small"
+                          onClick={() =>
+                            setOpenTakes((prev) => {
+                              const next = new Set(prev);
+                              if (!next.delete(index)) next.add(index);
+                              return next;
+                            })
+                          }
+                          startIcon={open ? <ExpandLess /> : <ExpandMore />}
+                          sx={{ color: "text.secondary", textTransform: "none" }}
+                        >
+                          {takes.length} previous take{takes.length > 1 ? "s" : ""}
+                        </Button>
+                      </TableCell>
+                    </TableRow>,
+                  );
+                  if (open) {
+                    takes.forEach((take) => {
+                      rows.push(
+                        <TableRow key={take.id} sx={{ bgcolor: "action.hover" }}>
+                          {groups.length > 0 && <TableCell padding="none" sx={{ width: laneWidth }} />}
+                          <TableCell colSpan={9} sx={{ py: 1 }}>
+                            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, pl: 4, flexWrap: "wrap" }}>
+                              {take.last_frame_path ? (
+                                <Box
+                                  component="img"
+                                  src={getFileUrl(take.last_frame_path, take.completed_at ?? undefined)}
+                                  alt="Last frame"
+                                  onClick={() =>
+                                    take.output_path &&
+                                    setVideoModal({
+                                      path: take.output_path,
+                                      v: take.completed_at ?? undefined,
+                                      segIndex: take.index,
+                                    })
+                                  }
+                                  sx={{
+                                    width: 56,
+                                    height: 56,
+                                    objectFit: "cover",
+                                    borderRadius: 0.5,
+                                    cursor: take.output_path ? "pointer" : "default",
+                                  }}
+                                />
+                              ) : (
+                                <Box sx={{ width: 56, height: 56, bgcolor: "action.disabledBackground", borderRadius: 0.5 }} />
+                              )}
+                              <StatusChip status={take.status} />
+                              {takeSeed(take) && (
+                                <Tooltip title="The seed this take generated with">
+                                  <Chip
+                                    size="small"
+                                    variant="outlined"
+                                    label={`seed ${takeSeed(take)}`}
+                                    sx={{ fontFamily: "monospace" }}
+                                  />
+                                </Tooltip>
+                              )}
+                              <IdentityChip segment={take} />
+                              {(() => {
+                                const reviewed =
+                                  take.rating != null || !!take.notes || !!take.observation_tags;
+                                return (
+                                  <Tooltip title={reviewed ? "Edit observations" : "Add observations"}>
+                                    <IconButton
+                                      size="small"
+                                      onClick={() => setObserving(take)}
+                                      color={reviewed ? "primary" : "default"}
+                                    >
+                                      {reviewed ? <RateReview fontSize="small" /> : <RateReviewOutlined fontSize="small" />}
+                                    </IconButton>
+                                  </Tooltip>
+                                );
+                              })()}
+                              <Typography variant="caption" color="text.secondary">
+                                {formatDate(take.created_at)}
+                              </Typography>
+                              <Box sx={{ flex: 1 }} />
+                              <Tooltip title="Delete this take permanently">
+                                <IconButton
+                                  size="small"
+                                  color="error"
+                                  onClick={() => setDeleteConfirm(take)}
+                                  disabled={actionLoading === take.id}
+                                >
+                                  <DeleteOutline fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                            </Box>
+                          </TableCell>
+                        </TableRow>,
+                      );
+                    });
+                  }
+                }
+    return rows;
+  };
+
   const laneWidth = groups.length > 0 ? groups.length * 24 + 24 : 0;
+
+  /** Mobile equivalent of takeRows. */
+  const mobileTakeItems = (index: number) => {
+    const items: ReactElement[] = [];
+            // Same treatment as the table: archived takes fold away under the take that
+            // replaced them, with no trim controls of their own.
+            const takes = archivedByIndex.get(index) ?? [];
+            if (takes.length > 0) {
+              const open = openTakes.has(index);
+              items.push(
+                <Box key={`takes-${index}`} sx={{ pl: 1 }}>
+                  <Button
+                    size="small"
+                    onClick={() =>
+                      setOpenTakes((prev) => {
+                        const next = new Set(prev);
+                        if (!next.delete(index)) next.add(index);
+                        return next;
+                      })
+                    }
+                    startIcon={open ? <ExpandLess /> : <ExpandMore />}
+                    sx={{ color: "text.secondary", textTransform: "none" }}
+                  >
+                    {takes.length} previous take{takes.length > 1 ? "s" : ""}
+                  </Button>
+                  {open &&
+                    takes.map((take) => (
+                      <Box
+                        key={take.id}
+                        sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.75, pl: 1, flexWrap: "wrap" }}
+                      >
+                        {take.last_frame_path && (
+                          <Box
+                            component="img"
+                            src={getFileUrl(take.last_frame_path, take.completed_at ?? undefined)}
+                            alt="Last frame"
+                            onClick={() =>
+                              take.output_path &&
+                              setVideoModal({
+                                path: take.output_path,
+                                v: take.completed_at ?? undefined,
+                                segIndex: take.index,
+                              })
+                            }
+                            sx={{ width: 44, height: 44, objectFit: "cover", borderRadius: 0.5 }}
+                          />
+                        )}
+                        <StatusChip status={take.status} />
+                        {takeSeed(take) && (
+                          <Chip
+                            size="small"
+                            variant="outlined"
+                            label={`seed ${takeSeed(take)}`}
+                            sx={{ fontFamily: "monospace", fontSize: 11 }}
+                          />
+                        )}
+                        <IconButton size="small" onClick={() => setObserving(take)}>
+                          <RateReview fontSize="small" />
+                        </IconButton>
+                      </Box>
+                    ))}
+                </Box>,
+              );
+            }
+    return items;
+  };
 
   return (
     <Box>
@@ -1466,114 +1647,16 @@ export default function JobDetail() {
                     </TableRow>
                   );
 
-                  // Archived takes of this position, folded away under it. They are alternatives
-                  // to this take, not steps after it, so they get no lane, no trim controls and
-                  // no transition — none of which mean anything for a clip that is not in the cut.
-                  const takes = archivedByIndex.get(seg.index) ?? [];
-                  if (takes.length > 0) {
-                    const open = openTakes.has(seg.index);
-                    rows.push(
-                      <TableRow key={`takes-toggle-${seg.id}`}>
-                        {groups.length > 0 && <TableCell padding="none" sx={{ width: laneWidth }} />}
-                        <TableCell colSpan={9} sx={{ py: 0.25, borderBottom: open ? "none" : undefined }}>
-                          <Button
-                            size="small"
-                            onClick={() =>
-                              setOpenTakes((prev) => {
-                                const next = new Set(prev);
-                                if (!next.delete(seg.index)) next.add(seg.index);
-                                return next;
-                              })
-                            }
-                            startIcon={open ? <ExpandLess /> : <ExpandMore />}
-                            sx={{ color: "text.secondary", textTransform: "none" }}
-                          >
-                            {takes.length} previous take{takes.length > 1 ? "s" : ""}
-                          </Button>
-                        </TableCell>
-                      </TableRow>,
-                    );
-                    if (open) {
-                      takes.forEach((take) => {
-                        rows.push(
-                          <TableRow key={take.id} sx={{ bgcolor: "action.hover" }}>
-                            {groups.length > 0 && <TableCell padding="none" sx={{ width: laneWidth }} />}
-                            <TableCell colSpan={9} sx={{ py: 1 }}>
-                              <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, pl: 4, flexWrap: "wrap" }}>
-                                {take.last_frame_path ? (
-                                  <Box
-                                    component="img"
-                                    src={getFileUrl(take.last_frame_path, take.completed_at ?? undefined)}
-                                    alt="Last frame"
-                                    onClick={() =>
-                                      take.output_path &&
-                                      setVideoModal({
-                                        path: take.output_path,
-                                        v: take.completed_at ?? undefined,
-                                        segIndex: take.index,
-                                      })
-                                    }
-                                    sx={{
-                                      width: 56,
-                                      height: 56,
-                                      objectFit: "cover",
-                                      borderRadius: 0.5,
-                                      cursor: take.output_path ? "pointer" : "default",
-                                    }}
-                                  />
-                                ) : (
-                                  <Box sx={{ width: 56, height: 56, bgcolor: "action.disabledBackground", borderRadius: 0.5 }} />
-                                )}
-                                <StatusChip status={take.status} />
-                                {takeSeed(take) && (
-                                  <Tooltip title="The seed this take generated with">
-                                    <Chip
-                                      size="small"
-                                      variant="outlined"
-                                      label={`seed ${takeSeed(take)}`}
-                                      sx={{ fontFamily: "monospace" }}
-                                    />
-                                  </Tooltip>
-                                )}
-                                <IdentityChip segment={take} />
-                                {(() => {
-                                  const reviewed =
-                                    take.rating != null || !!take.notes || !!take.observation_tags;
-                                  return (
-                                    <Tooltip title={reviewed ? "Edit observations" : "Add observations"}>
-                                      <IconButton
-                                        size="small"
-                                        onClick={() => setObserving(take)}
-                                        color={reviewed ? "primary" : "default"}
-                                      >
-                                        {reviewed ? <RateReview fontSize="small" /> : <RateReviewOutlined fontSize="small" />}
-                                      </IconButton>
-                                    </Tooltip>
-                                  );
-                                })()}
-                                <Typography variant="caption" color="text.secondary">
-                                  {formatDate(take.created_at)}
-                                </Typography>
-                                <Box sx={{ flex: 1 }} />
-                                <Tooltip title="Delete this take permanently">
-                                  <IconButton
-                                    size="small"
-                                    color="error"
-                                    onClick={() => setDeleteConfirm(take)}
-                                    disabled={actionLoading === take.id}
-                                  >
-                                    <DeleteOutline fontSize="small" />
-                                  </IconButton>
-                                </Tooltip>
-                              </Box>
-                            </TableCell>
-                          </TableRow>,
-                        );
-                      });
-                    }
-                  }
+                  rows.push(...takeRows(seg.index));
                   return rows;
                 })}
+                {/* Positions whose takes were all discarded without a replacement. They have no
+                    live segment to fold under, and dropping them would delete the evidence from
+                    view — which is the one thing discarding, rather than deleting, exists to
+                    avoid. */}
+                {orphanTakeIndices({ live: liveSegments, archivedByIndex }).flatMap((index) =>
+                  takeRows(index),
+                )}
               </TableBody>
             </Table>
           </TableContainer>
@@ -1871,68 +1954,14 @@ export default function JobDetail() {
                 </Box>
               );
 
-              // Same treatment as the table: archived takes fold away under the take that
-              // replaced them, with no trim controls of their own.
-              const takes = archivedByIndex.get(seg.index) ?? [];
-              if (takes.length > 0) {
-                const open = openTakes.has(seg.index);
-                items.push(
-                  <Box key={`takes-${seg.id}`} sx={{ pl: 1 }}>
-                    <Button
-                      size="small"
-                      onClick={() =>
-                        setOpenTakes((prev) => {
-                          const next = new Set(prev);
-                          if (!next.delete(seg.index)) next.add(seg.index);
-                          return next;
-                        })
-                      }
-                      startIcon={open ? <ExpandLess /> : <ExpandMore />}
-                      sx={{ color: "text.secondary", textTransform: "none" }}
-                    >
-                      {takes.length} previous take{takes.length > 1 ? "s" : ""}
-                    </Button>
-                    {open &&
-                      takes.map((take) => (
-                        <Box
-                          key={take.id}
-                          sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.75, pl: 1, flexWrap: "wrap" }}
-                        >
-                          {take.last_frame_path && (
-                            <Box
-                              component="img"
-                              src={getFileUrl(take.last_frame_path, take.completed_at ?? undefined)}
-                              alt="Last frame"
-                              onClick={() =>
-                                take.output_path &&
-                                setVideoModal({
-                                  path: take.output_path,
-                                  v: take.completed_at ?? undefined,
-                                  segIndex: take.index,
-                                })
-                              }
-                              sx={{ width: 44, height: 44, objectFit: "cover", borderRadius: 0.5 }}
-                            />
-                          )}
-                          <StatusChip status={take.status} />
-                          {takeSeed(take) && (
-                            <Chip
-                              size="small"
-                              variant="outlined"
-                              label={`seed ${takeSeed(take)}`}
-                              sx={{ fontFamily: "monospace", fontSize: 11 }}
-                            />
-                          )}
-                          <IconButton size="small" onClick={() => setObserving(take)}>
-                            <RateReview fontSize="small" />
-                          </IconButton>
-                        </Box>
-                      ))}
-                  </Box>,
-                );
-              }
+              items.push(...mobileTakeItems(seg.index));
               return items;
             })}
+            {/* Same as the table: positions discarded without a replacement still have to be
+                reachable. */}
+            {orphanTakeIndices({ live: liveSegments, archivedByIndex }).flatMap((index) =>
+              mobileTakeItems(index),
+            )}
           </Box>
         )}
       </Card>

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -101,7 +101,7 @@ import { discardSegment } from "../api/client";
 import SegmentPromptPopover from "../components/SegmentPromptPopover";
 import { buildFaceswapFields, resolveFaceswapImage } from "../lib/faceswapPayload";
 import { canRerollSeed } from "../lib/rerollEligibility";
-import { groupTakes, orphanTakeIndices, takeSeed } from "../lib/segmentTakes";
+import { allArchivedTakes, groupTakes, takeSeed } from "../lib/segmentTakes";
 import { useGoBack } from "../hooks/useGoBack";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
 import HologramConfig from "../components/HologramConfig";
@@ -289,7 +289,7 @@ export default function JobDetail() {
   const [reopening, setReopening] = useState(false);
   const [reopenConfirm, setReopenConfirm] = useState(false);
   const [rerollConfirm, setRerollConfirm] = useState(false);
-  const [openTakes, setOpenTakes] = useState<Set<number>>(new Set());
+  const [takesOpen, setTakesOpen] = useState(false);
   const [rerolling, setRerolling] = useState(false);
   const [holoOpen, setHoloOpen] = useState(false);
   const [holoBusy, setHoloBusy] = useState(false);
@@ -710,27 +710,23 @@ export default function JobDetail() {
 
   /** The "N previous takes" fold for one index — used under the live segment that replaced
    *  them, and standalone for a position whose takes were all discarded with no replacement. */
-  const takeRows = (index: number) => {
+  /** The "N previous takes" fold that closes the segment list.
+   *
+   *  One section under everything, not one per position: interleaving them put a fold between
+   *  segment 0 and segment 1 and broke the one thing the list is for — reading the video in
+   *  order. Takes are alternatives, not steps, so they get no lane, no trim and no transition. */
+  const takeRows = () => {
     const rows: ReactElement[] = [];
-                // Archived takes of this position, folded away under it. They are alternatives
-                // to this take, not steps after it, so they get no lane, no trim controls and
-                // no transition — none of which mean anything for a clip that is not in the cut.
-                const takes = archivedByIndex.get(index) ?? [];
+                const takes = allArchivedTakes({ live: liveSegments, archivedByIndex });
                 if (takes.length > 0) {
-                  const open = openTakes.has(index);
+                  const open = takesOpen;
                   rows.push(
-                    <TableRow key={`takes-toggle-${index}`}>
+                    <TableRow key="takes-toggle">
                       {groups.length > 0 && <TableCell padding="none" sx={{ width: laneWidth }} />}
                       <TableCell colSpan={9} sx={{ py: 0.25, borderBottom: open ? "none" : undefined }}>
                         <Button
                           size="small"
-                          onClick={() =>
-                            setOpenTakes((prev) => {
-                              const next = new Set(prev);
-                              if (!next.delete(index)) next.add(index);
-                              return next;
-                            })
-                          }
+                          onClick={() => setTakesOpen((open) => !open)}
                           startIcon={open ? <ExpandLess /> : <ExpandMore />}
                           sx={{ color: "text.secondary", textTransform: "none" }}
                         >
@@ -746,6 +742,11 @@ export default function JobDetail() {
                           {groups.length > 0 && <TableCell padding="none" sx={{ width: laneWidth }} />}
                           <TableCell colSpan={9} sx={{ py: 1 }}>
                             <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, pl: 4, flexWrap: "wrap" }}>
+                              {/* Which position this take was for: the list is pooled at the
+                                  bottom, so a row has to say what it was a take OF. */}
+                              <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 700, minWidth: 26 }}>
+                                #{take.index}
+                              </Typography>
                               {take.last_frame_path ? (
                                 <Box
                                   component="img"
@@ -824,24 +825,17 @@ export default function JobDetail() {
   const laneWidth = groups.length > 0 ? groups.length * 24 + 24 : 0;
 
   /** Mobile equivalent of takeRows. */
-  const mobileTakeItems = (index: number) => {
+  /** Mobile equivalent of takeRows: one section after every segment card. */
+  const mobileTakeItems = () => {
     const items: ReactElement[] = [];
-            // Same treatment as the table: archived takes fold away under the take that
-            // replaced them, with no trim controls of their own.
-            const takes = archivedByIndex.get(index) ?? [];
+            const takes = allArchivedTakes({ live: liveSegments, archivedByIndex });
             if (takes.length > 0) {
-              const open = openTakes.has(index);
+              const open = takesOpen;
               items.push(
-                <Box key={`takes-${index}`} sx={{ pl: 1 }}>
+                <Box key="takes" sx={{ pl: 1 }}>
                   <Button
                     size="small"
-                    onClick={() =>
-                      setOpenTakes((prev) => {
-                        const next = new Set(prev);
-                        if (!next.delete(index)) next.add(index);
-                        return next;
-                      })
-                    }
+                    onClick={() => setTakesOpen((open) => !open)}
                     startIcon={open ? <ExpandLess /> : <ExpandMore />}
                     sx={{ color: "text.secondary", textTransform: "none" }}
                   >
@@ -853,6 +847,9 @@ export default function JobDetail() {
                         key={take.id}
                         sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.75, pl: 1, flexWrap: "wrap" }}
                       >
+                          <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 700 }}>
+                            #{take.index}
+                          </Typography>
                         {take.last_frame_path && (
                           <Box
                             component="img"
@@ -1647,16 +1644,9 @@ export default function JobDetail() {
                     </TableRow>
                   );
 
-                  rows.push(...takeRows(seg.index));
                   return rows;
                 })}
-                {/* Positions whose takes were all discarded without a replacement. They have no
-                    live segment to fold under, and dropping them would delete the evidence from
-                    view — which is the one thing discarding, rather than deleting, exists to
-                    avoid. */}
-                {orphanTakeIndices({ live: liveSegments, archivedByIndex }).flatMap((index) =>
-                  takeRows(index),
-                )}
+                {takeRows()}
               </TableBody>
             </Table>
           </TableContainer>
@@ -1954,14 +1944,9 @@ export default function JobDetail() {
                 </Box>
               );
 
-              items.push(...mobileTakeItems(seg.index));
               return items;
             })}
-            {/* Same as the table: positions discarded without a replacement still have to be
-                reachable. */}
-            {orphanTakeIndices({ live: liveSegments, archivedByIndex }).flatMap((index) =>
-              mobileTakeItems(index),
-            )}
+            {mobileTakeItems()}
           </Box>
         )}
       </Card>


### PR DESCRIPTION
Two problems with how #340 placed archived takes, one reported and one found while fixing it.

## Reported: they interrupted the segment list

Folding each position's takes under the segment that replaced them put a "previous takes" row **between segment 0 and segment 1** — which breaks the one thing the segment list is for, reading the video in order.

All archived takes now sit in a **single fold beneath every segment**, ordered by position and newest-first within a position. Each row is labelled with the position it was a take of (`#0`), since the list is pooled and a row has to say what it was a take *of*.

## Found: a take with no live sibling rendered nowhere

#340 rendered rows by walking live segments, so takes at a position with **no live segment** were never rendered. That is the ordinary discard flow — discarding a segment *without* re-rolling it, where a bad segment leaves the cut while its rating and notes stay on the job, because a bad segment is frequently the most informative one.

Checked production: 0 of 5 archived takes lack a live sibling, so nothing was hidden yet — the next ordinary discard would have been the first.

Pooling every take at the bottom **removes the case** rather than special-casing it, which is why this PR no longer contains the orphan-index handling it started with.

## Also

- One fold means the toggle is one boolean instead of a set of open indices.
- Take rendering lives in `takeRows()` / `mobileTakeItems()` so the table and the mobile cards cannot drift apart.
- `allArchivedTakes()` joins the grouping helpers in `src/lib/segmentTakes.ts`, with tests for ordering and for the no-live-sibling case.

## Verification
- `npm run build` — green
- `npm test` — **146 passed**
- `npm run lint` — 4 errors, all pre-existing in files this branch does not touch