### PR TITLE
Area-matched resolution buckets for 480p/720p

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -31,6 +31,12 @@ import type { JobCreate, LoraListItem, FaceswapPreset } from "../api/types";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "./FaceswapConfig";
 import { buildFaceswapFields, shouldAttachStartImageAsFace } from "../lib/faceswapPayload";
 import {
+  BUCKET_AREA_480P,
+  BUCKET_AREA_720P,
+  bucketResolution,
+  describeBucket,
+} from "../lib/resolutionBuckets";
+import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
   DEFAULT_FPS,
@@ -66,6 +72,9 @@ export default function CreateJobDialog({
   const [origHeight, setOrigHeight] = useState(DEFAULT_HEIGHT);
   const [width, setWidth] = useState(DEFAULT_WIDTH);
   const [height, setHeight] = useState(DEFAULT_HEIGHT);
+  // What the last 480p/720p button press resolved to. Under-bucket sizes generate without error
+  // and only show up as soft texture in the clip, so the number is worth putting on screen.
+  const [bucketNote, setBucketNote] = useState("");
   const [scale, setScale] = useState(100);
   const mountedRef = useRef(true);
   const prevPreviewUrlRef = useRef<string | null>(null);
@@ -99,6 +108,7 @@ export default function CreateJobDialog({
       setOrigHeight(img.naturalHeight);
       setWidth(Math.round(img.naturalWidth * scalePct / 100));
       setHeight(Math.round(img.naturalHeight * scalePct / 100));
+      setBucketNote("");
       setScale(scalePct);
     };
     img.onerror = () => {
@@ -108,6 +118,7 @@ export default function CreateJobDialog({
       setOrigHeight(DEFAULT_HEIGHT);
       setWidth(DEFAULT_WIDTH);
       setHeight(DEFAULT_HEIGHT);
+      setBucketNote("");
       setScale(100);
       setImagePreview(null);
     };
@@ -265,6 +276,7 @@ export default function CreateJobDialog({
     setOrigHeight(DEFAULT_HEIGHT);
     setWidth(DEFAULT_WIDTH);
     setHeight(DEFAULT_HEIGHT);
+    setBucketNote("");
     setScale(100);
     setFps(DEFAULT_FPS);
     setDuration(DEFAULT_DURATION);
@@ -360,20 +372,25 @@ export default function CreateJobDialog({
     }
   };
 
-  // Set the SHORT side to `target` (480/720) while preserving the start image's aspect ratio, so
-  // the preset buttons never crop (the old buttons forced a fixed 480x832 / 720x1280 → clipped
-  // subjects whose image wasn't that exact ratio). Rounded to a multiple of 16 for the model.
-  const setShortSide = (target: number) => {
+  // Match the 480p/720p bucket's pixel AREA while preserving the start image's aspect ratio.
+  // Scaling the short side to 480/720 instead let total area float with the ratio, so we hit Wan
+  // 2.2's trained resolution only by accident — see src/lib/resolutionBuckets.ts.
+  const setBucket = (targetArea: number) => {
     const ow = origWidth || width;
     const oh = origHeight || height;
-    const r16 = (n: number) => Math.max(16, Math.round(n / 16) * 16);
-    if (oh >= ow) {
-      setWidth(r16(target));
-      setHeight(r16((target * oh) / ow));
-    } else {
-      setHeight(r16(target));
-      setWidth(r16((target * ow) / oh));
-    }
+    const result = bucketResolution(ow, oh, targetArea);
+    setWidth(result.width);
+    setHeight(result.height);
+    setBucketNote(describeBucket(ow, oh, result));
+    console.info("resolution bucket", {
+      srcWidth: ow,
+      srcHeight: oh,
+      targetArea,
+      width: result.width,
+      height: result.height,
+      areaPctOfTarget: Math.round(result.areaRatio * 100),
+      snapped: result.snapped,
+    });
   };
 
   const handleSubmit = async () => {
@@ -616,6 +633,7 @@ export default function CreateJobDialog({
                   setScale(s);
                   setWidth(Math.round(origWidth * s / 100));
                   setHeight(Math.round(origHeight * s / 100));
+                  setBucketNote("");
                 }}
                 valueLabelDisplay="auto"
                 valueLabelFormat={(v) => `${v}%`}
@@ -635,7 +653,10 @@ export default function CreateJobDialog({
                 type="number"
                 size="small"
                 value={width}
-                onChange={(e) => setWidth(parseInt(e.target.value) || 0)}
+                onChange={(e) => {
+                  setWidth(parseInt(e.target.value) || 0);
+                  setBucketNote("");
+                }}
                 sx={{ flex: 1, minWidth: 100 }}
               />
               <TextField
@@ -643,7 +664,10 @@ export default function CreateJobDialog({
                 type="number"
                 size="small"
                 value={height}
-                onChange={(e) => setHeight(parseInt(e.target.value) || 0)}
+                onChange={(e) => {
+                  setHeight(parseInt(e.target.value) || 0);
+                  setBucketNote("");
+                }}
                 sx={{ flex: 1, minWidth: 100 }}
               />
             </Box>
@@ -654,18 +678,23 @@ export default function CreateJobDialog({
               <Button
                 size="small"
                 variant="outlined"
-                onClick={() => setShortSide(480)}
+                onClick={() => setBucket(BUCKET_AREA_480P)}
               >
                 480p
               </Button>
               <Button
                 size="small"
                 variant="outlined"
-                onClick={() => setShortSide(720)}
+                onClick={() => setBucket(BUCKET_AREA_720P)}
               >
                 720p
               </Button>
             </Box>
+            {bucketNote && (
+              <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
+                {bucketNote}
+              </Typography>
+            )}
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>
               <TextField
                 label="FPS"

--- a/src/lib/resolutionBuckets.test.ts
+++ b/src/lib/resolutionBuckets.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  BUCKET_AREA_480P,
+  BUCKET_AREA_720P,
+  bucketResolution,
+  describeBucket,
+} from "./resolutionBuckets";
+
+const dims = (w: number, h: number, area: number) => {
+  const r = bucketResolution(w, h, area);
+  return [r.width, r.height];
+};
+
+describe("bucketResolution", () => {
+  it("area-matches an SDXL portrait instead of pinning the short side", () => {
+    // Short-side scaling gave 480x704 = 337,920 px, 15% under bucket.
+    expect(dims(832, 1216, BUCKET_AREA_480P)).toEqual([528, 768]);
+    expect(dims(1216, 832, BUCKET_AREA_480P)).toEqual([768, 528]);
+  });
+
+  it("area-matches a square source", () => {
+    // Short-side scaling gave 480x480 = 230,400 px, 42% under bucket. 624 rather than 640 is
+    // what the area formula yields: sqrt(399360)/1024 puts each side at 631.9 px, and 624 is the
+    // nearer multiple of 16 (640 is 8.05 px away, 624 is 7.9). The ticket's hand-computed 640 is
+    // 2.6% over the bucket where 624 is 2.5% under — same magnitude, opposite sign.
+    expect(dims(1024, 1024, BUCKET_AREA_480P)).toEqual([624, 624]);
+    expect(dims(1024, 1024, BUCKET_AREA_720P)).toEqual([960, 960]);
+  });
+
+  it("passes a native bucket straight through", () => {
+    expect(dims(832, 480, BUCKET_AREA_480P)).toEqual([832, 480]);
+    expect(dims(480, 832, BUCKET_AREA_480P)).toEqual([480, 832]);
+    expect(dims(1280, 720, BUCKET_AREA_720P)).toEqual([1280, 720]);
+    expect(dims(720, 1280, BUCKET_AREA_720P)).toEqual([720, 1280]);
+  });
+
+  it("snaps a near miss onto the native bucket", () => {
+    // 832x480 asked for at 720p lands on 1264x736 by area — inside 5% of 1280x720, which is a
+    // resolution the model was actually trained on.
+    const r = bucketResolution(832, 480, BUCKET_AREA_720P);
+    expect([r.width, r.height]).toEqual([1280, 720]);
+    expect(r.snapped).toBe(true);
+  });
+
+  it("does not snap when the aspect ratio is genuinely different", () => {
+    const r = bucketResolution(832, 1216, BUCKET_AREA_480P);
+    expect(r.snapped).toBe(false);
+  });
+
+  it("upscales a source smaller than the bucket", () => {
+    // Generating below bucket area is worse than upscaling into it, so small sources scale up.
+    const r = bucketResolution(512, 512, BUCKET_AREA_480P);
+    expect(r.width).toBeGreaterThan(512);
+    expect(r.height).toBeGreaterThan(512);
+    expect(r.areaRatio).toBeGreaterThan(0.95);
+  });
+
+  it("keeps every dimension a positive multiple of 16", () => {
+    const sources: Array<[number, number]> = [
+      [1, 1],
+      [4000, 3],
+      [3, 4000],
+      // Extreme enough that the scaled short side rounds to zero without the floor.
+      [10000, 1],
+      [1, 10000],
+      [1920, 1080],
+      [1024, 1024],
+      [832, 1216],
+    ];
+    for (const area of [BUCKET_AREA_480P, BUCKET_AREA_720P]) {
+      for (const [w, h] of sources) {
+        const r = bucketResolution(w, h, area);
+        expect(r.width % 16).toBe(0);
+        expect(r.height % 16).toBe(0);
+        expect(r.width).toBeGreaterThanOrEqual(16);
+        expect(r.height).toBeGreaterThanOrEqual(16);
+      }
+    }
+  });
+
+  it("lands within a few percent of the target area for ordinary aspects", () => {
+    const sources: Array<[number, number]> = [
+      [1024, 1024],
+      [832, 1216],
+      [1216, 832],
+      [1920, 1080],
+      [768, 1344],
+      [512, 512],
+    ];
+    for (const area of [BUCKET_AREA_480P, BUCKET_AREA_720P]) {
+      for (const [w, h] of sources) {
+        const r = bucketResolution(w, h, area);
+        expect(r.areaRatio).toBeGreaterThan(0.95);
+        expect(r.areaRatio).toBeLessThan(1.05);
+      }
+    }
+  });
+
+  it("falls back to a native bucket when the source size is unknown", () => {
+    expect(dims(0, 0, BUCKET_AREA_480P)).toEqual([832, 480]);
+    expect(dims(0, 0, BUCKET_AREA_720P)).toEqual([1280, 720]);
+  });
+});
+
+describe("describeBucket", () => {
+  it("reports the area as a percentage of the bucket", () => {
+    const r = bucketResolution(832, 1216, BUCKET_AREA_480P);
+    expect(describeBucket(832, 1216, r)).toBe("832x1216 -> 528x768 (102% of bucket area)");
+  });
+
+  it("calls out a native bucket", () => {
+    const r = bucketResolution(832, 480, BUCKET_AREA_480P);
+    expect(describeBucket(832, 480, r)).toBe(
+      "832x480 -> 832x480 (100% of bucket area, native bucket)",
+    );
+  });
+});

--- a/src/lib/resolutionBuckets.ts
+++ b/src/lib/resolutionBuckets.ts
@@ -1,0 +1,102 @@
+/**
+ * 480p / 720p resolution buckets for Wan 2.2.
+ *
+ * The old shortcut scaled the start image's SHORT side to 480 or 720 and derived the other
+ * dimension from the aspect ratio. That holds one dimension fixed and lets total pixel area float
+ * with the ratio — and Wan 2.2 is sensitive to total area, not to which side happens to be 480. A
+ * 832x1216 portrait came out 480x704 = 337,920 px, 15% under bucket; a square source came out
+ * 480x480 = 230,400 px, 42% under. Both generate without error and both produce soft texture,
+ * degraded faces and weak motion coherence, so the failure is invisible until you look at the clip.
+ *
+ * Area matching instead: keep the aspect ratio, scale to hit the bucket's pixel count.
+ */
+
+/** Area of Wan's native 832x480 / 480x832 buckets. */
+export const BUCKET_AREA_480P = 399360;
+/** Area of Wan's native 1280x720 / 720x1280 buckets. */
+export const BUCKET_AREA_720P = 921600;
+
+/**
+ * Trained resolutions. Landing on one of these beats a merely area-matched size, so a near miss
+ * snaps rather than sitting a few pixels off a resolution the model actually saw.
+ */
+const NATIVE_BUCKETS: ReadonlyArray<readonly [number, number]> = [
+  [832, 480],
+  [480, 832],
+  [1280, 720],
+  [720, 1280],
+];
+
+/** How close to a native bucket counts as "just use the native bucket". */
+const SNAP_TOLERANCE = 0.05;
+
+/**
+ * Dimensions must be multiples of 16: the VAE downsamples 8x spatially and the DiT patch size is
+ * 2 on top of that.
+ */
+const GRAIN = 16;
+
+export interface BucketResolution {
+  width: number;
+  height: number;
+  /** Final area as a fraction of the target — 1 is exactly on bucket, 0.85 is 15% under. */
+  areaRatio: number;
+  /** True when the result was snapped to an exact Wan native bucket. */
+  snapped: boolean;
+}
+
+const roundToGrain = (n: number) => Math.max(GRAIN, Math.round(n / GRAIN) * GRAIN);
+
+/**
+ * Resolution for `targetArea` that preserves the source aspect ratio.
+ *
+ * Scales UP as readily as down: a source smaller than the bucket is upscaled into it, because
+ * generating below bucket area is worse than feeding the model an upscaled image.
+ */
+export function bucketResolution(
+  srcW: number,
+  srcH: number,
+  targetArea: number,
+): BucketResolution {
+  // A missing or zero-sized source would divide by zero; fall back to the landscape bucket ratio,
+  // which snaps to a native bucket at both target areas.
+  const w0 = srcW > 0 ? srcW : 832;
+  const h0 = srcH > 0 ? srcH : 480;
+
+  const scale = Math.sqrt(targetArea / (w0 * h0));
+  let width = roundToGrain(w0 * scale);
+  let height = roundToGrain(h0 * scale);
+  let snapped = false;
+
+  for (const [bw, bh] of NATIVE_BUCKETS) {
+    if (
+      Math.abs(width - bw) / bw <= SNAP_TOLERANCE &&
+      Math.abs(height - bh) / bh <= SNAP_TOLERANCE
+    ) {
+      width = bw;
+      height = bh;
+      snapped = true;
+      break;
+    }
+  }
+
+  return { width, height, areaRatio: (width * height) / targetArea, snapped };
+}
+
+/**
+ * One-line summary of a bucket decision, for the dialog caption and the browser console.
+ *
+ * The area percentage is the point: an under-bucket result is the exact failure this replaced, and
+ * it is silent everywhere else.
+ */
+export function describeBucket(
+  srcW: number,
+  srcH: number,
+  result: BucketResolution,
+): string {
+  const pct = Math.round(result.areaRatio * 100);
+  const source = srcW > 0 && srcH > 0 ? `${srcW}x${srcH}` : "unknown source";
+  return `${source} -> ${result.width}x${result.height} (${pct}% of bucket area${
+    result.snapped ? ", native bucket" : ""
+  })`;
+}


### PR DESCRIPTION
Closes #345

## What was wrong

The 480p/720p buttons scaled the start image's **short side** to 480 or 720 and derived the other dimension from the aspect ratio. That pins one dimension and lets total pixel area float with the ratio — and Wan 2.2 is sensitive to total area, not to which side is 480. We hit a trained resolution only when the source happened to be 16:9.

| source | old | area vs 480p bucket |
|---|---|---|
| 832x1216 (SDXL portrait) | 480x704 = 337,920 px | **15% under** |
| 1024x1024 (square) | 480x480 = 230,400 px | **42% under** |

Both generate without error. The cost is soft texture, degraded faces and weak motion coherence — invisible until you look at the clip, which is why it survived this long.

## What it does now

`src/lib/resolutionBuckets.ts`:

- **Area matching.** Preserve the aspect ratio, scale to hit the bucket's pixel count (399,360 px for 480p = 832x480; 921,600 for 720p = 1280x720).
- **Multiples of 16**, floored at 16 (VAE 8x spatial downsample x DiT patch size 2).
- **Native-bucket snapping.** Within 5% of 832x480 / 480x832 / 1280x720 / 720x1280, snap to it exactly. Those are trained resolutions and beat a merely area-matched size — it also makes a source already at 832x480 an exact passthrough.
- **Upscales as readily as downscales.** A source below bucket area scales up; generating under-bucket is worse than upscaling into it.
- **Visibility.** Each press reports `832x1216 -> 528x768 (102% of bucket area)` as a caption under the buttons and as a `console.info` with the structured fields. Under-bucket is otherwise silent everywhere.

The math moved out of `CreateJobDialog.tsx` into `src/lib/` because vitest here is configured pure-logic-only (`src/**/*.test.ts`, node env, no jsdom) — the old inline closure was untestable by construction.

## One deviation from the ticket

The ticket asks for `1024x1024 -> 640x640` at 480p. The formula it also specifies yields **624x624**: `sqrt(399360)/1024` puts each side at 631.9 px, and 624 is the nearer multiple of 16 (640 is 8.05 px away, 624 is 7.9). 624x624 is 2.5% under bucket; 640x640 is 2.6% over — same magnitude, opposite sign. I followed the formula, since it is the normative half of the spec, and noted it in the test.

## The 720p routing question

The ticket asks to confirm routing still sends 720p to RunPod for square/near-square aspects. **There is no resolution-aware routing to confirm.** `claim_next_segment` (`wanly-api/app/routes/segments.py:227-320`) filters on status and `kind` (`gpu` vs `hologram`) only, ordered by priority then age — whichever worker polls first wins. Nothing declares or checks VRAM capability. So a 960x960 720p job (1.7x the attention memory of 1280x720) can land on the 3090 purely by poll timing, and that is true today, before this change. Filed as a follow-up rather than folded in here.

## Verification

- `npm run build` — clean.
- `npm test` — 157 passed (15 files), 11 of them new.
- **Proved the tests catch the bug.** Restored the old short-side logic in the lib: 5 of 11 fail. Set `SNAP_TOLERANCE = 0`: the two snapping tests fail. Dropped the `max(16, ...)` floor: the multiple-of-16 test fails (needed a 10000x1 case to reach it). Restored between each.
- `npm run lint` — the 4 errors are pre-existing in `FaceswapConfig.tsx`, `HologramConfig.tsx`, `SettingsSignature.tsx`; none in touched files.
- `wanly-gpu-docker` needs nothing: this is console-side derivation of a value that already flows job -> claim -> `WanImageToVideo`; no daemon dep, node, model or `.env` default changes.