### PR TITLE
Show the seed once, on the job

### DIFF
--- a/src/lib/segmentTakes.test.ts
+++ b/src/lib/segmentTakes.test.ts
@@ -37,13 +37,15 @@ describe("groupTakes", () => {
 });
 
 describe("takeSeed", () => {
-  it("shows a seed the segment carries", () => {
+  it("shows the seed an archived take carries", () => {
     expect(takeSeed(seg({ seed: "150488800771430" }))).toBe("150488800771430");
   });
 
-  it("shows nothing rather than a derived guess", () => {
-    // job.seed + index cannot be computed honestly in the browser: 95% of job seeds exceed
-    // 2**53, so the value held here has already been rounded.
+  it("shows nothing for a live segment, which carries no seed of its own", () => {
+    // A re-roll moves the new seed onto the job, so segment 0 is always the job seed and the
+    // header is the one place it appears. Deriving job.seed + index here would be dishonest
+    // anyway: 95% of job seeds exceed 2**53, so the value held in the browser is already
+    // rounded.
     expect(takeSeed(seg({ seed: null }))).toBeNull();
   });
 

--- a/src/lib/segmentTakes.ts
+++ b/src/lib/segmentTakes.ts
@@ -43,13 +43,17 @@ export function groupTakes(videoSegments: SegmentResponse[]): TakeGroups {
 }
 
 /**
- * What to show as a take's seed.
+ * What to show as an archived take's seed.
  *
- * Only a seed the segment actually carries. The alternative — deriving job.seed + index in the
- * browser — cannot be done honestly: seeds are stored as 64-bit integers and 95% of existing jobs
- * have one above 2**53, so the job seed the browser holds has already been rounded and any sum
- * from it is a number that never generated anything. The API sends seeds as strings for exactly
- * this reason, and stamps an archived take with the seed it ran on.
+ * Archived takes only. A live segment carries no seed of its own — a re-roll moves the new seed
+ * onto the JOB, so segment 0 is always the job seed and showing it twice would be one number in
+ * two places, free to disagree. The header is where it belongs, because that is where the create
+ * dialog takes it back from to reproduce a job.
+ *
+ * Never derived here. `job.seed + index` cannot be computed honestly in a browser: seeds are
+ * 64-bit and 95% of jobs have one above 2**53, so the job seed held here has already been
+ * rounded and any sum from it is a number that never generated anything. Archiving stamps the
+ * real value onto the take instead, and the API sends it as a string.
  */
 export function takeSeed(seg: SegmentResponse): string | null {
   return seg.seed ?? null;

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -694,10 +694,7 @@ export default function JobDetail() {
   // Archived takes are alternatives, not positions in the video, so they come out of the
   // sequence and sit under the take that replaced them.
   const { live: liveSegments, archivedByIndex } = groupTakes(videoSegments);
-  const liveTakeSeed = liveSegments.length === 1 ? takeSeed(liveSegments[0]) : null;
-  const liveSeed = liveTakeSeed
-    ? { value: liveTakeSeed, fromTake: true }
-    : { value: `${job.seed}`, fromTake: false };
+
   // The last LIVE segment: an archived take is not what a new segment continues from, and this
   // is what pre-fills the next-segment dialog.
   const lastSegment = liveSegments[liveSegments.length - 1];
@@ -975,14 +972,10 @@ export default function JobDetail() {
             >
               <MetaItem label="Dimensions" value={`${job.width}x${job.height}`} />
               <MetaItem label="FPS" value={`${job.fps}`} />
-              {/* The live take's seed when it has one of its own, because after a re-roll the
-                  job seed is no longer what generated what is on screen — it is only the seed the
-                  first take derived from. Falls back to the job seed, which is still the answer
-                  for every take that never asked for a particular one. */}
-              <MetaItem
-                label={liveSeed.fromTake ? "Seed (this take)" : "Seed"}
-                value={liveSeed.value}
-              />
+              {/* The job seed IS the live take's seed — a re-roll moves it here rather than
+                  putting a second, different number on segment 0. One live take, one answer, in
+                  the place the create dialog takes it back from. */}
+              <MetaItem label="Seed" value={`${job.seed}`} />
               <MetaItem
                 label="Segments"
                 value={`${job.completed_segment_count}`}
@@ -1401,21 +1394,6 @@ export default function JobDetail() {
                     <TableCell>
                       <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap" }}>
                         <StatusChip status={seg.status} />
-                        {/* Only a seed the segment actually carries. Deriving job.seed + index
-                            here would be dishonest: seeds are 64-bit and 95% of jobs have one
-                            above 2**53, so the job seed in this browser has already been rounded
-                            and any sum from it never generated anything. Archiving stamps the
-                            real value in, so takes in the archive answer for themselves. */}
-                        {takeSeed(seg) && (
-                          <Tooltip title="The seed this take generated with">
-                            <Chip
-                              size="small"
-                              variant="outlined"
-                              label={`seed ${takeSeed(seg)}`}
-                              sx={{ fontFamily: "monospace" }}
-                            />
-                          </Tooltip>
-                        )}
                         <IdentityChip segment={seg} />
                         {(() => {
                           const reviewed =


### PR DESCRIPTION
Console half of the model change in **wanly-api#199** — merge and deploy that first.

A re-rolled job showed two seeds: the job header, and a different one on segment 0, where the job's was the seed of a take that had already been archived. The API now moves the new seed onto the job, so:

- **Header shows the seed** — always the live take's, and the number the create dialog takes back to reproduce a job.
- **Segment 0 shows nothing.** It is always the job seed; a second copy is one number in two places, free to disagree.
- **Archived takes keep their chip.** Each carries the seed it actually ran on, which is what makes the previous-takes list worth reading.

Removes the live-row seed chip and the `Seed (this take)` header variant — both existed only because the two numbers could disagree.

## Verification
- `npm run build` — green
- `npm test` — 146 passed
- `npm run lint` — 4 errors, all pre-existing in files this branch does not touch