### PR TITLE
"Re-roll until": rule picker, budget setting, chain status chip

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -38,6 +38,7 @@ import type {
   FavoriteListResponse,
   AppSettingsResponse,
   AppSettingsUpdate,
+  RerollRequest,
 } from "./types";
 import { REPEAT_ARRAY_PARAMS } from "../lib/repeatArrayParams";
 import { LOCAL_STORAGE_TOKEN_KEY } from "../constants";
@@ -159,9 +160,13 @@ export async function addSegment(
 /** Archive segment 0 and queue an identical one with a new random seed.
  *
  *  Returns the NEW segment. The job also moves back to pending and the old take becomes
- *  discarded, so callers refetch the job rather than patching this into state. */
-export async function rerollJobSeed(jobId: string): Promise<SegmentResponse> {
-  const { data } = await api.post<SegmentResponse>(`/jobs/${jobId}/reroll`);
+ *  discarded, so callers refetch the job rather than patching this into state.
+ *
+ *  An optional rule ("re-roll until") makes it a loop: the API judges the finished take
+ *  against metric >= threshold and rolls again on a miss, up to the max_rerolls_per_job
+ *  setting. */
+export async function rerollJobSeed(jobId: string, rule?: RerollRequest): Promise<SegmentResponse> {
+  const { data } = await api.post<SegmentResponse>(`/jobs/${jobId}/reroll`, rule ?? {});
   return data;
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -189,6 +189,13 @@ export interface SegmentResponse {
   transition: string | null;
   trim_start_frames: number;
   trim_end_frames: number;
+  /** "Re-roll until": the rule this take was generated under (null = no rule). Judged >= by
+   *  the API against the mean of the matching metric series when the take completes; a miss
+   *  re-rolls automatically up to the max_rerolls_per_job setting. reroll_count is the take's
+   *  position in its chain (the user-initiated roll is 1). */
+  reroll_rule_metric: string | null;
+  reroll_rule_threshold: number | null;
+  reroll_count: number | null;
   motion_magnitude: number | null;
   identity_mean_cos: number | null;
   identity_mean_cos_ref: number | null;
@@ -549,6 +556,7 @@ export interface AppSettingsResponse {
   high_noise_steps: number;
   flow_shift: number;
   negative_prompt: string;
+  max_rerolls_per_job: number;
 }
 
 export interface FavoriteToggleRequest {
@@ -597,6 +605,13 @@ export interface AppSettingsUpdate {
   high_noise_steps?: number;
   flow_shift?: number;
   negative_prompt?: string;
+  max_rerolls_per_job?: number;
+}
+
+/** Optional rule for POST /jobs/{id}/reroll. Omitted = plain one-shot re-roll. */
+export interface RerollRequest {
+  rule_metric?: string;
+  rule_threshold?: number;
 }
 
 export interface SegmentReprocessRequest {

--- a/src/lib/rerollRule.test.ts
+++ b/src/lib/rerollRule.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { activeRuleTake, ruleMetricMean, ruleSpec } from "./rerollRule";
+import type { SegmentResponse } from "../api/types";
+
+// The mean must match what the API's judge computes (same series field, same 8-point
+// minimum), because the dialog shows this number as "this take measured X" right beside
+// the threshold the API will enforce.
+describe("ruleMetricMean", () => {
+  it("averages the series the metric maps to", () => {
+    const metrics = { series_expression: [2, 4, 2, 4, 2, 4, 2, 4] };
+    expect(ruleMetricMean(metrics, "expression")).toBe(3);
+  });
+
+  it("identity reads the plain 'series' field", () => {
+    const metrics = { series: [0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9] };
+    expect(ruleMetricMean(metrics, "identity")).toBeCloseTo(0.9);
+  });
+
+  it("refuses a series shorter than the chip minimum", () => {
+    // Below 8 points the metrics dialog draws no chip — the user must never be gated
+    // by a number they cannot see.
+    expect(ruleMetricMean({ series_motion: [1, 1, 1] }, "motion")).toBeNull();
+  });
+
+  it("ignores non-numeric entries and refuses when too few survive", () => {
+    const metrics = { series_detail: [200, null, "x", 220, 210, 205, 215, 208] };
+    expect(ruleMetricMean(metrics, "detail")).toBeNull();
+  });
+
+  it("handles missing metrics and unknown metric names", () => {
+    expect(ruleMetricMean(null, "expression")).toBeNull();
+    expect(ruleMetricMean({}, "vibes")).toBeNull();
+  });
+});
+
+describe("activeRuleTake", () => {
+  const seg = (over: Partial<SegmentResponse>): SegmentResponse =>
+    ({ index: 0, discarded: false, reroll_rule_metric: null, ...over }) as SegmentResponse;
+
+  it("finds the live segment-0 take carrying a rule", () => {
+    const take = seg({ reroll_rule_metric: "expression" });
+    expect(activeRuleTake([seg({ discarded: true }), take])).toBe(take);
+  });
+
+  it("ignores archived takes and rule-less jobs", () => {
+    expect(activeRuleTake([seg({ reroll_rule_metric: "expression", discarded: true })])).toBeNull();
+    expect(activeRuleTake([seg({})])).toBeNull();
+  });
+});
+
+describe("ruleSpec", () => {
+  it("knows all four axes and nothing else", () => {
+    for (const key of ["identity", "expression", "motion", "detail"]) {
+      expect(ruleSpec(key)?.key).toBe(key);
+    }
+    expect(ruleSpec("")).toBeUndefined();
+    expect(ruleSpec(null)).toBeUndefined();
+  });
+});

--- a/src/lib/rerollRule.ts
+++ b/src/lib/rerollRule.ts
@@ -1,0 +1,68 @@
+/**
+ * "Re-roll until" rules: the four quality axes a re-roll chain can gate on.
+ *
+ * The API judges a finished take by the MEAN of the matching per-frame series in
+ * identity_metrics — the same number the metrics dialog's chips display — so this module
+ * mirrors that computation exactly (same series fields, same 8-point minimum). The dialog
+ * uses it to show "this take measured X" beside the threshold input, and the banner chip
+ * uses it to say whether a finished chain ended by meeting its rule or by giving up.
+ * Two different values behind one decision would make both untrustworthy.
+ */
+
+import type { SegmentResponse } from "../api/types";
+
+export interface RerollRuleSpec {
+  key: string;
+  label: string;
+  /** Field inside identity_metrics holding the per-frame series. */
+  seriesField: string;
+  /** Decimals the axis is meaningfully read at (matches trajectorySeries). */
+  precision: number;
+  /** Step for the threshold input, scaled to the axis' natural units. */
+  step: number;
+  /** A starting threshold in the axis' typical range, for when the take itself
+   *  has no measurement to pre-fill from. */
+  fallbackThreshold: number;
+}
+
+export const REROLL_RULE_SPECS: RerollRuleSpec[] = [
+  { key: "identity", label: "Identity", seriesField: "series", precision: 3, step: 0.01, fallbackThreshold: 0.85 },
+  { key: "expression", label: "Expression", seriesField: "series_expression", precision: 1, step: 0.5, fallbackThreshold: 4 },
+  { key: "motion", label: "Motion", seriesField: "series_motion", precision: 2, step: 0.05, fallbackThreshold: 0.6 },
+  { key: "detail", label: "Detail", seriesField: "series_detail", precision: 0, step: 10, fallbackThreshold: 200 },
+];
+
+export function ruleSpec(metric: string | null | undefined): RerollRuleSpec | undefined {
+  return REROLL_RULE_SPECS.find((s) => s.key === metric);
+}
+
+/** Below this the metrics dialog draws no chip, and the API's judge refuses to gate — the
+ *  user must never be shown (or gated by) a number they can't see in the dialog. */
+const MIN_POINTS = 8;
+
+/** The mean the API's judge will compare against, or null when unevaluable. */
+export function ruleMetricMean(
+  metrics: Record<string, unknown> | null | undefined,
+  metric: string,
+): number | null {
+  const spec = ruleSpec(metric);
+  if (!spec || !metrics) return null;
+  const series = metrics[spec.seriesField];
+  if (!Array.isArray(series)) return null;
+  const values = series.filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+  if (values.length < MIN_POINTS) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+export function formatRuleValue(metric: string, value: number): string {
+  const spec = ruleSpec(metric);
+  return value.toFixed(spec ? spec.precision : 2);
+}
+
+/** The live segment-0 take carrying a rule, if the job has one. */
+export function activeRuleTake(videoSegments: SegmentResponse[]): SegmentResponse | null {
+  const take = videoSegments.find(
+    (s) => !s.discarded && s.index === 0 && s.reroll_rule_metric != null,
+  );
+  return take ?? null;
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -101,6 +101,13 @@ import { discardSegment } from "../api/client";
 import SegmentPromptPopover from "../components/SegmentPromptPopover";
 import { buildFaceswapFields, resolveFaceswapImage } from "../lib/faceswapPayload";
 import { canRerollSeed } from "../lib/rerollEligibility";
+import {
+  REROLL_RULE_SPECS,
+  ruleSpec,
+  ruleMetricMean,
+  formatRuleValue,
+  activeRuleTake,
+} from "../lib/rerollRule";
 import { allArchivedTakes, groupTakes, takeSeed } from "../lib/segmentTakes";
 import { useGoBack } from "../hooks/useGoBack";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "../components/FaceswapConfig";
@@ -289,6 +296,10 @@ export default function JobDetail() {
   const [reopening, setReopening] = useState(false);
   const [reopenConfirm, setReopenConfirm] = useState(false);
   const [rerollConfirm, setRerollConfirm] = useState(false);
+  // "" = plain one-shot re-roll (no rule). The threshold is text state so a half-typed
+  // number doesn't fight the input; parsed at roll time.
+  const [rerollRuleMetric, setRerollRuleMetric] = useState("");
+  const [rerollRuleThreshold, setRerollRuleThreshold] = useState("");
   const [takesOpen, setTakesOpen] = useState(false);
   const [rerolling, setRerolling] = useState(false);
   const [holoOpen, setHoloOpen] = useState(false);
@@ -354,6 +365,13 @@ export default function JobDetail() {
     fetchLoras();
   }, [fetchVideoPresets, fetchLoras]);
 
+  // The re-roll rule chip and dialog both show the take budget ("take 2/3"), so the max is
+  // needed at page load, not just when the dialog opens.
+  const { maxRerollsPerJob, fetchSettings: fetchAppSettings } = useSettingsStore();
+  useEffect(() => {
+    fetchAppSettings();
+  }, [fetchAppSettings]);
+
   // Effective video settings for a segment: its own preset override, else the job's default
   // preset, else the job's raw sampler values. Returns a name (if a preset applies), the 7
   // params for the signature table, and the effective LoRAs (preset's live-linked LoRAs win
@@ -411,10 +429,15 @@ export default function JobDetail() {
 
   const handleReroll = async () => {
     if (!id) return;
+    const threshold = parseFloat(rerollRuleThreshold);
+    const rule =
+      rerollRuleMetric && Number.isFinite(threshold)
+        ? { rule_metric: rerollRuleMetric, rule_threshold: threshold }
+        : undefined;
     setRerollConfirm(false);
     setRerolling(true);
     try {
-      await rerollJobSeed(id);
+      await rerollJobSeed(id, rule);
       // Refetch rather than patching state in: the response is the new segment, but the job's
       // status went back to pending and the old take is now archived, so the whole page moved.
       await fetchJob();
@@ -1128,6 +1151,46 @@ export default function JobDetail() {
         >
           <Typography variant="h6">Segments</Typography>
           <Box sx={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 1 }}>
+            {(() => {
+              // "Re-roll until" status: what bar the live take is chasing, and how the chain
+              // ended — met the rule, gave up at the cap, or couldn't be measured.
+              const ruleTake = activeRuleTake(videoSegments);
+              const spec = ruleTake ? ruleSpec(ruleTake.reroll_rule_metric) : undefined;
+              if (!ruleTake || !spec || ruleTake.reroll_rule_threshold == null) return null;
+              const bar = formatRuleValue(spec.key, ruleTake.reroll_rule_threshold);
+              const take = ruleTake.reroll_count ?? 1;
+              const running = ["pending", "claimed", "processing"].includes(ruleTake.status);
+              const measured = ruleMetricMean(ruleTake.identity_metrics, spec.key);
+              let label: string;
+              let color: "info" | "success" | "warning";
+              let tip: string;
+              if (running) {
+                label = `Until ${spec.label} ≥ ${bar} — take ${take}/${maxRerollsPerJob}`;
+                color = "info";
+                tip = "This take re-rolls automatically if it misses the rule";
+              } else if (measured != null && measured >= ruleTake.reroll_rule_threshold) {
+                label = `${spec.label} ${formatRuleValue(spec.key, measured)} ≥ ${bar} — met on take ${take}`;
+                color = "success";
+                tip = "The rule was met, so the loop stopped";
+              } else if (measured != null) {
+                label = `${spec.label} ${formatRuleValue(spec.key, measured)} < ${bar} — stopped at take ${take}`;
+                color = "warning";
+                tip = "The re-roll budget ran out before the rule was met — roll again or accept this take";
+              } else if (ruleTake.status === "failed") {
+                label = `Until ${spec.label} ≥ ${bar} — take ${take} failed`;
+                color = "warning";
+                tip = "A crashed take is not judged; retry it or re-roll";
+              } else {
+                label = `Until ${spec.label} ≥ ${bar} — take ${take} not measured`;
+                color = "warning";
+                tip = "This take has no measurement for the rule's axis, so the loop stopped";
+              }
+              return (
+                <Tooltip title={tip} arrow>
+                  <Chip size="small" variant="outlined" color={color} label={label} />
+                </Tooltip>
+              );
+            })()}
             {(job.status === "processing" || job.status === "pending") && (
               <>
                 <CircularProgress size={18} />
@@ -2057,11 +2120,79 @@ export default function JobDetail() {
             A new segment 0 is queued with the same prompt, LoRAs, preset and start image. Only
             the seed changes, so the two takes are directly comparable.
           </Typography>
+          <TextField
+            select
+            label="Re-roll until (optional)"
+            size="small"
+            fullWidth
+            value={rerollRuleMetric}
+            onChange={(e) => {
+              const metric = e.target.value;
+              setRerollRuleMetric(metric);
+              const spec = ruleSpec(metric);
+              setRerollRuleThreshold(spec ? String(spec.fallbackThreshold) : "");
+            }}
+            helperText={
+              rerollRuleMetric
+                ? undefined
+                : "With a rule, missed takes re-roll on their own until one clears the bar"
+            }
+            sx={{ mt: 3 }}
+          >
+            <MenuItem value="">No rule — roll once</MenuItem>
+            {REROLL_RULE_SPECS.map((spec) => (
+              <MenuItem key={spec.key} value={spec.key}>
+                {spec.label}
+              </MenuItem>
+            ))}
+          </TextField>
+          {rerollRuleMetric &&
+            (() => {
+              const spec = ruleSpec(rerollRuleMetric)!;
+              // The number the rule will be judged against, measured on the take being
+              // archived — the whole reason to pick a bar just above or below it.
+              const measured = ruleMetricMean(
+                liveSegments[0]?.identity_metrics ?? null,
+                rerollRuleMetric,
+              );
+              return (
+                <>
+                  <TextField
+                    label={`${spec.label} must reach (≥)`}
+                    size="small"
+                    type="number"
+                    fullWidth
+                    value={rerollRuleThreshold}
+                    onChange={(e) => setRerollRuleThreshold(e.target.value)}
+                    error={!Number.isFinite(parseFloat(rerollRuleThreshold))}
+                    helperText={
+                      measured != null
+                        ? `This take measured ${formatRuleValue(rerollRuleMetric, measured)}`
+                        : "This take has no measurement for this axis — the loop can only judge measured takes"
+                    }
+                    slotProps={{ htmlInput: { step: spec.step } }}
+                    sx={{ mt: 2 }}
+                  />
+                  <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1 }}>
+                    Rolls again automatically while {spec.label.toLowerCase()} stays below the
+                    bar, up to {maxRerollsPerJob} takes (changeable in Settings), then waits for
+                    you.
+                  </Typography>
+                </>
+              );
+            })()}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setRerollConfirm(false)}>Cancel</Button>
-          <Button variant="contained" onClick={handleReroll} disabled={rerolling}>
-            {rerolling ? "Rolling..." : "Re-roll"}
+          <Button
+            variant="contained"
+            onClick={handleReroll}
+            disabled={
+              rerolling ||
+              (!!rerollRuleMetric && !Number.isFinite(parseFloat(rerollRuleThreshold)))
+            }
+          >
+            {rerolling ? "Rolling..." : rerollRuleMetric ? "Re-roll until met" : "Re-roll"}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -24,14 +24,19 @@ export default function SettingsPage() {
   const [input2, setInput2] = useState("");
   const {
     negativePrompt,
+    maxRerollsPerJob,
     loaded,
     fetchSettings,
     saveSettings,
     setNegativePrompt,
+    setMaxRerollsPerJob,
   } = useSettingsStore();
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [rerollSaving, setRerollSaving] = useState(false);
+  const [rerollSaved, setRerollSaved] = useState(false);
+  const [rerollSaveError, setRerollSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     fetchTags();
@@ -64,6 +69,27 @@ export default function SettingsPage() {
       setSaveError(message);
     } finally {
       setSaving(false);
+    }
+  };
+
+  const parsedMaxRerolls = parseInt(maxRerollsPerJob, 10);
+  const maxRerollsValid = Number.isInteger(parsedMaxRerolls) && parsedMaxRerolls >= 1;
+
+  const handleSaveReroll = async () => {
+    if (!maxRerollsValid) return;
+    setRerollSaving(true);
+    setRerollSaved(false);
+    setRerollSaveError(null);
+    try {
+      await saveSettings({ max_rerolls_per_job: parsedMaxRerolls });
+      setRerollSaved(true);
+    } catch (err) {
+      console.error("Failed to save re-roll settings:", err);
+      const message =
+        err instanceof Error ? err.message : "Failed to save settings. Please try again.";
+      setRerollSaveError(message);
+    } finally {
+      setRerollSaving(false);
     }
   };
 
@@ -211,6 +237,57 @@ export default function SettingsPage() {
                 {saveError && (
                   <Alert severity="error" sx={{ mt: 1 }} onClose={() => setSaveError(null)}>
                     {saveError}
+                  </Alert>
+                )}
+              </Box>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card sx={{ mt: 3 }}>
+        <CardContent>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            Re-roll
+          </Typography>
+          {!loaded ? (
+            <Box sx={{ textAlign: "center", py: 2 }}>
+              <CircularProgress size={24} />
+            </Box>
+          ) : (
+            <>
+              <TextField
+                label="Max re-rolls per job"
+                size="small"
+                type="number"
+                value={maxRerollsPerJob}
+                onChange={(e) => setMaxRerollsPerJob(e.target.value)}
+                error={!maxRerollsValid}
+                helperText={
+                  maxRerollsValid
+                    ? 'How many takes a "re-roll until" rule may generate before it gives up and waits for you'
+                    : "Must be a whole number of at least 1"
+                }
+                slotProps={{ htmlInput: { min: 1, step: 1 } }}
+                sx={{ mt: 1, width: "100%", maxWidth: 320 }}
+              />
+              <Box sx={{ mt: 2 }}>
+                <Button
+                  variant="contained"
+                  size="small"
+                  onClick={handleSaveReroll}
+                  disabled={rerollSaving || !maxRerollsValid}
+                >
+                  {rerollSaving ? "Saving..." : "Save"}
+                </Button>
+                {rerollSaved && (
+                  <Alert severity="success" sx={{ mt: 1 }}>
+                    Re-roll settings saved
+                  </Alert>
+                )}
+                {rerollSaveError && (
+                  <Alert severity="error" sx={{ mt: 1 }} onClose={() => setRerollSaveError(null)}>
+                    {rerollSaveError}
                   </Alert>
                 )}
               </Box>

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -11,6 +11,8 @@ interface SettingsState {
   defaultHighNoiseSteps: string;
   defaultFlowShift: string;
   negativePrompt: string;
+  /** "Re-roll until" budget: how many takes a rule-driven chain may generate per job. */
+  maxRerollsPerJob: string;
   loaded: boolean;
   fetchSettings: () => Promise<void>;
   saveSettings: (updates: AppSettingsUpdate) => Promise<void>;
@@ -22,6 +24,7 @@ interface SettingsState {
   setDefaultHighNoiseSteps: (value: string) => void;
   setDefaultFlowShift: (value: string) => void;
   setNegativePrompt: (value: string) => void;
+  setMaxRerollsPerJob: (value: string) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()((set) => ({
@@ -33,6 +36,7 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
   defaultHighNoiseSteps: "2",
   defaultFlowShift: "5",
   negativePrompt: "",
+  maxRerollsPerJob: "3",
   loaded: false,
   fetchSettings: async () => {
     try {
@@ -46,6 +50,7 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
         defaultHighNoiseSteps: String(s.high_noise_steps),
         defaultFlowShift: String(s.flow_shift),
         negativePrompt: s.negative_prompt,
+        maxRerollsPerJob: String(s.max_rerolls_per_job ?? 3),
         loaded: true,
       });
     } catch {
@@ -64,6 +69,7 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
       defaultHighNoiseSteps: String(s.high_noise_steps),
       defaultFlowShift: String(s.flow_shift),
       negativePrompt: s.negative_prompt,
+      maxRerollsPerJob: String(s.max_rerolls_per_job ?? 3),
     });
   },
   setDefaultLightx2vHigh: (value) => set({ defaultLightx2vHigh: value }),
@@ -74,4 +80,5 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
   setDefaultHighNoiseSteps: (value) => set({ defaultHighNoiseSteps: value }),
   setDefaultFlowShift: (value) => set({ defaultFlowShift: value }),
   setNegativePrompt: (value) => set({ negativePrompt: value }),
+  setMaxRerollsPerJob: (value) => set({ maxRerollsPerJob: value }),
 }));


### PR DESCRIPTION
Closes #342. Console half of the feature; the loop itself is wanly-api#201 (judged server-side in the completion PATCH, daemon untouched).

- **Re-roll dialog**: optional "Re-roll until" rule — axis dropdown + `≥` threshold (comparison hard-coded per the ticket). Shows what the take being archived measured on the chosen axis, since the whole point is picking a bar relative to that. No rule selected = exactly today's one-shot behavior.
- **Settings**: new "Re-roll" section with *Max re-rolls per job* (default 3) — the number of takes a rule-driven chain may generate before giving up and waiting.
- **Banner chip** on Job Detail narrates the chain: `Until Expression ≥ 4 — take 2/3` while rolling; then met / budget spent / failed / unmeasurable. Without this, an automatic re-roll is indistinguishable from a stuck job.
- `src/lib/rerollRule.ts` mirrors the API judge exactly (same `identity_metrics` series fields, same 8-point minimum as the metric chips) so the number shown is the number that gates.

**Verified**: `npm test` 165 passed (5 new suites' worth in `rerollRule.test.ts`), `npm run build` green.