### PR TITLE
Tag pills on Videos, the same filter the Image Repo has

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -30,7 +30,7 @@ import type {
   ImageFile,
   ImageJobInfo,
   ImageSearchResponse,
-  ImageTagCount,
+  TagCount,
   FavoriteToggleRequest,
   SegmentClip,
   SmashcutBody,
@@ -86,10 +86,31 @@ export async function getJobs(params?: {
   sort?: string;
   name?: string;
   q?: string;
+  /** Whole tags, ANDed. `q` is a name fragment; these are exact, so "ar" does not match
+   *  "argentina". */
+  tags?: string[];
   starred?: boolean;
 }): Promise<JobListResponse> {
-  const { data } = await api.get<JobListResponse>("/jobs", { params });
+  const { data } = await api.get<JobListResponse>("/jobs", {
+    params,
+    ...REPEAT_ARRAY_PARAMS,
+  });
   return data;
+}
+
+/** Every job tag in use with how many jobs carry it UNDER THE GIVEN FILTER — so the Videos pills
+ *  show what exists inside the current result set rather than offering dead ends. */
+export async function getJobTagCounts(params: {
+  status?: string;
+  q?: string;
+  tags?: string[];
+  starred?: boolean;
+}): Promise<TagCount[]> {
+  const { data } = await api.get<{ items: TagCount[] }>("/jobs/tag-counts", {
+    params,
+    ...REPEAT_ARRAY_PARAMS,
+  });
+  return data.items;
 }
 
 export async function reorderJobs(jobIds: string[]): Promise<JobResponse[]> {
@@ -489,8 +510,8 @@ export async function getImageTagCounts(params: {
   q?: string;
   tags?: string[];
   exclude?: string[];
-}): Promise<ImageTagCount[]> {
-  const { data } = await api.get<{ items: ImageTagCount[] }>("/images/tag-counts", {
+}): Promise<TagCount[]> {
+  const { data } = await api.get<{ items: TagCount[] }>("/images/tag-counts", {
     params,
     ...REPEAT_ARRAY_PARAMS,
   });

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -524,7 +524,8 @@ export interface ImageFile {
   tags: string | null;
 }
 
-export interface ImageTagCount {
+/** One tag and how many items carry it under the current filter. Images and jobs both. */
+export interface TagCount {
   tag: string;
   count: number;
 }

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -1,16 +1,17 @@
 import { Box, Button, Chip, Typography } from "@mui/material";
-import type { ImageTagCount } from "../api/types";
-import { isTagSelected } from "../lib/imageFilter";
+import type { TagCount } from "../api/types";
+import { isTagSelected } from "../lib/tagFilter";
 
 interface Props {
-  counts: ImageTagCount[];
+  counts: TagCount[];
   selected: string[];
   onToggle: (tag: string) => void;
   onClear: () => void;
 }
 
 /**
- * The tag pills above the image grid. Clicking narrows; every selection ANDs.
+ * The tag pills above a filtered grid — the Image Repo and Videos both use them. Clicking
+ * narrows; every selection ANDs.
  *
  * Counts come from the API scoped to the CURRENT filter, which is what makes this navigable
  * rather than a guessing game: with Kelly selected, the pills left standing are the tags that
@@ -22,8 +23,11 @@ interface Props {
  * is on 76 images and is not in the vocabulary -- and pills built from the vocabulary would
  * strand them. It also puts the fat-fingers ("pusy", "cowgirlowgirl", one image each) on screen
  * with their counts, which is the only way they will ever get cleaned up.
+ *
+ * Presentational on purpose: the caller owns where the counts come from and where the selection
+ * is stored, so the same row serves images (/images/tag-counts) and videos (/jobs/tag-counts).
  */
-export default function ImageTagFilter({ counts, selected, onToggle, onClear }: Props) {
+export default function TagFilterBar({ counts, selected, onToggle, onClear }: Props) {
   if (counts.length === 0 && selected.length === 0) return null;
 
   return (

--- a/src/lib/tagFilter.test.ts
+++ b/src/lib/tagFilter.test.ts
@@ -6,7 +6,7 @@ import {
   parseTagParam,
   serializeTagParam,
   toggleTag,
-} from "./imageFilter";
+} from "./tagFilter";
 
 describe("parseTagParam", () => {
   it("splits on commas and trims", () => {

--- a/src/lib/tagFilter.ts
+++ b/src/lib/tagFilter.ts
@@ -1,13 +1,16 @@
 /**
- * The image-repo filter: a filename fragment and a set of whole tags, all ANDed.
+ * The tag filter shared by the Image Repo and Videos: a free-text fragment and a set of whole
+ * tags, all ANDed.
  *
  * Two controls with two different jobs. Tags match in full — measured on production, a substring
- * search for "kelly" returned 74% of the repo because it also caught KellyYoung, KellyBangs and
- * KellyTeacher — while the text box matches the filename as a fragment, which is right there and
- * is the only way to find an untagged image.
+ * search for "kelly" returned 74% of the image repo because it also caught KellyYoung,
+ * KellyBangs and KellyTeacher, and searching Videos for "AR" returned everything containing
+ * "ar" (#353) — while the text box matches a filename/job name as a fragment, which is right
+ * there and is the only way to find an untagged item.
  *
- * The selection lives in the URL (?tags=Kelly,Missionary) like the rest of this page's browsing
- * state, so back/forward and a refresh keep it, and a filtered view can be pasted to yourself.
+ * The selection lives in the URL (?tags=Kelly,Missionary) like the rest of a list page's
+ * browsing state, so back/forward and a refresh keep it, and a filtered view can be pasted to
+ * yourself.
  */
 
 /** Tags are comma-joined in the URL. Empty segments are dropped rather than sent as blank tags,

--- a/src/pages/ImageRepo.tsx
+++ b/src/pages/ImageRepo.tsx
@@ -66,19 +66,19 @@ import {
   searchImages,
   getImageTagCounts,
 } from "../api/client";
-import type { ImageFolder, ImageFile, ImageJobInfo, ImageTagCount } from "../api/types";
+import type { ImageFolder, ImageFile, ImageJobInfo, TagCount } from "../api/types";
 import CreateJobDialog from "../components/CreateJobDialog";
 import CropResizeDialog from "../components/CropResizeDialog";
 import FavoriteHeart from "../components/FavoriteHeart";
 import { useTagStore } from "../stores/tagStore";
-import ImageTagFilter from "../components/ImageTagFilter";
+import TagFilterBar from "../components/TagFilterBar";
 import {
   describeFilter,
   hasFilter,
   parseTagParam,
   serializeTagParam,
   toggleTag,
-} from "../lib/imageFilter";
+} from "../lib/tagFilter";
 import { useQueryState, getPage, pageValue, getPerPage, perPageValue } from "../hooks/useQueryState";
 
 const FOLDER_ROWS_OPTIONS = [12, 24, 48];
@@ -142,7 +142,7 @@ export default function ImageRepo() {
   const [lightboxTags, setLightboxTags] = useState("");
   const tagSaveTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const [searchResults, setSearchResults] = useState<ImageFile[]>([]);
-  const [tagCounts, setTagCounts] = useState<ImageTagCount[]>([]);
+  const [tagCounts, setTagCounts] = useState<TagCount[]>([]);
   const [searchTotal, setSearchTotal] = useState(0);
   const [searchLoading, setSearchLoading] = useState(false);
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -1235,7 +1235,7 @@ export default function ImageRepo() {
           />
         </Box>
 
-        <ImageTagFilter
+        <TagFilterBar
           counts={tagCounts}
           selected={selectedTags}
           onToggle={(tag) => setSelectedTags(toggleTag(selectedTags, tag))}
@@ -1758,7 +1758,7 @@ export default function ImageRepo() {
         />
       </Box>
 
-      <ImageTagFilter
+      <TagFilterBar
         counts={tagCounts}
         selected={selectedTags}
         onToggle={(tag) => setSelectedTags(toggleTag(selectedTags, tag))}

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import {
   Box,
   Typography,
@@ -20,11 +20,13 @@ import {
 import { useIsMobile } from "../hooks/useIsMobile";
 import { Close, Error as ErrorIcon, Favorite, NavigateBefore, NavigateNext, PlayCircleOutline, Repeat, Search, Shuffle, VideoLibrary } from "@mui/icons-material";
 import { useNavigate } from "react-router";
-import { getJobs, getJob, getFileUrl, getFavorites, toggleFavorite } from "../api/client";
-import type { JobDetailResponse, JobResponse } from "../api/types";
+import { getJobs, getJob, getFileUrl, getFavorites, toggleFavorite, getJobTagCounts } from "../api/client";
+import type { JobDetailResponse, JobResponse, TagCount } from "../api/types";
 import IdentityChip from "../components/IdentityChip";
 import { DEFAULT_JOB_FETCH_LIMIT, POLL_INTERVAL_FAST } from "../constants";
 import FavoriteHeart from "../components/FavoriteHeart";
+import TagFilterBar from "../components/TagFilterBar";
+import { describeFilter, parseTagParam, serializeTagParam, toggleTag } from "../lib/tagFilter";
 import { useQueryState, getPage, pageValue, getPerPage, perPageValue } from "../hooks/useQueryState";
 
 const ROWS_PER_PAGE_OPTIONS = [12, 24, 48];
@@ -58,6 +60,7 @@ export default function Videos() {
   const [loadingRandom, setLoadingRandom] = useState(false);
   const [loopVideo, setLoopVideo] = useState(false);
   const [favoritesSet, setFavoritesSet] = useState<Set<string>>(new Set());
+  const [tagCounts, setTagCounts] = useState<TagCount[]>([]);
 
   // List state lives in the URL (?page=3&per=24&q=…&fav=1) so it survives the
   // unmount caused by clicking through to /jobs/:id — and browser back/forward.
@@ -71,6 +74,31 @@ export default function Videos() {
   // rewrite the URL on every keystroke; it is seeded from the URL on mount.
   const [searchQuery, setSearchQuery] = useState(debouncedQuery);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Tag selection is URL state too (?tags=kelly,ar), so a filtered view survives the click
+  // through to /jobs/:id and can be pasted to yourself. Same shape as the Image Repo.
+  //
+  // Memoised on the raw STRING, not on `params`: react-router rebuilds the URLSearchParams
+  // whenever any param changes, so keying off the object would hand the fetch callbacks a fresh
+  // tags array on every page click and re-fetch the counts, which do not depend on the page.
+  const rawTags = params.get("tags");
+  const selectedTags = useMemo(() => parseTagParam(rawTags), [rawTags]);
+  const setSelectedTags = useCallback(
+    (next: string[]) => setQuery({ tags: serializeTagParam(next), page: null }),
+    [setQuery],
+  );
+  // Tags go to the API as repeated keys; memoised so it is a stable dep for the fetch callbacks
+  // rather than a fresh array every render.
+  const tagsParam = useMemo(
+    () => (selectedTags.length ? selectedTags : undefined),
+    [selectedTags],
+  );
+  // How to name the current filter in the empty state, so "no results" says what found nothing.
+  // Favourites narrows client-side rather than through the query, so it has to be added by hand
+  // or an empty favourites view would claim there are no videos at all.
+  const filterLabel = [describeFilter(debouncedQuery, selectedTags), favoritesOnly ? "Favorites" : ""]
+    .filter(Boolean)
+    .join(" + ");
 
   // Scroll to top when page changes
   useEffect(() => {
@@ -109,6 +137,7 @@ export default function Videos() {
         offset: page * rowsPerPage,
         sort: "updated_at_desc",
         q: debouncedQuery || undefined,
+        tags: tagsParam,
       });
       setJobs(res.items);
       setTotal(res.total);
@@ -117,13 +146,33 @@ export default function Videos() {
     } finally {
       setLoading(false);
     }
-  }, [page, rowsPerPage, debouncedQuery]);
+  }, [page, rowsPerPage, debouncedQuery, tagsParam]);
 
   useEffect(() => {
     fetchVideos();
     const interval = setInterval(fetchVideos, POLL_INTERVAL_FAST);
     return () => clearInterval(interval);
   }, [fetchVideos]);
+
+  // Counts are re-fetched WITH the filter, not once on mount: scoped to the current selection
+  // they say what actually co-occurs with it, so a dead-end combination is never offered.
+  // Scoped to the same statuses the grid asks for, or the pills would count queued work the
+  // page cannot show.
+  const fetchTagCounts = useCallback(async () => {
+    try {
+      setTagCounts(
+        await getJobTagCounts({
+          status: "finalized,finalizing",
+          q: debouncedQuery || undefined,
+          tags: tagsParam,
+        }),
+      );
+    } catch {
+      // leave the pills as they are
+    }
+  }, [debouncedQuery, tagsParam]);
+
+  useEffect(() => { fetchTagCounts(); }, [fetchTagCounts]);
 
   const fetchFavorites = useCallback(async () => {
     try {
@@ -171,12 +220,13 @@ export default function Videos() {
   const handlePlayRandom = async () => {
     setLoadingRandom(true);
     try {
-      // Fetch all finalized jobs (respecting the active search filter)
+      // Fetch all finalized jobs (respecting the active search and tag filters)
       const res = await getJobs({
         status: "finalized",
         limit: DEFAULT_JOB_FETCH_LIMIT,
         offset: 0,
         q: debouncedQuery || undefined,
+        tags: tagsParam,
       });
       const allJobs = favoritesOnly
         ? res.items.filter((j) => favoritesSet.has(j.id))
@@ -272,6 +322,13 @@ export default function Videos() {
           sx={{ minWidth: 240 }}
         />
       </Box>
+
+      <TagFilterBar
+        counts={tagCounts}
+        selected={selectedTags}
+        onToggle={(tag) => setSelectedTags(toggleTag(selectedTags, tag))}
+        onClear={() => setSelectedTags([])}
+      />
 
       {loading && finalizedJobs.length === 0 && (
         <Box sx={{ textAlign: "center", py: 8 }}>
@@ -460,11 +517,17 @@ export default function Videos() {
           <Card>
             <Box sx={{ textAlign: "center", py: 8 }}>
               <VideoLibrary sx={{ fontSize: 64, color: "text.disabled", mb: 2 }} />
+              {/* Name the filter when one is on. "No finalized videos yet" under an active
+                  filter reads as "you have no videos", which is alarming and untrue. */}
               <Typography variant="h6" color="text.secondary">
-                No finalized videos yet
+                {filterLabel ? `No videos match ${filterLabel}` : "No finalized videos yet"}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Finalized videos will appear here once you complete and merge a job.
+                {selectedTags.length > 1
+                  ? "Every tag narrows — two tags means both on one video."
+                  : filterLabel
+                    ? "Try clearing the filter."
+                    : "Finalized videos will appear here once you complete and merge a job."}
               </Typography>
             </Box>
           </Card>


### PR DESCRIPTION
Closes #352. Also addresses the tag half of #353.

Pairs with **wanly-api#205**, which adds the `tags` param and `/jobs/tag-counts`. Merge the API first — without it the pill row just stays empty rather than breaking the page.

## What changed

Videos could only be narrowed by a text box that matched job name **and** tags by substring. That is the same bug the Image Repo fixed in July (`%kelly%` matched 74% of the repo because it caught KellyYoung, KellyBangs, KellyTeacher), and #353 is it showing up on Videos: searching "AR" returns everything tagged `argentina` or `starlight`.

- **Counted tag pills above the Videos grid.** Clicking narrows, every selection ANDs, and the counts come from the API *scoped to the current filter* — so with `kelly` selected the pills left standing are what actually co-occurs with kelly, and a dead-end combination is never offered.
- **Selection lives in the URL** (`?tags=kelly,ar`) like the rest of this page's browsing state, so it survives the click through to `/jobs/:id`, browser back/forward, and a refresh.
- **Play Random respects it** — shuffling inside a filtered set was the obvious thing to want.
- **The empty state names the filter.** "No finalized videos yet" under an active filter reads as "you have no videos", which is alarming and untrue.

## Shared, not copied

`lib/imageFilter` → `lib/tagFilter`, `ImageTagFilter` → `TagFilterBar`, `ImageTagCount` → `TagCount`. All three were already generic; the names were the only thing tying them to images. No logic change, and the existing unit tests move with the file.

## On #353

The pill is the precise instrument and fully answers "show me AR videos". The search box still matches "ar" inside a job **name** (`kitchen argentina`) — deliberate, because name-fragment matching is the only way to find a half-remembered name, and one control cannot be both. If that noise still bites in practice, word-boundary name matching is the follow-up. Called out in wanly-api#205 with a test that names the trade-off.

## Testing

- `npm run build` green.
- `npm run test` — 180 passed, 17 files.
- `npm run lint` — 11 problems, byte-identical to `main` (all pre-existing).
- API side exercised over real HTTP against a local instance: `?tags=ar` returns only the AR-tagged job, `?q=AR` shows the documented name-fragment behaviour, and `/jobs/tag-counts` narrows correctly when a tag is selected.

Not yet loaded in a browser against a live API — the endpoints it calls are still in review.