### PR TITLE
feat(jobs): clone an existing job

### DIFF
--- a/src/components/CreateJobDialog.tsx
+++ b/src/components/CreateJobDialog.tsx
@@ -27,7 +27,8 @@ import { useTagStore } from "../stores/tagStore";
 import { useVideoPresetStore } from "../stores/videoPresetStore";
 import SettingsSignature from "./SettingsSignature";
 import { createJob, getFileUrl, getFaceswapPresets, sha256Hex, checkStartingImageExists } from "../api/client";
-import type { JobCreate, LoraListItem, FaceswapPreset } from "../api/types";
+import type { JobCreate, LoraListItem, FaceswapPreset, JobDetailResponse } from "../api/types";
+import { cloneJobValues, cloneSourceSegment } from "../lib/cloneJob";
 import FaceswapConfig, { defaultFaceswapState, type FaceswapConfigState } from "./FaceswapConfig";
 import { buildFaceswapFields, shouldAttachStartImageAsFace } from "../lib/faceswapPayload";
 import {
@@ -53,6 +54,9 @@ interface CreateJobDialogProps {
   initialStartingImage?: File | null;
   initialStartingImageUri?: string | null;
   initialImageTags?: string | null;
+  /** Clone: pre-fill every field from an existing job. Settings and start image only —
+   *  segments, takes, videos and observations are history and are deliberately not carried. */
+  cloneFrom?: JobDetailResponse | null;
 }
 
 export default function CreateJobDialog({
@@ -62,6 +66,7 @@ export default function CreateJobDialog({
   initialStartingImage,
   initialStartingImageUri,
   initialImageTags,
+  cloneFrom,
 }: CreateJobDialogProps) {
   const isMobile = useIsMobile();
   const { defaultLightx2vHigh, defaultLightx2vLow, defaultCfgHigh, defaultCfgLow, defaultStepsTotal, defaultHighNoiseSteps, defaultFlowShift, negativePrompt: defaultNegativePrompt, fetchSettings } = useSettingsStore();
@@ -90,8 +95,13 @@ export default function CreateJobDialog({
     };
   }, []);
 
-  // Load image dimensions from a URL, handling cleanup and error states
-  const loadImageFromUrl = useCallback((url: string) => {
+  // Load image dimensions from a URL, handling cleanup and error states.
+  //
+  // `keepSize` is for cloning: the source job already resolved its own width/height (possibly a
+  // bucket press, possibly a hand-typed number), and that is the setting being cloned. The
+  // default path would silently overwrite it with naturalWidth x scale the moment the image
+  // finished loading — asynchronously, so the field would look right and then change.
+  const loadImageFromUrl = useCallback((url: string, keepSize?: { width: number; height: number }) => {
     // Revoke previous blob URL to prevent memory leaks
     if (prevPreviewUrlRef.current?.startsWith("blob:")) {
       URL.revokeObjectURL(prevPreviewUrlRef.current);
@@ -102,25 +112,42 @@ export default function CreateJobDialog({
     const img = new window.Image();
     img.onload = () => {
       if (!mountedRef.current) return;
-      const oversize = img.naturalWidth >= 1216 || img.naturalHeight >= 832;
-      const scalePct = oversize ? 75 : 100;
       setOrigWidth(img.naturalWidth);
       setOrigHeight(img.naturalHeight);
+      setBucketNote("");
+      if (keepSize) {
+        setWidth(keepSize.width);
+        setHeight(keepSize.height);
+        // Put the slider where the cloned size actually sits against the real image.
+        setScale(img.naturalWidth ? Math.round((keepSize.width / img.naturalWidth) * 100) : 100);
+        return;
+      }
+      const oversize = img.naturalWidth >= 1216 || img.naturalHeight >= 832;
+      const scalePct = oversize ? 75 : 100;
       setWidth(Math.round(img.naturalWidth * scalePct / 100));
       setHeight(Math.round(img.naturalHeight * scalePct / 100));
-      setBucketNote("");
       setScale(scalePct);
     };
     img.onerror = () => {
       if (!mountedRef.current) return;
+      setBucketNote("");
+      setImagePreview(null);
+      if (keepSize) {
+        // The clone's numbers are known good even when the preview will not load; only the
+        // orig/scale pair is unknowable, so leave the slider at 100% of the cloned size.
+        setOrigWidth(keepSize.width);
+        setOrigHeight(keepSize.height);
+        setWidth(keepSize.width);
+        setHeight(keepSize.height);
+        setScale(100);
+        return;
+      }
       // Reset to defaults on load failure
       setOrigWidth(DEFAULT_WIDTH);
       setOrigHeight(DEFAULT_HEIGHT);
       setWidth(DEFAULT_WIDTH);
       setHeight(DEFAULT_HEIGHT);
-      setBucketNote("");
       setScale(100);
-      setImagePreview(null);
     };
     img.src = url;
   }, []);
@@ -210,7 +237,10 @@ export default function CreateJobDialog({
       getFaceswapPresets().then((presets) => {
         setFaceswapPresets(presets);
         const kelly = presets.find((p) => p.name.toLowerCase() === "kelly_young.safetensors" || p.key.toLowerCase() === "kelly_young.safetensors.png");
-        if (kelly && !faceswap.presetUri) setFaceswap((prev) => ({ ...prev, presetUri: kelly.url }));
+        // Decide against `prev`, not the `faceswap` this effect closed over. This resolves after
+        // an unknown number of renders, so the captured value is stale by definition — and a
+        // clone that had just set a face would get Kelly written over it, non-deterministically.
+        if (kelly) setFaceswap((prev) => (prev.presetUri ? prev : { ...prev, presetUri: kelly.url }));
       }).catch(() => {});
     }
   }, [open, fetchLoras, fetchTags]);
@@ -337,6 +367,66 @@ export default function CreateJobDialog({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, videoPresetId, videoPresets]);
+
+  // Clone: pre-fill from an existing job. Settings and start image only — segments, takes,
+  // videos and observations are that job's history and stay with it.
+  //
+  // Declared LAST of the on-open effects on purpose. The three above it each write the same
+  // fields from a different source (settings defaults, then the retained preset), and effects
+  // run in declaration order, so anything earlier would be applied over the clone. Claiming
+  // `didApplyPresetOnOpen` closes the second pass: setting videoPresetId re-triggers that effect
+  // on the next render, which would re-apply the preset's prompt/sampler/LoRAs over the cloned
+  // ones and quietly undo half of this.
+  const didCloneOnOpen = useRef(false);
+  useEffect(() => {
+    if (!open || !cloneFrom) {
+      didCloneOnOpen.current = false;
+      return;
+    }
+    if (didCloneOnOpen.current) return;
+
+    // LoRA names/previews come from the library. It is fetched on open, so wait for it rather
+    // than filling the picker with truncated UUIDs.
+    const hasLoras = !!cloneSourceSegment(cloneFrom)?.loras?.length;
+    if (hasLoras && loraLibrary.length === 0) return;
+
+    didCloneOnOpen.current = true;
+    didApplyPresetOnOpen.current = true;
+
+    const v = cloneJobValues(cloneFrom, loraLibrary);
+    setName(v.name);
+    setNameManuallyEdited(true);
+    setFps(v.fps);
+    setSeed(v.seed);
+    setLightx2vHigh(v.lightx2vHigh);
+    setLightx2vLow(v.lightx2vLow);
+    setCfgHigh(v.cfgHigh);
+    setCfgLow(v.cfgLow);
+    setStepsTotal(v.stepsTotal);
+    setHighNoiseSteps(v.highNoiseSteps);
+    setFlowShift(v.flowShift);
+    setVideoPresetId(v.videoPresetId);
+    setTags(v.tags);
+    setPrompt(v.prompt);
+    setNegativePrompt(v.negativePrompt);
+    if (v.duration != null) setDuration(v.duration);
+    if (v.speed != null) setSpeed(v.speed);
+    setLoras(v.loras);
+    if (v.faceswap) setFaceswap(v.faceswap);
+
+    if (v.startingImageUri) {
+      setStartingImage(null);
+      setStartingImageUri(v.startingImageUri);
+      // Keep the job's own width/height — see loadImageFromUrl.
+      loadImageFromUrl(getFileUrl(v.startingImageUri), { width: v.width, height: v.height });
+    } else {
+      setWidth(v.width);
+      setHeight(v.height);
+      setOrigWidth(v.width);
+      setOrigHeight(v.height);
+      setScale(100);
+    }
+  }, [open, cloneFrom, loraLibrary, loadImageFromUrl]);
 
   // Select a user-defined video-settings preset (live link). "" = Custom (raw fields below).
   const applyVideoPreset = (id: string) => {

--- a/src/lib/cloneJob.test.ts
+++ b/src/lib/cloneJob.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import { cloneJobValues, cloneSourceSegment, type LoraLookup } from "./cloneJob";
+import type { JobDetailResponse, SegmentResponse } from "../api/types";
+
+const FACE = "s3://wanly-jobs/8f3a/faceswap_source.png";
+const START = "s3://wanly-images/2026-08-03/00003-710610150-swapped.png";
+
+function seg(overrides: Partial<SegmentResponse> = {}): SegmentResponse {
+  return {
+    index: 0,
+    prompt: "a woman turns toward the camera",
+    negative_prompt: "blurry",
+    duration_seconds: 5,
+    speed: 1.0,
+    discarded: false,
+    created_at: "2026-08-01T00:00:00Z",
+    loras: null,
+    faceswap_enabled: false,
+    faceswap_method: null,
+    faceswap_source_type: null,
+    faceswap_image: null,
+    faceswap_faces_order: null,
+    faceswap_faces_index: null,
+    faceswap_model: null,
+    faceswap_pixel_boost: null,
+    seed_faceswap: false,
+    ...overrides,
+  } as unknown as SegmentResponse;
+}
+
+function job(overrides: Partial<JobDetailResponse> = {}): JobDetailResponse {
+  return {
+    name: "k3llydw_60fps",
+    width: 704,
+    height: 480,
+    fps: 60,
+    // A real seed, above 2**53. Written through Number() rather than as a literal because a
+    // literal trips no-loss-of-precision — which is the whole point: this is the same rounding
+    // JSON.parse already applied before the value reached the browser.
+    seed: Number("3150982733094861699"),
+    starting_image: START,
+    lightx2v_strength_high: 1,
+    lightx2v_strength_low: 0,
+    cfg_high: 2.5,
+    cfg_low: 2.5,
+    steps_total: 12,
+    high_noise_steps: 2,
+    flow_shift: 5,
+    video_preset_id: "preset-1",
+    tags: "doggystyle,front",
+    segments: [seg()],
+    ...overrides,
+  } as unknown as JobDetailResponse;
+}
+
+describe("cloneSourceSegment", () => {
+  it("takes the LIVE take at index 0, not the array's first element", () => {
+    const archived = seg({ prompt: "the old prompt", discarded: true });
+    const live = seg({ prompt: "the current prompt" });
+    // Archived first, exactly as a re-rolled job arrives.
+    const source = cloneSourceSegment(job({ segments: [archived, live, seg({ index: 1 })] }));
+    expect(source?.prompt).toBe("the current prompt");
+  });
+
+  it("is null when the job has no live segment 0", () => {
+    expect(cloneSourceSegment(job({ segments: [seg({ discarded: true })] }))).toBeNull();
+  });
+});
+
+describe("cloneJobValues", () => {
+  it("carries the job's settings and start image", () => {
+    const v = cloneJobValues(job());
+    expect(v.name).toBe("k3llydw_60fps (copy)");
+    expect(v.fps).toBe(60);
+    expect(v.width).toBe(704);
+    expect(v.height).toBe(480);
+    expect(v.cfgHigh).toBe("2.5");
+    expect(v.stepsTotal).toBe("12");
+    expect(v.flowShift).toBe("5");
+    expect(v.videoPresetId).toBe("preset-1");
+    expect(v.tags).toBe("doggystyle,front");
+    expect(v.startingImageUri).toBe(START);
+  });
+
+  it("carries the live segment's prompt, duration and speed", () => {
+    const v = cloneJobValues(job({ segments: [seg({ duration_seconds: 3, speed: 1.25 })] }));
+    expect(v.prompt).toBe("a woman turns toward the camera");
+    expect(v.negativePrompt).toBe("blurry");
+    expect(v.duration).toBe(3);
+    expect(v.speed).toBe(1.25);
+  });
+
+  it("NEVER carries the seed — it arrives rounded and would reproduce nothing", () => {
+    expect(cloneJobValues(job()).seed).toBe("");
+  });
+
+  it("renders an unset sampler field as empty, not '0' or 'null'", () => {
+    const v = cloneJobValues(job({ cfg_high: null, steps_total: null }));
+    expect(v.cfgHigh).toBe("");
+    expect(v.stepsTotal).toBe("");
+  });
+
+  it("survives a job whose live segment 0 is gone", () => {
+    const v = cloneJobValues(job({ segments: [seg({ discarded: true })] }));
+    expect(v.prompt).toBe("");
+    expect(v.loras).toEqual([]);
+    expect(v.faceswap).toBeNull();
+    // Job-level settings still clone.
+    expect(v.fps).toBe(60);
+  });
+
+  describe("LoRAs", () => {
+    const LIB: LoraLookup[] = [{ id: "lora-a", name: "k3llydw", preview_image: "p.png" }];
+
+    it("names and previews from the library", () => {
+      const v = cloneJobValues(
+        job({ segments: [seg({ loras: [{ lora_id: "lora-a", high_weight: 0, low_weight: 1 }] })] }),
+        LIB,
+      );
+      expect(v.loras).toEqual([
+        { lora_id: "lora-a", name: "k3llydw", high_weight: 0, low_weight: 1, preview_image: "p.png" },
+      ]);
+    });
+
+    it("falls back to a truncated id when the library has no entry", () => {
+      const v = cloneJobValues(
+        job({ segments: [seg({ loras: [{ lora_id: "abcdefgh-1234", high_weight: 1, low_weight: 0 }] })] }),
+        LIB,
+      );
+      expect(v.loras[0].name).toBe("abcdefgh");
+      expect(v.loras[0].preview_image).toBeNull();
+    });
+
+    it("drops a reference with no id rather than showing a phantom LoRA", () => {
+      const v = cloneJobValues(
+        job({ segments: [seg({ loras: [{ high_weight: 1, low_weight: 1 }] })] }),
+        LIB,
+      );
+      expect(v.loras).toEqual([]);
+    });
+  });
+
+  describe("faceswap", () => {
+    it("clones an UPLOAD face as a preset pointing at the stored URI", () => {
+      // The File is gone; the bytes are in S3. Keeping sourceType="upload" would send no face
+      // while the swap stayed enabled — a silent no-op in the daemon.
+      const v = cloneJobValues(job({
+        segments: [seg({
+          faceswap_enabled: true,
+          faceswap_source_type: "upload",
+          faceswap_image: FACE,
+        })],
+      }));
+      expect(v.faceswap?.sourceType).toBe("preset");
+      expect(v.faceswap?.presetUri).toBe(FACE);
+      expect(v.faceswap?.file).toBeNull();
+      expect(v.faceswap?.enabled).toBe(true);
+    });
+
+    it("leaves start_frame alone and parks no dead URI on it", () => {
+      const v = cloneJobValues(job({
+        segments: [seg({
+          faceswap_enabled: true,
+          faceswap_source_type: "start_frame",
+          faceswap_image: START,
+        })],
+      }));
+      expect(v.faceswap?.sourceType).toBe("start_frame");
+      expect(v.faceswap?.presetUri).toBeNull();
+    });
+
+    it("keeps a preset face as a preset", () => {
+      const v = cloneJobValues(job({
+        segments: [seg({
+          faceswap_enabled: true,
+          faceswap_source_type: "preset",
+          faceswap_image: FACE,
+          faceswap_model: "inswapper_128",
+          faceswap_pixel_boost: "512x512",
+          faceswap_faces_index: "1",
+          faceswap_faces_order: "large-small",
+        })],
+      }));
+      expect(v.faceswap?.sourceType).toBe("preset");
+      expect(v.faceswap?.presetUri).toBe(FACE);
+      expect(v.faceswap?.model).toBe("inswapper_128");
+      expect(v.faceswap?.pixelBoost).toBe("512x512");
+      expect(v.faceswap?.facesIndex).toBe("1");
+      expect(v.faceswap?.facesOrder).toBe("large-small");
+    });
+
+    it("carries a seed-only re-anchor, which is independent of enabled", () => {
+      const v = cloneJobValues(job({
+        segments: [seg({
+          faceswap_enabled: false,
+          seed_faceswap: true,
+          faceswap_source_type: "preset",
+          faceswap_image: FACE,
+        })],
+      }));
+      expect(v.faceswap?.enabled).toBe(false);
+      expect(v.faceswap?.seedFaceswap).toBe(true);
+      expect(v.faceswap?.presetUri).toBe(FACE);
+    });
+
+    it("falls back to defaults when the segment stored no swap config", () => {
+      const v = cloneJobValues(job());
+      expect(v.faceswap?.enabled).toBe(false);
+      expect(v.faceswap?.sourceType).toBe("start_frame");
+      expect(v.faceswap?.method).toBe("facefusion");
+    });
+  });
+});

--- a/src/lib/cloneJob.ts
+++ b/src/lib/cloneJob.ts
@@ -1,0 +1,159 @@
+/**
+ * What "clone this job" resolves to, as plain values.
+ *
+ * WHY THIS EXISTS: the same lesson as `faceswapPayload.ts` — the interesting decisions here are
+ * pure state -> state mapping, and buried inside a `useEffect` they are unreachable by any test
+ * the repo can run. Two of them are silent when wrong:
+ *
+ *   - the source segment. After a re-roll there are two segments at index 0 and the archived one
+ *     carries a prompt/LoRA set that is no longer the job. Cloning it produces a job that looks
+ *     right and reproduces something nobody asked for.
+ *   - the faceswap source. An "upload" face is a File this browser no longer has. Drop it and the
+ *     clone arrives with the swap ENABLED and no face, which the daemon treats as "skip the swap"
+ *     — the exact silent no-op documented in faceswapPayload.ts.
+ *
+ * Deliberately imports no component and no `../api/client`: that module installs axios
+ * interceptors at import time, one of which assigns `window.location.href` on a 401.
+ */
+import type { JobDetailResponse, SegmentResponse } from "../api/types";
+import type { FaceswapConfigState } from "./faceswapPayload";
+import { groupTakes } from "./segmentTakes";
+import {
+  DEFAULT_FACESWAP_SOURCE_TYPE,
+  DEFAULT_FACESWAP_METHOD,
+  DEFAULT_FACESWAP_MODEL,
+  DEFAULT_FACESWAP_PIXEL_BOOST,
+  DEFAULT_FACESWAP_FACES_INDEX,
+  DEFAULT_FACESWAP_FACES_ORDER,
+} from "../constants";
+
+export interface ClonedLora {
+  lora_id: string;
+  name: string;
+  high_weight: number;
+  low_weight: number;
+  preview_image: string | null;
+}
+
+/** Just enough of a LoRA library entry to name and preview a cloned reference. */
+export interface LoraLookup {
+  id: string;
+  name: string;
+  preview_image: string | null;
+}
+
+export interface ClonedJobValues {
+  name: string;
+  fps: number;
+  width: number;
+  height: number;
+  /** Always "" — see the note in `cloneJobValues`. */
+  seed: string;
+  lightx2vHigh: string;
+  lightx2vLow: string;
+  cfgHigh: string;
+  cfgLow: string;
+  stepsTotal: string;
+  highNoiseSteps: string;
+  flowShift: string;
+  videoPresetId: string;
+  tags: string;
+  startingImageUri: string | null;
+  prompt: string;
+  negativePrompt: string;
+  duration: number | null;
+  speed: number | null;
+  loras: ClonedLora[];
+  faceswap: FaceswapConfigState | null;
+}
+
+/**
+ * The live take at index 0 — the config the job is currently described by.
+ *
+ * Not `segments[0]`: after a re-roll the array's first element may be the ARCHIVED take.
+ */
+export function cloneSourceSegment(job: JobDetailResponse): SegmentResponse | null {
+  return groupTakes(job.segments).live.find((s) => s.index === 0) ?? null;
+}
+
+const str = (v: number | null | undefined): string => (v == null ? "" : String(v));
+
+export function cloneJobValues(
+  job: JobDetailResponse,
+  loraLibrary: LoraLookup[] = [],
+): ClonedJobValues {
+  const source = cloneSourceSegment(job);
+
+  return {
+    name: `${job.name} (copy)`,
+    fps: job.fps,
+    width: job.width,
+    height: job.height,
+    // NEVER cloned. `job.seed` arrives as a JSON *number*, and seeds are 64-bit with 95% of jobs
+    // above 2**53 — so by the time it reaches the browser it has already been rounded (the same
+    // reason segment seeds are sent as strings; see lib/segmentTakes). Carrying it would put an
+    // exact-looking number in the field that never generated anything. Blank = a fresh seed,
+    // which is what a clone wants regardless.
+    seed: "",
+    lightx2vHigh: str(job.lightx2v_strength_high),
+    lightx2vLow: str(job.lightx2v_strength_low),
+    cfgHigh: str(job.cfg_high),
+    cfgLow: str(job.cfg_low),
+    stepsTotal: str(job.steps_total),
+    highNoiseSteps: str(job.high_noise_steps),
+    flowShift: str(job.flow_shift),
+    videoPresetId: job.video_preset_id ?? "",
+    tags: job.tags ?? "",
+    startingImageUri: job.starting_image ?? null,
+    prompt: source?.prompt ?? "",
+    negativePrompt: source?.negative_prompt ?? "",
+    duration: source?.duration_seconds ?? null,
+    speed: source?.speed ?? null,
+    loras: cloneLoras(source, loraLibrary),
+    faceswap: source ? cloneFaceswap(source) : null,
+  };
+}
+
+function cloneLoras(source: SegmentResponse | null, library: LoraLookup[]): ClonedLora[] {
+  return (source?.loras ?? []).flatMap((l) => {
+    // A LoRA reference with no id cannot be re-selected in the picker; carrying a nameless row
+    // would only look like a LoRA is loaded when none is.
+    if (!l.lora_id) return [];
+    const lib = library.find((item) => item.id === l.lora_id);
+    return [{
+      lora_id: l.lora_id,
+      name: lib?.name ?? l.lora_id.slice(0, 8),
+      high_weight: l.high_weight,
+      low_weight: l.low_weight,
+      preview_image: lib?.preview_image ?? null,
+    }];
+  });
+}
+
+function cloneFaceswap(source: SegmentResponse): FaceswapConfigState {
+  // An "upload" face was a File, and this browser does not have it. The API stored those bytes in
+  // S3 and put the URI on the segment, so the honest reconstruction is a PRESET pointing at that
+  // same URI — identical face, no re-upload. Keeping sourceType="upload" would leave the picker
+  // with no file and send no face at all.
+  const wasUpload = source.faceswap_source_type === "upload" && !!source.faceswap_image;
+  const sourceType = wasUpload
+    ? "preset"
+    : ((source.faceswap_source_type as FaceswapConfigState["sourceType"] | null)
+        ?? DEFAULT_FACESWAP_SOURCE_TYPE);
+
+  return {
+    enabled: source.faceswap_enabled,
+    method: source.faceswap_method ?? DEFAULT_FACESWAP_METHOD,
+    sourceType,
+    // The File cannot survive a clone; the URI above replaces it.
+    file: null,
+    // "start_frame" resolves its face from the start image at submit time. Parking a URI here
+    // would be dead state that the mode never reads.
+    presetUri: sourceType === "start_frame" ? null : (source.faceswap_image ?? null),
+    facesIndex: source.faceswap_faces_index ?? DEFAULT_FACESWAP_FACES_INDEX,
+    facesOrder: source.faceswap_faces_order ?? DEFAULT_FACESWAP_FACES_ORDER,
+    model: source.faceswap_model ?? DEFAULT_FACESWAP_MODEL,
+    pixelBoost: source.faceswap_pixel_boost ?? DEFAULT_FACESWAP_PIXEL_BOOST,
+    seedFaceswap: source.seed_faceswap,
+  };
+}

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -57,6 +57,7 @@ import {
   ViewInAr,
   RateReview,
   RateReviewOutlined,
+  ContentCopy,
 } from "@mui/icons-material";
 import { useParams, useNavigate, Link as RouterLink } from "react-router";
 import {
@@ -99,6 +100,7 @@ import IdentityChip from "../components/IdentityChip";
 import SegmentObservationDialog from "../components/SegmentObservationDialog";
 import { discardSegment } from "../api/client";
 import SegmentPromptPopover from "../components/SegmentPromptPopover";
+import CreateJobDialog from "../components/CreateJobDialog";
 import { buildFaceswapFields, resolveFaceswapImage } from "../lib/faceswapPayload";
 import { canRerollSeed } from "../lib/rerollEligibility";
 import {
@@ -293,6 +295,7 @@ export default function JobDetail() {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [deleteJobConfirm, setDeleteJobConfirm] = useState(false);
   const [deletingJob, setDeletingJob] = useState(false);
+  const [cloneOpen, setCloneOpen] = useState(false);
   const [reopening, setReopening] = useState(false);
   const [reopenConfirm, setReopenConfirm] = useState(false);
   const [rerollConfirm, setRerollConfirm] = useState(false);
@@ -947,6 +950,14 @@ export default function JobDetail() {
             {job.name}
           </Typography>
         )}
+        <Tooltip title="Clone this job — same settings and start image, no takes or history">
+          <IconButton
+            onClick={() => setCloneOpen(true)}
+            size={isMobile ? "small" : "medium"}
+          >
+            <ContentCopy />
+          </IconButton>
+        </Tooltip>
         <Tooltip title="Delete job">
           <IconButton
             color="error"
@@ -2356,6 +2367,19 @@ export default function JobDetail() {
               : prev,
           )
         }
+      />
+
+      {/* Clone. The create dialog does the pre-filling; this only hands it the job. Landing on
+          the queue afterwards rather than staying here makes it obvious a NEW job was queued —
+          staying put looks like nothing happened. */}
+      <CreateJobDialog
+        open={cloneOpen}
+        cloneFrom={job}
+        onClose={() => setCloneOpen(false)}
+        onCreated={() => {
+          setCloneOpen(false);
+          navigate("/jobs");
+        }}
       />
 
       {/* Frame preview popover */}


### PR DESCRIPTION
Closes #349

Clone button on Job Detail (next to Delete). Opens the create dialog pre-filled from the job, so a new job can be queued from a known-good config without re-entering it. Settings and start image only — segments, takes, videos and observations are that job's history and stay with it.

## What clones

| | |
|---|---|
| **Job** | name (` (copy)`), fps, width/height, sampler fields, video preset, tags, start image |
| **Live segment 0** | prompt, negative prompt, duration, speed, LoRAs + weights, full faceswap config |
| **Not cloned** | seed, segments, takes, videos, observations, job status |

## The three things that aren't trivial

Each of these fails silently, which is why they get comments in the code.

**Effect ordering.** The create dialog already has three on-open effects writing the same fields from settings defaults and the retained preset. Effects run in declaration order, so the clone is declared last — and it claims `didApplyPresetOnOpen`, because setting `videoPresetId` re-triggers that effect on the next render and would re-apply the preset's prompt/sampler/LoRAs over the cloned ones.

**The source segment.** After a re-roll there are two segments at index 0 and `segments[0]` may be the *archived* take, carrying a prompt/LoRA set that is no longer the job. Uses `groupTakes`' live take, as the rest of the page does.

**The uploaded face.** An `upload` face was a File this browser no longer has — but the API stored the bytes in S3 and put the URI on the segment, so it clones as a *preset* pointing at that URI. Carrying `sourceType="upload"` forward would leave the swap enabled with no face, which the daemon reads as "skip the swap" — the same silent no-op `faceswapPayload.ts` was written to prevent.

Also: `loadImageFromUrl` gained a `keepSize` option. Without it the start image finishing loading would asynchronously overwrite the cloned width/height with `naturalWidth × scale` — the field would look right, then change.

## The seed is deliberately not cloned

`job.seed` is serialized as a JSON `int`, and seeds are 64-bit with most jobs above 2\*\*53 — so it has **already been rounded** by the time it reaches the browser. `lib/segmentTakes.ts` says this outright, which is why archived takes get their seed as a string instead. Cloning `job.seed` would put an exact-looking number in the field that never generated anything. Blank = the API assigns a fresh one, which is what a clone wants regardless.

Worth noting separately: the Job Detail header displays `job.seed` directly, so that number is already rounded on screen today. Pre-existing, not touched here — flagging it as its own ticket.

## Verification

- `npm run build` green (the check that counts — `tsc --noEmit` checks nothing here)
- `npm run lint` back at the baseline count (11 problems, same as `main`)
- `npx vitest run`: 180 passed, 17 files

The mapping lives in `lib/cloneJob.ts` rather than inside the effect for the reason `faceswapPayload.ts` exists — buried in a `useEffect`, none of it is reachable by a test. 15 new tests cover it, and per AGENTS.md the two silent cases were proven to catch: forcing the upload-face branch off failed 1 test, replacing the live-take lookup with `segments[0]` failed 3.

## Also fixed

A latent stale-closure read alongside it: the "default the face to Kelly" callback tested the `faceswap` it closed over rather than `prev`, so it could overwrite a face set after the effect ran. Non-deterministic, and the clone path would have hit it.